### PR TITLE
remove `@shopify/eslint-plugin` dependencies

### DIFF
--- a/packages/eslint-plugin/.github/CONTRIBUTING.md
+++ b/packages/eslint-plugin/.github/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to `eslint-plugin-hydrogen`
+
+## Thanks for your interest in being a contributor ❤️
+
+If this is your first time contributing to an Open Source Project on GitHub, you can learn how from [this free course](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+All changes should have tests and documentation.
+
+## Project setup
+
+1. Fork and clone the repo
+2. `$ yarn install` to install dependencies
+3. `$ yarn test` to run all tests
+
+## Test changes in the starter template
+
+Before submitting a PR you can test your changes in the starter template by replacing the contents of `packages/dev/.eslintrc.js` with:
+
+```js
+module.exports = {
+  extends: ['plugin:hydrogen/recommended'],
+};
+```
+
+And then modifying the `lint:js` task in `packages/dev/package.json` to be:
+
+```json
+    "lint:js": "eslint --rulesdir '../eslint-plugin/dist/' --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx src",
+```
+
+Finally, run `yarn lint:js` from the root of that package.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,27 +1,12 @@
+<!-- This file is generated from the source code. Edit the files in /packages/eslint-plugin and run 'yarn generate-docs' at the root of this repo. -->
+
 # `eslint-plugin-hydrogen`
 
 Hydrogen provides an ESLint plugin to enforce Shopify’s javascript best practices and catch common issues when using React Server components in Hydrogen apps.
 
-| Rule                                                                                | Description                                                                   | Configurations | Fixable |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------- | ------- |
-| [hydrogen/no-state-in-server-components](./src/rules/no-state-in-server-components) | Prevents `useState` and `useReducer` in React Server Components               | `recommended`  |         |
-| [hydrogen/prefer-image-component](./src/rules/prefer-image-component)               | Prefer using @shopify/hydrogen `Image` component in place of HTML `img` tags' | `recommended`  | ✅      |
+## Configurations
 
-## Installation
-
-You'll first need to install [ESLint](http://eslint.org) in addition to this module.
-
-```bash
-yarn add --dev eslint eslint-plugin-hydrogen
-```
-
-## Usage
-
-Hydrogen’s ESLint configurations come bundled in this package. In order to use them, you simply extend the relevant configuration in your project’s `.eslintrc.js`.
-
-### Configurations
-
-#### Recommended
+### Recommended
 
 This plugin exports a recommended configuration.
 
@@ -34,15 +19,31 @@ config file:
 }
 ```
 
-#### Recommended for Typescript projects
+### Hydrogen
 
-This plugin exports a recommended configuration for Typescript projects.
+This plugin exports a `hydrogen` configuration. Unlike the [recommended](#recommended) configuration, this excludes suggested third-party plugins and configurations. Instead, it enables only the `hydrogen` rules with their suggested defaults.
 
 To enable this configuration use the `extends` property in your `.eslintrc.js`
 config file:
 
 ```ts
 {
-  extends: 'plugin:hydrogen/recommended-typescript',
+  extends: 'plugin:hydrogen/hydrogen',
 }
 ```
+
+## Contributing
+
+If you've come here to help contribute – Thank you ❤️ Take a look at the [contributing docs](./.github/contributing.md) to get getting started.
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org) in addition to this module.
+
+```bash
+yarn add --dev eslint eslint-plugin-hydrogen
+```
+
+## Usage
+
+Hydrogen’s ESLint configurations come bundled in this package. To use them you must extend the relevant configuration in your project’s `.eslintrc.js`.

--- a/packages/eslint-plugin/docs/configurations.md
+++ b/packages/eslint-plugin/docs/configurations.md
@@ -1,0 +1,27 @@
+## Configurations
+
+### Recommended
+
+This plugin exports a recommended configuration.
+
+To enable this configuration use the `extends` property in your `.eslintrc.js`
+config file:
+
+```ts
+{
+  extends: 'plugin:hydrogen/recommended',
+}
+```
+
+### Hydrogen
+
+This plugin exports a `hydrogen` configuration. Unlike the [recommended](#recommended) configuration, this excludes suggested third-party plugins and configurations. Instead, it enables only the `hydrogen` rules with their suggested defaults.
+
+To enable this configuration use the `extends` property in your `.eslintrc.js`
+config file:
+
+```ts
+{
+  extends: 'plugin:hydrogen/hydrogen',
+}
+```

--- a/packages/eslint-plugin/docs/contributing.md
+++ b/packages/eslint-plugin/docs/contributing.md
@@ -1,0 +1,3 @@
+## Contributing
+
+If you've come here to help contribute – Thank you ❤️ Take a look at the [contributing docs](./.github/contributing.md) to get getting started.

--- a/packages/eslint-plugin/docs/installation.md
+++ b/packages/eslint-plugin/docs/installation.md
@@ -1,0 +1,7 @@
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org) in addition to this module.
+
+```bash
+yarn add --dev eslint eslint-plugin-hydrogen
+```

--- a/packages/eslint-plugin/docs/overview.md
+++ b/packages/eslint-plugin/docs/overview.md
@@ -1,0 +1,3 @@
+# `eslint-plugin-hydrogen`
+
+Hydrogen provides an ESLint plugin to enforce Shopify’s javascript best practices and catch common issues when using React Server components in Hydrogen apps.

--- a/packages/eslint-plugin/docs/usage.md
+++ b/packages/eslint-plugin/docs/usage.md
@@ -1,0 +1,3 @@
+## Usage
+
+Hydrogen’s ESLint configurations come bundled in this package. To use them you must extend the relevant configuration in your project’s `.eslintrc.js`.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,27 +20,29 @@
     "directory": "packages/eslint-plugin"
   },
   "dependencies": {
-    "@shopify/eslint-plugin": "^40.4.0",
-    "@typescript-eslint/experimental-utils": "^4.0.1"
+    "@typescript-eslint/experimental-utils": "^4.0.1",
+    "@typescript-eslint/eslint-plugin": "^4.26.0",
+    "@typescript-eslint/parser": "^4.26.0",
+    "@typescript-eslint/types": "^4.20.0",
+    "eslint": "^7.27.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-jest": "^24.3.0",
+    "eslint-plugin-jsx-a11y": "^6.4.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "prettier": "^2.0.0"
   },
   "devDependencies": {
     "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.22",
-    "@typescript-eslint/parser": "^4.20.0",
-    "@typescript-eslint/types": "^4.20.0",
     "dedent": "^0.7.0",
-    "eslint": "^7.23.0",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.4"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">= 4",
-    "eslint": ">=5",
-    "prettier": ">= 2"
-  },
-  "peerDependenciesMeta": {
-    "@typescript-eslint/eslint-plugin": {
-      "optional": true
-    }
+    "eslint": ">=5"
   }
 }

--- a/packages/eslint-plugin/src/configs/core.ts
+++ b/packages/eslint-plugin/src/configs/core.ts
@@ -1,0 +1,100 @@
+export default {
+  extends: [
+    'eslint:recommended',
+    'plugin:eslint-comments/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:prettier/recommended',
+  ],
+  plugins: ['eslint-comments', 'prettier', 'react', 'react-hooks', 'jsx-a11y'],
+  env: {
+    es2021: true,
+    browser: true,
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  rules: {
+    'no-console': 'warn',
+    'eslint-comments/no-unused-disable': 'error',
+    'object-shorthand': ['error', 'always', {avoidQuotes: true}],
+    'react/display-name': 'off',
+    'react/prop-types': 'off',
+    'react/no-array-index-key': 'warn',
+    'react/react-in-jsx-scope': 'off',
+    '@shopify/jsx-no-hardcoded-content': 'off',
+    '@shopify/jsx-no-complex-expressions': 'off',
+    'no-use-before-define': 'off',
+    'no-warning-comments': 'off',
+    'jsx-a11y/label-has-for': 'off',
+    'jsx-a11y/control-has-associated-label': 'off',
+  },
+  ignorePatterns: ['node_modules/', 'build/', '*.graphql.d.ts', '*.graphql.ts'],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      parser: '@typescript-eslint/parser',
+      extends: ['plugin:@typescript-eslint/recommended'],
+      rules: {
+        'react/prop-types': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/ban-types': [
+          'error',
+          {
+            types: {
+              String: {message: 'Use string instead', fixWith: 'string'},
+              Boolean: {message: 'Use boolean instead', fixWith: 'boolean'},
+              Number: {message: 'Use number instead', fixWith: 'number'},
+              Object: {message: 'Use object instead', fixWith: 'object'},
+              Array: {message: 'Provide a more specific type'},
+              ReadonlyArray: {message: 'Provide a more specific type'},
+            },
+          },
+        ],
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: 'default',
+            format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+            leadingUnderscore: 'allowSingleOrDouble',
+            trailingUnderscore: 'allowSingleOrDouble',
+          },
+          {
+            selector: 'typeLike',
+            format: ['PascalCase'],
+          },
+          {
+            selector: 'typeParameter',
+            format: ['PascalCase'],
+            leadingUnderscore: 'allow',
+          },
+          {
+            selector: 'interface',
+            format: ['PascalCase'],
+          },
+        ],
+      },
+    },
+    {
+      files: ['*.test.*'],
+      plugins: ['jest'],
+      extends: ['plugin:jest/recommended'],
+      env: {
+        node: true,
+        jest: true,
+      },
+    },
+  ],
+};

--- a/packages/eslint-plugin/src/configs/hydrogen.ts
+++ b/packages/eslint-plugin/src/configs/hydrogen.ts
@@ -1,0 +1,7 @@
+export default {
+  plugins: ['hydrogen'],
+  rules: {
+    'hydrogen/no-state-in-server-components': 'error',
+    'hydrogen/prefer-image-component': 'error',
+  },
+};

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,0 +1,8 @@
+import {merge} from '../utilities';
+
+import core from './core';
+import hydrogen from './hydrogen';
+
+const recommended = merge(core, hydrogen);
+
+export default recommended;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,9 +1,9 @@
-import recommended from './config/recommended';
-import recommendedTypescript from './config/recommended-typescript';
+import recommended from './configs/recommended';
+import hydrogen from './configs/hydrogen';
 
 export {rules} from './rules';
 
 export const configs = {
   recommended,
-  'recommended-typescript': recommendedTypescript,
+  hydrogen,
 };

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,7 +1,7 @@
 import {noStateInServerComponents} from './no-state-in-server-components';
 import {preferImageComponent} from './prefer-image-component';
 
-export const rules = {
+export const rules: {[key: string]: any} = {
   'no-state-in-server-components': noStateInServerComponents,
   'prefer-image-component': preferImageComponent,
 };

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/details.md
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/details.md
@@ -1,0 +1,3 @@
+## Rule Details
+
+This rule prevents using these hooks in files that do not end with the `.client` suffix that denotes a React Component that does not run on the server.

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/overview.md
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/overview.md
@@ -1,0 +1,3 @@
+# Prevents `useState` and `useReducer` in React Server Components (`hydrogen/no-state-in-server-components`)
+
+The `useState` and `useReducer` state handling hooks do not function as expected in React Server Components because they execute once per request on the server.

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/examples/invalid.example.tsx
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/examples/invalid.example.tsx
@@ -1,0 +1,9 @@
+// Examples of **incorrect** code for this rule:
+
+// MyComponent.jsx or MyComponent.server.jsx
+import {useState} from 'react';
+
+function MyNonClientComponent() {
+  const [state, setState] = useState();
+  return null;
+}

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/examples/valid.example.tsx
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/examples/valid.example.tsx
@@ -1,0 +1,9 @@
+// Examples of **correct** code for this rule:
+
+// MyClientComponent.client.jsx
+import {useState} from 'react';
+
+function MyClientComponent() {
+  const [state, setState] = useState();
+  return null;
+}

--- a/packages/eslint-plugin/src/rules/prefer-image-component/docs/details.md
+++ b/packages/eslint-plugin/src/rules/prefer-image-component/docs/details.md
@@ -1,0 +1,3 @@
+## Rule Details
+
+This rule prevents using the `img` tag directly and suggests using the `Image` component from `@shopify/hydrogen`.

--- a/packages/eslint-plugin/src/rules/prefer-image-component/docs/overview.md
+++ b/packages/eslint-plugin/src/rules/prefer-image-component/docs/overview.md
@@ -1,0 +1,3 @@
+# Prefer using @shopify/hydrogen `Image` component in place of HTML `img` tags(`hydrogen/prefer-image-component`)
+
+Images can cause layout shifts if they load after the surrounding page has already rendered. This can lead to [Cumulative Layout Shift](https://web.dev/cls/), a [Core Web Vital](https://web.dev/vitals/) that [Google uses in search ranking](https://developers.google.com/search/blog/2020/05/evaluating-page-experience).

--- a/packages/eslint-plugin/src/rules/prefer-image-component/examples/invalid.example.tsx
+++ b/packages/eslint-plugin/src/rules/prefer-image-component/examples/invalid.example.tsx
@@ -1,0 +1,7 @@
+// Examples of **incorrect** code for this rule:
+
+function MyComponent() {
+  return (
+    <img src="/image.png" alt="My product image" width={300} height={300} />
+  );
+}

--- a/packages/eslint-plugin/src/rules/prefer-image-component/examples/valid.example.tsx
+++ b/packages/eslint-plugin/src/rules/prefer-image-component/examples/valid.example.tsx
@@ -1,0 +1,9 @@
+// Examples of **correct** code for this rule:
+
+import {Image} from '@shopify/hydrogen';
+
+function MyComponent() {
+  return (
+    <Image src="/image.png" alt="My product image" width={300} height={300} />
+  );
+}

--- a/packages/eslint-plugin/src/utilities/index.ts
+++ b/packages/eslint-plugin/src/utilities/index.ts
@@ -16,3 +16,59 @@ function getRepoFromPackageJson(pkg: any) {
 
   return join(repoPathParts.dir, repoPathParts.name, pkg.repository.directory);
 }
+
+export const deepCopy = <T>(obj: T): T => {
+  if (typeof obj === 'object') {
+    const copyArray = (arr: any[]): any => arr.map((val) => deepCopy(val));
+    if (obj instanceof Array) return copyArray(obj);
+    const newObj = {} as T;
+    for (const key in obj) {
+      const val = obj[key];
+      if (val instanceof Array) {
+        newObj[key] = copyArray(val);
+      } else if (typeof val === 'object') {
+        newObj[key] = deepCopy(val);
+      } else {
+        newObj[key] = val;
+      }
+    }
+    return newObj;
+  }
+  return obj;
+};
+
+/**
+ * Does a shallow merge of object `from` to object `to`.
+ * Traverses each of the keys in Object `from`, allowing for:
+ *
+ * * If the value of a key is an array, it will be concatenated
+ * 	 onto `to`.
+ * * If the value of a key is an object it will extend `to` the
+ *   key/values of that object.
+ */
+export function merge<
+  F extends object,
+  T extends object,
+  R extends F & T = F & T
+>(from: F, to: T): R {
+  const mergedInto = deepCopy(to) as R;
+  for (const key in from) {
+    const curKey = key as unknown as keyof R;
+    const hasKey = mergedInto.hasOwnProperty(key);
+    const fromVal = from[key];
+    if (Array.isArray(fromVal)) {
+      if (!hasKey || !(mergedInto[curKey] instanceof Array))
+        mergedInto[curKey] = [] as unknown as R[typeof curKey];
+
+      (mergedInto[curKey] as unknown as Array<any>).push(...fromVal);
+    } else if (typeof fromVal === 'object') {
+      if (!hasKey || !(typeof mergedInto[curKey] === 'object'))
+        mergedInto[curKey] = {} as unknown as R[typeof curKey];
+
+      Object.assign(mergedInto[curKey], fromVal);
+    } else {
+      mergedInto[curKey] = fromVal as unknown as R[typeof curKey];
+    }
+  }
+  return mergedInto;
+}


### PR DESCRIPTION


### Description

This PR is meant to make our ESLint package simpler by untying it from the `@shopify/eslint-plugin`. This plugin was too heavy and it was a mistake (of mine) to go this route and has led to dependency issues. 

Along the way I also:
- Added more documentation.
- Removed the typescript configuration and now we use the `overrides` key in the `recommended` config instead. 
- Adding a "hydrogen rule only" configuration for users that will just want to append to their existing configurations with this plugin.

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
