### PR TITLE
feat: Support explicit root in the CLI

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Add ability to explicitly set the root for the running command using the `--root` flag
 
 ## 0.6.0 - 2021-11-05
 

--- a/packages/cli/src/utilities/index.ts
+++ b/packages/cli/src/utilities/index.ts
@@ -1,4 +1,4 @@
-import {join, resolve} from 'path';
+import {resolve} from 'path';
 
 import minimist from 'minimist';
 
@@ -15,10 +15,8 @@ const DEFAULT_SUBCOMMANDS = {
 export function parseCliArguments(rawInputs?: string[]) {
   const inputs = minimist(rawInputs || []);
   const command = inputs._[0];
-  const root =
-    command === 'create' && inputs._[2]
-      ? join(process.cwd(), inputs._[2])
-      : process.cwd();
+
+  const root = inputs.root || process.cwd();
   const subcommand =
     inputs._[1] || DEFAULT_SUBCOMMANDS[command as 'create' | 'version'];
   const {debug} = inputs;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a `--root` flag to CLI commands.

### Additional context

Previously we were grabbing this from a positional argument, but as we add more commands this is a less brittle. 

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
