### PR TITLE
[Hydrogen reference docs]: Add cross-references to releases and `useQuery` docs

### DIFF
--- a/packages/hydrogen/src/docs/components.md
+++ b/packages/hydrogen/src/docs/components.md
@@ -1,7 +1,7 @@
 <aside class="note beta">
 <h4>Developer preview</h4>
 
-<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces new features and refines existing functionality. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
+<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces <a href="https://github.com/Shopify/hydrogen/releases">new features and refines existing functionality</a>. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
 
 </aside>
 

--- a/packages/hydrogen/src/docs/hooks.md
+++ b/packages/hydrogen/src/docs/hooks.md
@@ -1,7 +1,7 @@
 <aside class="note beta">
 <h4>Developer preview</h4>
 
-<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces new features and refines existing functionality. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
+<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces <a href="https://github.com/Shopify/hydrogen/releases">new features and refines existing functionality</a>. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
 
 </aside>
 

--- a/packages/hydrogen/src/docs/hydrogen-sdk.md
+++ b/packages/hydrogen/src/docs/hydrogen-sdk.md
@@ -1,7 +1,7 @@
 <aside class="note beta">
 <h4>Developer preview</h4>
 
-<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces new features and refines existing functionality. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
+<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces <a href="https://github.com/Shopify/hydrogen/releases">new features and refines existing functionality</a>. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
 
 </aside>
 

--- a/packages/hydrogen/src/docs/utilities.md
+++ b/packages/hydrogen/src/docs/utilities.md
@@ -1,7 +1,7 @@
 <aside class="note beta">
 <h4>Developer preview</h4>
 
-<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces new features and refines existing functionality. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
+<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces <a href="https://github.com/Shopify/hydrogen/releases">new features and refines existing functionality</a>. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
 
 </aside>
 

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -1,7 +1,7 @@
 <aside class="note beta">
 <h4>Developer preview</h4>
 
-<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces new features and refines existing functionality. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
+<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces <a href="https://github.com/Shopify/hydrogen/releases">new features and refines existing functionality</a>. Production launches of Hydrogen custom storefronts aren't yet supported as Shopify is evolving the Hydrogen framework.</p>
 
 </aside>
 

--- a/packages/hydrogen/src/framework/docs/react-server-components.md
+++ b/packages/hydrogen/src/framework/docs/react-server-components.md
@@ -179,7 +179,7 @@ All data fetching happens on the server and is never exposed to the client, unle
 Hydrogen provides the following ways to fetch data from server components:
 
 - [`useShopQuery`](/api/hydrogen/hooks/global/useshopquery): A hook that allows you to make server-only GraphQL queries to the Storefront API.
-- `useQuery`: A simple wrapper around `fetch` that supports [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html). You can use this function to call any third-party APIs.
+- [`useQuery`](/api/hydrogen/hooks/global/usequery):: A simple wrapper around `fetch` that supports [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html). You can use this function to call any third-party APIs.
 
 ### Accessing Hydrogen components from client components
 


### PR DESCRIPTION
## This PR: 
- Updates the `React Server Components` topic to include a cross-reference to the `useQuery` hook docs
- Adds a link to the releases page in GitHub
- Relates to https://github.com/Shopify/shopify-dev/issues/10171