### PR TITLE
fix: LocalizationProvider in a Suspense boundary

### DIFF
--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Wrap LocalizationProvider in a proper Suspense boundary
+- Optimize `@headlessui/react` to prevent dev server slowness while we investigate a long term solution
 
 ## 0.6.0 - 2021-11-05
 

--- a/packages/dev/src/App.server.jsx
+++ b/packages/dev/src/App.server.jsx
@@ -17,10 +17,10 @@ export default function App({...serverState}) {
   const pages = import.meta.globEager('./pages/**/*.server.[jt]sx');
 
   return (
-    <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
-      <LocalizationProvider>
-        <CartProvider>
-          <Suspense fallback={<LoadingFallback />}>
+    <Suspense fallback={<LoadingFallback />}>
+      <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
+        <LocalizationProvider>
+          <CartProvider>
             <DefaultSeo />
             <Switch>
               <DefaultRoutes
@@ -29,9 +29,9 @@ export default function App({...serverState}) {
                 fallback={<NotFound />}
               />
             </Switch>
-          </Suspense>
-        </CartProvider>
-      </LocalizationProvider>
-    </ShopifyServerProvider>
+          </CartProvider>
+        </LocalizationProvider>
+      </ShopifyServerProvider>
+    </Suspense>
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

RE: #64 

@frandiox discovered we aren't wrapping `<LocalizationProvider>` in a Suspense boundary. That means that when the query runs uncached, it throws to the React runtime and perhaps causes the `Cannot use <Switch>...` error.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
