### PR TITLE
[Hydrogen reference docs]: Update framework docs links

### DIFF
--- a/packages/hydrogen/src/components/AddToCartButton/README.md
+++ b/packages/hydrogen/src/components/AddToCartButton/README.md
@@ -46,7 +46,7 @@ export function MyComponent() {
 
 ## Component type
 
-The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Used by
 

--- a/packages/hydrogen/src/components/AddToCartButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/AddToCartButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/BuyNowButton/README.md
+++ b/packages/hydrogen/src/components/BuyNowButton/README.md
@@ -27,7 +27,7 @@ export function MyComponent() {
 
 ## Component type
 
-The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/BuyNowButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/BuyNowButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartCheckoutButton/README.md
+++ b/packages/hydrogen/src/components/CartCheckoutButton/README.md
@@ -11,7 +11,7 @@ The `CartCheckoutButton` component renders a button that redirects to the checko
 
 ## Component type
 
-The `CartCheckoutButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartCheckoutButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Example code
 

--- a/packages/hydrogen/src/components/CartCheckoutButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartCheckoutButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartCheckoutButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartCheckoutButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartEstimatedCost/README.md
+++ b/packages/hydrogen/src/components/CartEstimatedCost/README.md
@@ -28,7 +28,7 @@ export default function MyCart() {
 ## Component type
 
 The `CartEstimatedCost` component is a client component, which means that it renders on the client.
-For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartEstimatedCost/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartEstimatedCost/docs/component-type.md
@@ -1,4 +1,4 @@
 ## Component type
 
 The `CartEstimatedCost` component is a client component, which means that it renders on the client.
-For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineAttributes/README.md
+++ b/packages/hydrogen/src/components/CartLineAttributes/README.md
@@ -38,7 +38,7 @@ The `CartLineAttributes` components provides an object with the following keys a
 
 ## Component type
 
-The `CartLineAttributes` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineAttributes` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Alias
 

--- a/packages/hydrogen/src/components/CartLineAttributes/docs/2-component-type.md
+++ b/packages/hydrogen/src/components/CartLineAttributes/docs/2-component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineAttributes` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineAttributes` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineImage/README.md
+++ b/packages/hydrogen/src/components/CartLineImage/README.md
@@ -27,7 +27,7 @@ The `CartLineImage` component is aliased by the `CartLine.Image` component. You 
 
 ## Component type
 
-The `CartLineImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLineImage/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLineImage/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLinePrice/README.md
+++ b/packages/hydrogen/src/components/CartLinePrice/README.md
@@ -33,7 +33,7 @@ The `CartLinePrice` component is aliased by the `CartLine.Price` component. You 
 
 ## Component type
 
-The `CartLinePrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLinePrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLinePrice/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLinePrice/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLinePrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLinePrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineProductTitle/README.md
+++ b/packages/hydrogen/src/components/CartLineProductTitle/README.md
@@ -31,7 +31,7 @@ The `CartLineProductTitle` component is aliased by the `CartLine.ProductTitle` c
 
 ## Component type
 
-The `CartLineProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLineProductTitle/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLineProductTitle/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineProvider/README.md
+++ b/packages/hydrogen/src/components/CartLineProvider/README.md
@@ -26,7 +26,7 @@ The `CartLineProvider` component is aliased by the `CartLine` component. You can
 
 ## Component type
 
-The `CartLineProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLineProvider/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLineProvider/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineQuantity/README.md
+++ b/packages/hydrogen/src/components/CartLineQuantity/README.md
@@ -27,7 +27,7 @@ The `CartLineQuantity` component is aliased by the `CartLine.Quantity` component
 
 ## Component type
 
-The `CartLineQuantity` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineQuantity` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLineQuantity/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLineQuantity/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineQuantity` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineQuantity` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/README.md
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/README.md
@@ -39,7 +39,7 @@ The `CartLineQuantityAdjustButton` component is aliased by the `CartLine.Quantit
 
 ## Component type
 
-The `CartLineQuantityAdjustButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineQuantityAdjustButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineQuantityAdjustButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineQuantityAdjustButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLineSelectedOptions/README.md
+++ b/packages/hydrogen/src/components/CartLineSelectedOptions/README.md
@@ -42,7 +42,7 @@ The `CartLineSelectedOptions` components provides an object with the following k
 
 ## Component type
 
-The `CartLineSelectedOptions` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineSelectedOptions` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Alias
 

--- a/packages/hydrogen/src/components/CartLineSelectedOptions/docs/2-component-type.md
+++ b/packages/hydrogen/src/components/CartLineSelectedOptions/docs/2-component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLineSelectedOptions` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLineSelectedOptions` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartLines/README.md
+++ b/packages/hydrogen/src/components/CartLines/README.md
@@ -46,7 +46,7 @@ export function MyComponentWithRenderProps() {
 
 ## Component type
 
-The `CartLines` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLines` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartLines/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartLines/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartLines` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartLines` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartProvider/README.md
+++ b/packages/hydrogen/src/components/CartProvider/README.md
@@ -12,7 +12,7 @@ export function App() {
 
 ## Component type
 
-The `CartProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartProvider/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartProvider/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/CartShopPayButton/README.md
+++ b/packages/hydrogen/src/components/CartShopPayButton/README.md
@@ -19,7 +19,7 @@ export default function MyComponent() {
 
 ## Component type
 
-The `CartShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/CartShopPayButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/CartShopPayButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `CartShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `CartShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ExternalVideo/README.md
+++ b/packages/hydrogen/src/components/ExternalVideo/README.md
@@ -54,7 +54,7 @@ export default function MyProductVideo() {
 
 ## Component type
 
-The `ExternalVideo` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ExternalVideo` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/ExternalVideo/docs/component-type.md
+++ b/packages/hydrogen/src/components/ExternalVideo/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ExternalVideo` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ExternalVideo` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/Image/README.md
+++ b/packages/hydrogen/src/components/Image/README.md
@@ -65,7 +65,7 @@ export default function ExternalImageWithLoader() {
 
 ## Component type
 
-The `Image` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Image` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/Image/docs/component-type.md
+++ b/packages/hydrogen/src/components/Image/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `Image` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Image` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/LocalizationProvider/README.md
+++ b/packages/hydrogen/src/components/LocalizationProvider/README.md
@@ -10,7 +10,7 @@ Any descendents of this provider can use the `useCountry` and `useAvailableCount
 
 ## Component type
 
-The `LocalizationProvider` component is a server component, which means that it renders on the server. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `LocalizationProvider` component is a server component, which means that it renders on the server. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Example code
 

--- a/packages/hydrogen/src/components/LocalizationProvider/docs/component-type.md
+++ b/packages/hydrogen/src/components/LocalizationProvider/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `LocalizationProvider` component is a server component, which means that it renders on the server. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `LocalizationProvider` component is a server component, which means that it renders on the server. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/MediaFile/README.md
+++ b/packages/hydrogen/src/components/MediaFile/README.md
@@ -58,7 +58,7 @@ export function MyComponent() {
 
 ## Component type
 
-The `MediaFile` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `MediaFile` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/MediaFile/docs/component-type.md
+++ b/packages/hydrogen/src/components/MediaFile/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `MediaFile` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `MediaFile` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/Metafield/README.md
+++ b/packages/hydrogen/src/components/Metafield/README.md
@@ -76,7 +76,7 @@ The `Metafield` components provides the Metafield object with a `value` that was
 
 ## Component type
 
-The `Metafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Metafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/Metafield/docs/3-component-type.md
+++ b/packages/hydrogen/src/components/Metafield/docs/3-component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `Metafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Metafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/Model3D/README.md
+++ b/packages/hydrogen/src/components/Model3D/README.md
@@ -106,7 +106,7 @@ export default function MyProductModel() {
 
 ## Component type
 
-The `Model3D` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Model3D` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/Model3D/docs/component-type.md
+++ b/packages/hydrogen/src/components/Model3D/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `Model3D` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Model3D` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/Money/README.md
+++ b/packages/hydrogen/src/components/Money/README.md
@@ -60,7 +60,7 @@ export default function ProductWithCustomMoney() {
 
 ## Component type
 
-The `Money` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Money` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/Money/docs/component-type.md
+++ b/packages/hydrogen/src/components/Money/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `Money` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Money` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ProductDescription/README.md
+++ b/packages/hydrogen/src/components/ProductDescription/README.md
@@ -24,7 +24,7 @@ The `ProductDescription` component is aliased by `Product.Description`. You can 
 
 ## Component type
 
-The `ProductDescription` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductDescription` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/ProductDescription/docs/component-type.md
+++ b/packages/hydrogen/src/components/ProductDescription/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ProductDescription` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductDescription` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ProductMetafield/README.md
+++ b/packages/hydrogen/src/components/ProductMetafield/README.md
@@ -42,7 +42,7 @@ export function ProductWithRenderProp({product}) {
 
 ## Component type
 
-The `ProductMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/ProductMetafield/docs/component-type.md
+++ b/packages/hydrogen/src/components/ProductMetafield/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ProductMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ProductPrice/README.md
+++ b/packages/hydrogen/src/components/ProductPrice/README.md
@@ -32,7 +32,7 @@ The `ProductPrice` component is aliased by the `Product.Price` component. You ca
 
 ## Component type
 
-The `ProductPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/ProductPrice/docs/component-type.md
+++ b/packages/hydrogen/src/components/ProductPrice/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ProductPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -36,7 +36,7 @@ The `ProductProvider` component is aliased by the `Product` component. You can u
 
 ## Component type
 
-The `ProductProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/ProductProvider/docs/component-type.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ProductProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductProvider` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ProductTitle/README.md
+++ b/packages/hydrogen/src/components/ProductTitle/README.md
@@ -24,7 +24,7 @@ The `ProductTitle` component is aliased by the `Product.Title` component. You ca
 
 ## Component type
 
-The `ProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/ProductTitle/docs/component-type.md
+++ b/packages/hydrogen/src/components/ProductTitle/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ProductTitle` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/RawHtml/README.md
+++ b/packages/hydrogen/src/components/RawHtml/README.md
@@ -26,7 +26,7 @@ export function MyComponent() {
 
 ## Component type
 
-The `RawHtml` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `RawHtml` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Used by
 

--- a/packages/hydrogen/src/components/RawHtml/docs/component-type.md
+++ b/packages/hydrogen/src/components/RawHtml/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `RawHtml` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `RawHtml` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantAddToCartButton/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantAddToCartButton/README.md
@@ -60,7 +60,7 @@ The `SelectedVariantAddToCartButton` component is aliased by the `Product.Select
 
 ## Component type
 
-The `SelectedVariantAddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantAddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantAddToCartButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantAddToCartButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantAddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantAddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantBuyNowButton/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantBuyNowButton/README.md
@@ -28,7 +28,7 @@ The `SelectedVariantBuyNowButton` component is aliased by the `Product.SelectedV
 
 ## Component type
 
-The `SelectedVariantBuyNowButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantBuyNowButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantBuyNowButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantBuyNowButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantBuyNowButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantBuyNowButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantImage/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantImage/README.md
@@ -23,7 +23,7 @@ The `SelectedVariantImage` component is aliased by the `Product.SelectedVariant.
 
 ## Component type
 
-The `SelectedVariantImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantImage/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantImage/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantImage` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantMetafield/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantMetafield/README.md
@@ -48,7 +48,7 @@ export function ProductWithRenderProp({product}) {
 
 ## Component type
 
-The `SelectedVariantMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantMetafield/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantMetafield/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantMetafield` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantPrice/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantPrice/README.md
@@ -29,7 +29,7 @@ The `SelectedVariantPrice` component is aliased by the `Product.SelectedVariant.
 
 ## Component type
 
-The `SelectedVariantPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantPrice/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantPrice/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantShopPayButton/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantShopPayButton/README.md
@@ -24,7 +24,7 @@ The `SelectedVariantShopPayButton` component is aliased by the `Product.Selected
 
 ## Component type
 
-The `SelectedVariantShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantShopPayButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantShopPayButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/SelectedVariantUnitPrice/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantUnitPrice/README.md
@@ -23,7 +23,7 @@ The `SelectedVariantUnitPrice` component is aliased by the `Product.SelectedVari
 
 ## Component type
 
-The `SelectedVariantUnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantUnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Related components
 

--- a/packages/hydrogen/src/components/SelectedVariantUnitPrice/docs/component-type.md
+++ b/packages/hydrogen/src/components/SelectedVariantUnitPrice/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `SelectedVariantUnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `SelectedVariantUnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/ShopPayButton/README.md
+++ b/packages/hydrogen/src/components/ShopPayButton/README.md
@@ -21,7 +21,7 @@ export function MyProduct({variantId}) {
 
 ## Component type
 
-The `ShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Used by
 

--- a/packages/hydrogen/src/components/ShopPayButton/docs/component-type.md
+++ b/packages/hydrogen/src/components/ShopPayButton/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ShopPayButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/UnitPrice/README.md
+++ b/packages/hydrogen/src/components/UnitPrice/README.md
@@ -80,7 +80,7 @@ export default function ProductWithCustomUnitPrice() {
 
 ## Component type
 
-The `UnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `UnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/UnitPrice/docs/component-type.md
+++ b/packages/hydrogen/src/components/UnitPrice/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `UnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `UnitPrice` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/components/Video/README.md
+++ b/packages/hydrogen/src/components/Video/README.md
@@ -52,7 +52,7 @@ export default function MyProductVideo() {
 
 ## Component type
 
-The `Video` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Video` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## GraphQL fragment
 

--- a/packages/hydrogen/src/components/Video/docs/component-type.md
+++ b/packages/hydrogen/src/components/Video/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `Video` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `Video` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/docs/components.md
+++ b/packages/hydrogen/src/docs/components.md
@@ -262,5 +262,5 @@ The [LocalizationProvider](/api/hydrogen/components/localization/localizationpro
 ## Next steps
 
 - [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
-- Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn about [Hydrogen's architecture and framework](/api/hydrogen/framework).
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/docs/hooks.md
+++ b/packages/hydrogen/src/docs/hooks.md
@@ -175,5 +175,5 @@ Hydrogen includes the following metafield hooks:
 ## Next steps
 
 - [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
-- Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn about [Hydrogen's architecture and framework](/api/hydrogen/framework).
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/docs/hydrogen-sdk.md
+++ b/packages/hydrogen/src/docs/hydrogen-sdk.md
@@ -347,5 +347,5 @@ Hydrogen includes the following utilities to help speed up your development proc
 ## Next steps
 
 - [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
-- Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn about [Hydrogen's architecture and framework](/api/hydrogen/framework).
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/docs/utilities.md
+++ b/packages/hydrogen/src/docs/utilities.md
@@ -25,5 +25,5 @@ Hydrogen includes the following utilities:
 ## Next steps
 
 - [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
-- Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn about [Hydrogen's architecture and framework](/api/hydrogen/framework).
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/foundation/ShopifyProvider/README.md
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/README.md
@@ -8,7 +8,7 @@ The `ShopifyProvider` component wraps your entire app and provides support for h
 
 ## Component type
 
-The `ShopifyProvider` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ShopifyProvider` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).
 
 ## Example code
 

--- a/packages/hydrogen/src/foundation/ShopifyProvider/docs/component-type.md
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/docs/component-type.md
@@ -1,3 +1,3 @@
 ## Component type
 
-The `ShopifyProvider` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+The `ShopifyProvider` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/api/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/foundation/useServerState/README.md
+++ b/packages/hydrogen/src/foundation/useServerState/README.md
@@ -1,6 +1,6 @@
 <!-- This file is generated from the source code. Edit the files in /packages/hydrogen/src/foundation/useServerState and run 'yarn generate-docs' at the root of this repo. -->
 
-The `useServerState` hook allows you to [manage server state](/custom-storefronts/hydrogen/framework/server-state) when using Hydrogen as a React Server Component framework.
+The `useServerState` hook allows you to [manage server state](/api/hydrogen/framework/server-state) when using Hydrogen as a React Server Component framework.
 
 ## Return value
 

--- a/packages/hydrogen/src/foundation/useServerState/use-server-state.tsx
+++ b/packages/hydrogen/src/foundation/useServerState/use-server-state.tsx
@@ -2,7 +2,7 @@ import {useContext} from 'react';
 import {ServerStateContext} from '../ServerStateProvider';
 
 /**
- * The `useServerState` hook allows you to [manage server state](/custom-storefronts/hydrogen/framework/server-state) when using Hydrogen as a React Server Component framework.
+ * The `useServerState` hook allows you to [manage server state](/api/hydrogen/framework/server-state) when using Hydrogen as a React Server Component framework.
  *
  * ## Return value
  *

--- a/packages/hydrogen/src/framework/docs/cache.md
+++ b/packages/hydrogen/src/framework/docs/cache.md
@@ -192,5 +192,5 @@ Full-page caching is powered completely by [`cache-control` headers on the Hydro
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/css-support.md
+++ b/packages/hydrogen/src/framework/docs/css-support.md
@@ -46,5 +46,5 @@ Check back to read the official guidance as Shopify approaches a stable release 
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -20,7 +20,7 @@ Hydrogen comes with [React Router](https://reactrouter.com/), a tool that allows
 
 When you [create a Hydrogen app](/custom-storefronts/hydrogen/getting-started#step-1-create-a-new-hydrogen-app), a file structure for the project is generated. Most of the files that you'll work with in the Hydrogen project are located in the `/src` directory. The `/src` directory contains the following:
 
-- A set of boilerplate [components](/api/hydrogen/components) (`components`) and [pages](/custom-storefronts/hydrogen/framework/pages) (`pages`)
+- A set of boilerplate [components](/api/hydrogen/components) (`components`) and [pages](/api/hydrogen/framework/pages) (`pages`)
 - The main app component, which includes boilerplate code for the app and routing (`App.server.jsx`)
 - The Hydrogen app's two entry points, which are based on environment:
 
@@ -77,4 +77,4 @@ The Hydrogen app is hosted on a worker platform (for example, Oxygen or Cloudfla
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/framework/docs/pages.md
+++ b/packages/hydrogen/src/framework/docs/pages.md
@@ -130,7 +130,7 @@ Since this code lives inside a server component, you can use [`useShopQuery`](/a
 
 ### `response.cache()`
 
-If you want to modify the [full-page cache options](/custom-storefronts/hydrogen/framework/cache), then you can call `cache()` on the response object:
+If you want to modify the [full-page cache options](/api/hydrogen/framework/cache), then you can call `cache()` on the response object:
 
 {% codeblock file %}
 
@@ -149,7 +149,7 @@ export default function MyProducts({response}) {
 
 ## Server state props
 
-In addition to `request` and `response` props, any state you manage with [`setServerState`](/custom-storefronts/hydrogen/framework/server-state) is passed to each of your page server components as props:
+In addition to `request` and `response` props, any state you manage with [`setServerState`](/api/hydrogen/framework/server-state) is passed to each of your page server components as props:
 
 {% codeblock file %}
 
@@ -447,6 +447,6 @@ const QUERY = gql`
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
-- Learn how to manage the [state on the server](/custom-storefronts/hydrogen/framework/server-state) as you're building your Hydrogen app.
-- Get familiar with the [file-based routing system](/custom-storefronts/hydrogen/framework/routes) that Hydrogen uses.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn how to manage the [state on the server](/api/hydrogen/framework/server-state) as you're building your Hydrogen app.
+- Get familiar with the [file-based routing system](/api/hydrogen/framework/routes) that Hydrogen uses.

--- a/packages/hydrogen/src/framework/docs/react-server-components.md
+++ b/packages/hydrogen/src/framework/docs/react-server-components.md
@@ -155,7 +155,7 @@ The following section includes information about working with React Server Compo
 
 ### Sharing `state` between client and server
 
-The `state` object is core to React Server Components. Hydrogen provides a [`useServerState()` hook with a `setServerState()` helper function](/custom-storefronts/hydrogen/framework/server-state), which allows components to paginate within collections, programmatically switch routes, or do anything that requires new data from the server.
+The `state` object is core to React Server Components. Hydrogen provides a [`useServerState()` hook with a `setServerState()` helper function](/api/hydrogen/framework/server-state), which allows components to paginate within collections, programmatically switch routes, or do anything that requires new data from the server.
 
 Sharing state information between the client and server is important for common tasks, like `page` routing. The following diagram shows how the `page` state is shared between the client and server:
 
@@ -224,6 +224,6 @@ The following prop wouldn't send successfully:
 
 ## Next steps
 
-- Learn how to manage the [state on the server](/custom-storefronts/hydrogen/framework/server-state) as you're building your Hydrogen app.
-- Get familiar with the [file-based routing system](/custom-storefronts/hydrogen/framework/routes) that Hydrogen uses.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn how to manage the [state on the server](/api/hydrogen/framework/server-state) as you're building your Hydrogen app.
+- Get familiar with the [file-based routing system](/api/hydrogen/framework/routes) that Hydrogen uses.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/routes.md
+++ b/packages/hydrogen/src/framework/docs/routes.md
@@ -74,5 +74,5 @@ const {pathname} = useLocation();
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/secrets.md
+++ b/packages/hydrogen/src/framework/docs/secrets.md
@@ -16,6 +16,6 @@ You need to prefix your secret names with `VITE_` for them to be displayed withi
 
 ## Next steps
 
-- Learn how to manage the [state on the server](/custom-storefronts/hydrogen/framework/server-state) as you're building your Hydrogen app.
-- Get familiar with the [file-based routing system](/custom-storefronts/hydrogen/framework/routes) that Hydrogen uses.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn how to manage the [state on the server](/api/hydrogen/framework/server-state) as you're building your Hydrogen app.
+- Get familiar with the [file-based routing system](/api/hydrogen/framework/routes) that Hydrogen uses.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -74,6 +74,6 @@ export default function App({...serverState}) {
 
 ## Next steps
 
-- Learn how to manage the [state on the server](/custom-storefronts/hydrogen/framework/server-state) as you're building your Hydrogen app.
-- Get familiar with the [file-based routing system](/custom-storefronts/hydrogen/framework/routes) that Hydrogen uses.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn how to manage the [state on the server](/api/hydrogen/framework/server-state) as you're building your Hydrogen app.
+- Get familiar with the [file-based routing system](/api/hydrogen/framework/routes) that Hydrogen uses.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/server-state.md
+++ b/packages/hydrogen/src/framework/docs/server-state.md
@@ -1,4 +1,4 @@
-As you build your Hydrogen app with [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), you'll likely need to update `state` on the server. Sharing state information between the client and server is important for common tasks, like [page routing](/custom-storefronts/hydrogen/framework/react-server-components#sharing-state-between-client-and-server).
+As you build your Hydrogen app with [React Server Components](/api/hydrogen/framework/react-server-components), you'll likely need to update `state` on the server. Sharing state information between the client and server is important for common tasks, like [page routing](/api/hydrogen/framework/react-server-components#sharing-state-between-client-and-server).
 
 This guide describes how to manage your server state during your development process.
 
@@ -82,6 +82,6 @@ export default function ProductSelector({selectedProductId}) {
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
 - Learn how to interact with the [`useServerState`](/api/hydrogen/hooks/global/useserverstate) hook.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/static-assets.md
+++ b/packages/hydrogen/src/framework/docs/static-assets.md
@@ -23,5 +23,5 @@ Product images are served from the Shopify database, so you don't need to place 
 
 ## Next steps
 
-- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
-- Learn how the [page server component](/custom-storefronts/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.
+- Learn about [React Server Components](/api/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn how the [page server component](/api/hydrogen/framework/pages) receives props, which includes custom versions of `request` and `response`.

--- a/packages/hydrogen/src/framework/docs/third-party-dependencies.md
+++ b/packages/hydrogen/src/framework/docs/third-party-dependencies.md
@@ -18,7 +18,7 @@ yarn add <dependency>
 
 Consider the following:
 
-- If the dependency interacts with `useState` or browser APIs, then place it inside a `*.client.jsx` component. Follow the [rules of server and client components](/custom-storefronts/hydrogen/framework/react-server-components#rules-for-server-and-client-components).
+- If the dependency interacts with `useState` or browser APIs, then place it inside a `*.client.jsx` component. Follow the [rules of server and client components](/api/hydrogen/framework/react-server-components#rules-for-server-and-client-components).
 - If the dependency is purely client-based, and you don't need to interact with it in individual components, then you can insert it in `src/entry-client.jsx`.
 - If the dependency includes a style import from a CSS file, then you can import that in `src/entry-client.jsx`.
 

--- a/packages/hydrogen/src/hooks/useQuery/README.md
+++ b/packages/hydrogen/src/hooks/useQuery/README.md
@@ -36,7 +36,7 @@ The `options` object accepts the following properties:
 
 | Key     | Required | Description                                                                                                |
 | ------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `cache` | No       | An object describing the [cache policy](/custom-storefronts/hydrogen/framework/cache) for the request. |
+| `cache` | No       | An object describing the [cache policy](/api/hydrogen/framework/cache) for the request. |
 
 ## Related hooks
 

--- a/packages/hydrogen/src/hooks/useQuery/docs/1-arguments.md
+++ b/packages/hydrogen/src/hooks/useQuery/docs/1-arguments.md
@@ -12,4 +12,4 @@ The `options` object accepts the following properties:
 
 | Key     | Required | Description                                                                                             |
 | ------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `cache` | No       | An object describing the [cache policy](/custom-storefronts/hydrogen/framework/cache) for the request. |
+| `cache` | No       | An object describing the [cache policy](/api/hydrogen/framework/cache) for the request. |

--- a/packages/hydrogen/src/hooks/useServerState/README.md
+++ b/packages/hydrogen/src/hooks/useServerState/README.md
@@ -1,4 +1,4 @@
-The `useServerState` hook allows you to [manage server state](/custom-storefronts/hydrogen/framework/server-state) when using Hydrogen as a React Server Component framework.
+The `useServerState` hook allows you to [manage server state](/api/hydrogen/framework/server-state) when using Hydrogen as a React Server Component framework.
 
 ## Return value
 

--- a/packages/hydrogen/src/hooks/useShopQuery/docs/1-arguments.md
+++ b/packages/hydrogen/src/hooks/useShopQuery/docs/1-arguments.md
@@ -6,4 +6,4 @@ The `useShopQuery` takes an object as its only argument, with the following keys
 | ----------- | -------- | ---------------------------------------------------------------------------------------------------------- |
 | `query`     | Yes      | A string of the GraphQL query.                                                                             |
 | `variables` | No       | An object of the variables for the GraphQL query.                                                          |
-| `cache`     | No       | An object describing the [cache policy](/custom-storefronts/hydrogen/framework/cache) for the request. |
+| `cache`     | No       | An object describing the [cache policy](/api/hydrogen/framework/cache) for the request. |

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -214,75 +214,75 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     generator.section({
       title: 'Hydrogen framework overview',
       description: 'Learn about the architecture and framework of Hydrogen.',
-      url: '/custom-storefronts/hydrogen/framework/index.md',
+      url: '/api/hydrogen/framework/index.md',
       entry: 'framework/docs/index.md',
     }),
     generator.section({
       title: 'React Server Components',
       description:
         'Learn about React Server Components, an opinionated data-fetching and rendering workflow for React apps.',
-      url: '/custom-storefronts/hydrogen/framework/react-server-components.md',
+      url: '/api/hydrogen/framework/react-server-components.md',
       entry: 'framework/docs/react-server-components.md',
     }),
     generator.section({
       title: 'Built-in CSS support',
       description:
         'Learn about the CSS support built into Hydrogen apps and how you can customize the styles in your app.',
-      url: '/custom-storefronts/hydrogen/framework/css-support.md',
+      url: '/api/hydrogen/framework/css-support.md',
       entry: 'framework/docs/css-support.md',
     }),
     generator.section({
       title: 'Cache',
       description: 'Learn how to manage cache options for Hydrogen apps.',
-      url: '/custom-storefronts/hydrogen/framework/cache.md',
+      url: '/api/hydrogen/framework/cache.md',
       entry: 'framework/docs/cache.md',
     }),
     generator.section({
       title: 'Server state',
       description:
         'Learn how to update the state on the server when you are building your Hydrogen app.',
-      url: '/custom-storefronts/hydrogen/framework/server-state.md',
+      url: '/api/hydrogen/framework/server-state.md',
       entry: 'framework/docs/server-state.md',
     }),
     generator.section({
       title: 'Routes',
       description:
         'Get familiar with the file-based routing system that Hydrogen uses.',
-      url: '/custom-storefronts/hydrogen/framework/routes.md',
+      url: '/api/hydrogen/framework/routes.md',
       entry: 'framework/docs/routes.md',
     }),
     generator.section({
       title: 'Pages',
       description: 'Learn about how page server components receive props.',
-      url: '/custom-storefronts/hydrogen/framework/pages.md',
+      url: '/api/hydrogen/framework/pages.md',
       entry: 'framework/docs/pages.md',
     }),
     generator.section({
       title: 'Secrets',
       description:
         'Learn how to store sensitive information in your Hydrogen project.',
-      url: '/custom-storefronts/hydrogen/framework/secrets.md',
+      url: '/api/hydrogen/framework/secrets.md',
       entry: 'framework/docs/secrets.md',
     }),
     generator.section({
       title: 'SEO',
       description:
         'Learn how to customize the output of SEO-related tags in your Hydrogen client and server components.',
-      url: '/custom-storefronts/hydrogen/framework/seo.md',
+      url: '/api/hydrogen/framework/seo.md',
       entry: 'framework/docs/seo.md',
     }),
     generator.section({
       title: 'Static assets',
       description:
         'Learn how to reference and serve static assets in Hydrogen.',
-      url: '/custom-storefronts/hydrogen/framework/static-assets.md',
+      url: '/api/hydrogen/framework/static-assets.md',
       entry: 'framework/docs/static-assets.md',
     }),
     generator.section({
       title: 'Third-party dependencies',
       description:
         'Tips and tricks for using third-party dependencies in Hydrogen apps.',
-      url: '/custom-storefronts/hydrogen/framework/third-party-dependencies.md',
+      url: '/api/hydrogen/framework/third-party-dependencies.md',
       entry: 'framework/docs/third-party-dependencies.md',
     }),
   ]);


### PR DESCRIPTION
## This PR: 
- Updates all references to framework docs on Shopify.dev from `/custom-storefronts/hydrogen/framework` to `/api/hydrogen/framework` on Shopify.dev
- Relates to https://github.com/Shopify/shopify-dev/issues/10171