### PR TITLE
[Hydrogen reference docs]: Update `/beta` links

### DIFF
--- a/packages/hydrogen/src/utilities/flattenConnection/README.md
+++ b/packages/hydrogen/src/utilities/flattenConnection/README.md
@@ -53,8 +53,8 @@ export function Product({handle}) {
 
 ## Related components
 
-- [ProductProvider](beta/hydrogen/reference/components/product-variant/productprovider)
+- [ProductProvider](api/hydrogen/components/product-variant/productprovider)
 
 ## Related hooks
 
-- [useProduct](beta/hydrogen/reference/hooks/product-variant/useproduct)
+- [useProduct](api/hydrogen/hooks/product-variant/useproduct)

--- a/packages/hydrogen/src/utilities/flattenConnection/docs/related.md
+++ b/packages/hydrogen/src/utilities/flattenConnection/docs/related.md
@@ -1,7 +1,7 @@
 ## Related components
 
-- [ProductProvider](beta/hydrogen/reference/components/product-variant/productprovider)
+- [ProductProvider](api/hydrogen/components/product-variant/productprovider)
 
 ## Related hooks
 
-- [useProduct](beta/hydrogen/reference/hooks/product-variant/useproduct)
+- [useProduct](api/hydrogen/hooks/product-variant/useproduct)

--- a/packages/hydrogen/src/utilities/parseMetafieldValue/README.md
+++ b/packages/hydrogen/src/utilities/parseMetafieldValue/README.md
@@ -82,4 +82,4 @@ export function Product({handle}) {
 
 ## Related hook
 
-- [`useParsedMetafields`](/beta/hydrogen/reference/hooks/metafield/useparsedmetafields)
+- [`useParsedMetafields`](/api/hydrogen/hooks/metafield/useparsedmetafields)

--- a/packages/hydrogen/src/utilities/parseMetafieldValue/docs/related.md
+++ b/packages/hydrogen/src/utilities/parseMetafieldValue/docs/related.md
@@ -1,3 +1,3 @@
 ## Related hook
 
-- [`useParsedMetafields`](/beta/hydrogen/reference/hooks/metafield/useparsedmetafields)
+- [`useParsedMetafields`](/api/hydrogen/hooks/metafield/useparsedmetafields)


### PR DESCRIPTION
## This PR: 
- Updates `/beta` links to point to the new locations on Shopify.dev
- Relates to https://github.com/Shopify/hydrogen/pull/134 and https://github.com/Shopify/shopify-dev/issues/10171