### PR TITLE
fix: delay writing error response until headers are set

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+- fix: do not set headers after they are sent to client
+
 ## 0.6.0 - 2021-11-05
 
 - feat: disable the quantity adjust button when the cart is not idle


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Early errors were piped to the response directly and this was flushing headers. Then, any call to `setHeader` was throwing error.

This delays writing the error to the response until proper headers are set.

Related #139

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
