### PR TITLE
[Template] Fix Gradient Overlapping the Footer

### DIFF
--- a/packages/dev/src/components/Footer.server.jsx
+++ b/packages/dev/src/components/Footer.server.jsx
@@ -3,7 +3,7 @@ import {Link} from '@shopify/hydrogen';
 export default function Footer({collection, product}) {
   return (
     <footer role="contentinfo">
-      <div className="bg-white border-t border-b border-black border-opacity-5">
+      <div className="relative bg-white border-t border-b border-black border-opacity-5">
         <div className="mx-auto max-w-7xl px-4 py-14 md:px-8 grid grid-cols-1 md:grid-cols-3 gap-12">
           {/* eslint-disable-next-line @shopify/jsx-prefer-fragment-wrappers */}
           <div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

In short viewports, the gradient is overlapping the footer as seen [here](https://screenshot.click/footer.mov).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
