### PR TITLE
Remove `CartProvider` from the `BuyNowButton`

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- fix: remove CartProvider from BuyNowButton
 - fix: reading property of null for component props
 - fix: transform deeply-imported client components
 - fix: duplicated files and contexts in browser

--- a/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
+++ b/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, ElementType, useState, useCallback} from 'react';
 import type {ReactNode} from 'react';
-import {CartProvider, useInstantCheckout} from '../CartProvider';
+import {useInstantCheckout} from '../CartProvider';
 import {Props} from '../types';
 
 export interface BuyNowButtonProps {
@@ -21,16 +21,6 @@ export type BuyNowButtonPropsWeControl = 'onClick';
 
 /** The `BuyNowButton` component renders a button that adds an item to the cart and redirects the customer to checkout. */
 export function BuyNowButton<TTag extends ElementType = 'button'>(
-  props: Props<TTag, BuyNowButtonPropsWeControl> & BuyNowButtonProps
-) {
-  return (
-    <CartProvider>
-      <Button {...props} />
-    </CartProvider>
-  );
-}
-
-function Button<TTag extends ElementType = 'button'>(
   props: Props<TTag, BuyNowButtonPropsWeControl> & BuyNowButtonProps
 ) {
   const {createInstantCheckout, checkoutUrl} = useInstantCheckout();

--- a/packages/hydrogen/src/components/CartProvider/hooks.tsx
+++ b/packages/hydrogen/src/components/CartProvider/hooks.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {useShop} from '../../foundation';
 import {flattenConnection} from '../../utilities';
 import {CartInput} from '../../graphql/types/types';
@@ -47,10 +47,9 @@ export function useCartFetch() {
 }
 
 export function useInstantCheckout() {
-  const [cart, updateCart] = React.useState<Cart | undefined>();
-  const [checkoutUrl, updateCheckoutUrl] =
-    React.useState<Cart['checkoutUrl']>();
-  const [error, updateError] = React.useState<string | undefined>();
+  const [cart, updateCart] = useState<Cart | undefined>();
+  const [checkoutUrl, updateCheckoutUrl] = useState<Cart['checkoutUrl']>();
+  const [error, updateError] = useState<string | undefined>();
 
   const fetch = useCartFetch();
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR removes the `CartProvider` from the `BuyNowButton`, as it is no longer needed.

When the `BuyNowButton` was created, it originally relied on the `CartProvider` as it made use of the `useCartCreateCallback` hook to create a cart and then re-direct to checkout. 

The `BuyNowButton` was since refactored to use the `useInstantCheckout` hook, which doesn't make use of any `CartProvider` dependencies. As such, we can safely remove the `CartProvider` since it's no longer needed. 🎉 

### Additional context

Instructions for reviewing:
- With an _empty_ cart: go to a product page, click the BUY IT NOW button. You should get redirected to checkout with _only_ the product for which you clicked BUY IT NOW for. There should be no other line items.
- With a pre-existing cart with line items: go to a product page, click the BUY IT NOW button. You should get redirected to checkout with _only_ the product for which you clicked BUY IT NOW for. There should be no other line items, as BUY IT NOW produces a new cart for _only_ the product that you clicked BUY IT NOW for.

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
