### PR TITLE
[Template] Currency Selector Style Updates

### DIFF
--- a/packages/dev/src/components/CurrencySelector.client.jsx
+++ b/packages/dev/src/components/CurrencySelector.client.jsx
@@ -18,15 +18,16 @@ export default function CurrencySelector() {
   return (
     <div className="hidden lg:block">
       <Listbox onChange={setCountry}>
-        <Listbox.Button className="font-medium text-sm h-8 p-2 w-16">
-          {selectedCountry.currency.isoCode}
+        <Listbox.Button className="font-medium text-sm h-8 p-2 flex items-center">
+          <span className="mr-4">{selectedCountry.currency.isoCode}</span>
+          <ArrowIcon />
         </Listbox.Button>
 
-        <Listbox.Options className="absolute z-10 mt-2 border-t-4 border-blue-600">
-          <div className="bg-white w-28 border-2 border-black">
+        <Listbox.Options className="absolute z-10 mt-2">
+          <div className="bg-white p-4 rounded-lg drop-shadow-2xl">
             <Listbox.Option
               disabled
-              className="p-2 text-sm text-left font-bold"
+              className="p-2 text-lg text-left font-medium uppercase"
             >
               Currency
             </Listbox.Option>
@@ -36,9 +37,8 @@ export default function CurrencySelector() {
                 <Listbox.Option key={country.isoCode} value={country.isoCode}>
                   {({active}) => (
                     <div
-                      className={`p-2 flex justify-between items-center text-left w-full cursor-pointer ${
-                        isSelected ? 'font-medium' : null
-                      } ${active ? 'bg-gray-200' : null}`}
+                      className={`w-36 py-2 px-3 flex justify-between items-center text-left cursor-pointer rounded
+                      ${active ? 'bg-gray-200' : null}`}
                     >
                       {country.currency.isoCode}
                       {isSelected ? <CheckIcon /> : null}
@@ -57,18 +57,38 @@ export default function CurrencySelector() {
 function CheckIcon() {
   return (
     <svg
-      className="mr-2"
-      width="14"
-      height="10"
-      viewBox="0 0 14 10"
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 10L9 12L13 8M19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10Z"
+        stroke="#354CF6"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ArrowIcon({className}) {
+  return (
+    <svg
+      className={className}
+      width="10"
+      height="6"
+      viewBox="0 0 10 6"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M13.7071 0.292893C14.0976 0.683417 14.0976 1.31658 13.7071 1.70711L5.70711 9.70711C5.31658 10.0976 4.68342 10.0976 4.29289 9.70711L0.292893 5.70711C-0.0976311 5.31658 -0.0976311 4.68342 0.292893 4.29289C0.683417 3.90237 1.31658 3.90237 1.70711 4.29289L5 7.58579L12.2929 0.292893C12.6834 -0.0976311 13.3166 -0.0976311 13.7071 0.292893Z"
-        fill="#354CF6"
+        d="M0.292893 0.292893C0.683416 -0.097631 1.31658 -0.097631 1.7071 0.292893L4.99999 3.58579L8.29288 0.292893C8.6834 -0.0976311 9.31657 -0.0976311 9.70709 0.292893C10.0976 0.683417 10.0976 1.31658 9.70709 1.70711L5.7071 5.70711C5.31657 6.09763 4.68341 6.09763 4.29289 5.70711L0.292893 1.70711C-0.0976309 1.31658 -0.0976309 0.683417 0.292893 0.292893Z"
+        fill="#374151"
       />
     </svg>
   );

--- a/packages/dev/src/components/CurrencySelector.client.jsx
+++ b/packages/dev/src/components/CurrencySelector.client.jsx
@@ -62,6 +62,7 @@ function CheckIcon() {
       viewBox="0 0 20 20"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       <path
         d="M7 10L9 12L13 8M19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10Z"

--- a/packages/dev/src/components/CurrencySelector.client.jsx
+++ b/packages/dev/src/components/CurrencySelector.client.jsx
@@ -79,6 +79,7 @@ function ArrowIcon({className}) {
   return (
     <svg
       className={className}
+      aria-hidden="true"
       width="10"
       height="6"
       viewBox="0 0 10 6"

--- a/packages/dev/src/components/LoadingFallback.jsx
+++ b/packages/dev/src/components/LoadingFallback.jsx
@@ -12,7 +12,7 @@ export default function LoadingFallback() {
               <OpenIcon />
             </div>
             <p className="font-black uppercase text-2xl tracking-widest">
-              Snowdevil Snowboards
+              Snowdevil
             </p>
             <CartIcon />
           </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

Updating the styles for the desktop currency selector. Includes adding new iconography.

Also fixing the fact that the store name was changed on admin, and is hardcoded for the loading fallback.

![](https://screenshot.click/CleanShot_2021-11-05_at_11.46.302x.png)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
