### PR TITLE
fix: do not lowercase SVG tags in RSC

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - fix: update interaction prompt and interaction promp style attributes for Model3d
 - feat: use Image url field instead of deprecated originalSrc field
 - feat: switch to unstable API
+- feat: fix lowercased SVG tags in RSC
 
 ## 0.5.8 - 2021-11-04
 

--- a/packages/hydrogen/src/framework/Hydration/react-utils.ts
+++ b/packages/hydrogen/src/framework/Hydration/react-utils.ts
@@ -57,7 +57,7 @@ function renderReactProp(prop: any): any {
 export function parseReactFromString(input: string, options: any = {}) {
   return domToReact(
     // @ts-ignore
-    htmlToDOM(input, {lowerCaseAttributeNames: false}),
+    htmlToDOM(input, {lowerCaseTags: false, lowerCaseAttributeNames: false}),
     options
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

SVG tags such as `<clipPath>` or `<linearGradient>` are lowercased in RSC "wire" syntax, which seems to break in Chrome randomly.

@jplhomer @wizardlyhel do you think this change would break something else?

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
