### PR TITLE
[Template] Re-export Link component

### DIFF
--- a/packages/dev/src/components/Link.client.jsx
+++ b/packages/dev/src/components/Link.client.jsx
@@ -1,0 +1,1 @@
+export {Link} from '@shopify/hydrogen/client';

--- a/packages/dev/src/components/ProductCard.server.jsx
+++ b/packages/dev/src/components/ProductCard.server.jsx
@@ -1,4 +1,6 @@
-import {Link, Image, Money} from '@shopify/hydrogen';
+import {Image, Money} from '@shopify/hydrogen';
+
+import {Link} from './Link.client';
 
 export default function ProductCard({product}) {
   const selectedVariant = product.variants.edges[0].node;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We were seeing a hard refresh every-time you clicked a `ProductCard` on the collections page. This surfaced that the cart takes time to fetch so any eager clicking of `AddToCart` could result in an error. This PR re-exports the Link component which is a known issue to solve for the hard refresh. 

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
