### PR TITLE
Better cart line quantity adjustsments

### DIFF
--- a/packages/dev/src/components/Cart.client.jsx
+++ b/packages/dev/src/components/Cart.client.jsx
@@ -107,6 +107,7 @@ function CartItems() {
               <CartLine.QuantityAdjustButton
                 adjust="remove"
                 aria-label="Remove from cart"
+                className="disabled:pointer-events-all disabled:cursor-wait"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -135,8 +136,8 @@ function CartItemQuantity() {
     <div className="flex border border-gray-300 items-center overflow-auto mt-2">
       <CartLine.QuantityAdjustButton
         adjust="decrease"
-        className="p-2"
         aria-label="Decrease quantity"
+        className="p-2 disabled:pointer-events-all disabled:cursor-wait"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -157,8 +158,8 @@ function CartItemQuantity() {
       />
       <CartLine.QuantityAdjustButton
         adjust="increase"
-        className="p-2"
         aria-label="Increase quantity"
+        className="p-2 disabled:pointer-events-all disabled:cursor-wait"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- feat: disable the quantity adjust button when the cart is not idle
 - feat: use country server state in cart for the inContext directive
 - fix: update interaction prompt and interaction promp style attributes for Model3d
 - feat: use Image url field instead of deprecated originalSrc field

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
@@ -1,5 +1,6 @@
 import React, {ReactNode, ElementType} from 'react';
 import {
+  useCart,
   useCartLinesRemoveCallback,
   useCartLinesUpdateCallback,
 } from '../CartProvider';
@@ -24,11 +25,13 @@ export function CartLineQuantityAdjustButton<
 ) {
   const updateLines = useCartLinesUpdateCallback();
   const removeLines = useCartLinesRemoveCallback();
+  const {status} = useCart();
   const cartLine = useCartLine();
   const {children, adjust, ...passthroughProps} = props;
 
   return (
     <button
+      disabled={status !== 'idle'}
       onClick={() => {
         if (adjust === 'remove') {
           removeLines([cartLine.id]);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes the issue brought up during the starter template QA review: 

> Type: Bug
Priority:  Must fix
Title: Clicking quantity increment/decrement quickly is ignored or slow
Describe the bug: The plus/minus icons for quantity are slow/sometimes don’t respond if you click really fast/constantly. There is a delay to responding that feels a bit off.
Expected behaviour: Add a loader to block multiple increments if we’re waiting on an API or make it more responsive :) 

The fix involved:
- Updating the `CartLineQuantityAdjustButton` to be `disabled` automatically when the cart status is anything but `idle` (which means that there is some action going on, either creating, fetching, etc). 
- Updating the button styling in the starter template to use the `wait` cursor when the button is disabled. 

To 🎩 : 
Open the starter template and add an item to your cart. Open the cart, and try quickly increasing/decreasing the quantity. You will see the cursor be the `wait` cursor while the action is pending, and clicking the button during this time will not result in any action. 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
