### PR TITLE
fix: where react props can be null, yet still technically an "object"

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+- fix: reading property of null for component props
 
 ## 0.6.1 - 2021-11-08
 

--- a/packages/hydrogen/src/framework/Hydration/react-utils.ts
+++ b/packages/hydrogen/src/framework/Hydration/react-utils.ts
@@ -30,6 +30,7 @@ export function renderReactProps(props: any) {
 function renderReactProp(prop: any): any {
   if (
     typeof prop === 'object' &&
+    prop !== null &&
     prop['$$typeof'] === Symbol.for('react.element')
   ) {
     if (prop.type instanceof Function) {


### PR DESCRIPTION
Thank you JavaScript

<!-- Thank you for contributing! -->

### Description

Fix a problem where a react prop can be null, yet our logic only checks `typeof prop !== 'object'`, but that is true for null! Subsequently the code tries to lookup a prop on null and fails.

### Additional context

🤜 JavaScript

### Before submitting the PR, please make sure you do the following:

- [X] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository for your change, if needed
