### PR TITLE
feat: Lint changelogs for "Keep a changelog" semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "ts-node": "^10.2.1",
     "typescript": "^4.2.3",
     "vite": "^2.6.0",
-    "yorkie": "^2.0.0"
+    "yorkie": "^2.0.0",
+    "glob": "^7.2.0"
   },
   "gitHooks": {
     "pre-commit": "lint-staged",

--- a/tests/changelogs.test.ts
+++ b/tests/changelogs.test.ts
@@ -60,8 +60,8 @@ readChangelogs().forEach(({packageChangelogPath, packageChangelog}) => {
         /^<!-- ## Unreleased -->\n\n## /gm;
 
       expect([
-        unrelasedHeaderWithContent.test(packageChangelog) ||
-          unrelasedHeaderWithSubHeader.test(packageChangelog),
+        unreleasedHeaderWithContent.test(packageChangelog) ||
+          unreleasedHeaderWithSubHeader.test(packageChangelog),
         commentedUnreleasedHeaderWithNoContent.test(packageChangelog),
       ]).toContain(true);
     });

--- a/tests/changelogs.test.ts
+++ b/tests/changelogs.test.ts
@@ -54,8 +54,8 @@ readChangelogs().forEach(({packageChangelogPath, packageChangelog}) => {
       // - An Unreleased header, that is immediatly preceded by a bullet ("- ...")
       // - A commented out Unreleased header, that is immediatly preceded by a level 2 heading (Version info)
 
-      const unrelasedHeaderWithContent = /^## Unreleased\n\n- /gm;
-      const unrelasedHeaderWithSubHeader = /^## Unreleased\n\n### /gm;
+      const unreleasedHeaderWithContent = /^## Unreleased\n\n- /gm;
+      const unreleasedHeaderWithSubHeader = /^## Unreleased\n\n### /gm;
       const commentedUnreleasedHeaderWithNoContent =
         /^<!-- ## Unreleased -->\n\n## /gm;
 

--- a/tests/changelogs.test.ts
+++ b/tests/changelogs.test.ts
@@ -1,0 +1,154 @@
+import {join, resolve} from 'path';
+
+import {readFileSync} from 'fs-extra';
+import glob from 'glob';
+
+const ROOT_PATH = resolve(__dirname, '..');
+
+const HEADER_START_REGEX = /^## /;
+const CHANGELOG_INTRO = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).`;
+
+readChangelogs().forEach(({packageChangelogPath, packageChangelog}) => {
+  describe(`changelog consistency for ${packageChangelogPath}`, () => {
+    it('begins with the "Keep a Changelog" intro section', () => {
+      const actualIntro = packageChangelog.substring(0, CHANGELOG_INTRO.length);
+
+      expect(actualIntro).toBe(CHANGELOG_INTRO);
+    });
+
+    it('contains only known headers', () => {
+      const headerLines = packageChangelog
+        .split('\n')
+        .filter((line) => /^\s*#/.exec(line));
+      const offendingHeaders = headerLines.filter(
+        (headerLine) => !headerIsAllowed(headerLine)
+      );
+
+      expect(offendingHeaders).toStrictEqual([]);
+    });
+
+    it('has exactly 1 empty line before headings', () => {
+      const notEnoughSpacingBeforeHeadings = /[^\n]+\n^#.*$/gm;
+
+      expect(packageChangelog).not.toStrictEqual(
+        expect.stringMatching(notEnoughSpacingBeforeHeadings)
+      );
+    });
+
+    it('has exactly 1 empty line after headings', () => {
+      const notEnoughSpacingAfterHeadings = /^#.*$\n[^\n]+/gm;
+
+      expect(packageChangelog).not.toStrictEqual(
+        expect.stringMatching(notEnoughSpacingAfterHeadings)
+      );
+    });
+
+    it('contains an Unreleased header with content, or a commented out Unreleased header with no content', () => {
+      // One of the following must be present
+      // - An Unreleased header, that is immediatly preceded by a level 3 heading ("Changed" etc)
+      // - An Unreleased header, that is immediatly preceded by a bullet ("- ...")
+      // - A commented out Unreleased header, that is immediatly preceded by a level 2 heading (Version info)
+
+      const unrelasedHeaderWithContent = /^## Unreleased\n\n- /gm;
+      const unrelasedHeaderWithSubHeader = /^## Unreleased\n\n### /gm;
+      const commentedUnreleasedHeaderWithNoContent =
+        /^<!-- ## Unreleased -->\n\n## /gm;
+
+      expect([
+        unrelasedHeaderWithContent.test(packageChangelog) ||
+          unrelasedHeaderWithSubHeader.test(packageChangelog),
+        commentedUnreleasedHeaderWithNoContent.test(packageChangelog),
+      ]).toContain(true);
+    });
+
+    it('does not contain duplicate headers', () => {
+      const headerLines = packageChangelog
+        .split('\n')
+        .filter(
+          (line) => HEADER_START_REGEX.exec(line) || /## Unreleased/.exec(line)
+        )
+        .sort();
+      const uniqueHeaderLines = headerLines.filter(
+        (element, index, array) => array.indexOf(element) === index
+      );
+
+      expect(headerLines).toStrictEqual(uniqueHeaderLines);
+    });
+  });
+});
+
+const allowedHeaders = [
+  '# Changelog',
+  '## Unreleased',
+  /^## \d+\.\d+\.\d-\w+\.\d+ - \d\d\d\d-\d\d-\d\d$/, // -alpha.x releases
+  /^## \d+\.\d+\.\d+ - \d\d\d\d-\d\d-\d\d$/,
+  '### Fixed',
+  '### Added',
+  '### Changed',
+  '### Deprecated',
+  '### Removed',
+  '### Security',
+  /^####/,
+];
+
+function headerIsAllowed(headerLine) {
+  return allowedHeaders.some((allowedHeader) => {
+    if (allowedHeader instanceof RegExp) {
+      return allowedHeader.test(headerLine);
+    } else {
+      return allowedHeader === headerLine;
+    }
+  });
+}
+
+function readChangelogs() {
+  const packagesPath = join(ROOT_PATH, 'packages');
+
+  return glob
+    .sync(join(packagesPath, '*/'))
+    .filter(hasPackageJSON)
+    .filter(hasChangelog)
+    .map((packageDir) => {
+      const packageChangelogPath = join(packageDir, 'CHANGELOG.md');
+      const packageChangelog = safeReadSync(packageChangelogPath, {
+        encoding: 'utf8',
+      }).toString('utf-8');
+
+      return {
+        packageDir,
+        packageChangelogPath,
+        packageChangelog,
+      };
+    });
+}
+
+function safeReadSync(path, options) {
+  try {
+    return readFileSync(path, options);
+  } catch {
+    return '';
+  }
+}
+
+function hasChangelog(packageDir) {
+  const changelogJSONPath = join(packageDir, 'CHANGELOG.md');
+  const changelog = safeReadSync(changelogJSONPath, {
+    encoding: 'utf8',
+  });
+
+  return changelog.length > 0;
+}
+
+function hasPackageJSON(packageDir) {
+  const packageJSONPath = join(packageDir, 'package.json');
+  const packageJSON = safeReadSync(packageJSONPath, {
+    encoding: 'utf8',
+  });
+
+  return packageJSON.length > 0;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds tests to lint changelogs so that we can keep these consistent and prevent bugs when working with our release scripts.

### Additional context

I adapted these from tests I found in other repos and made adjustments for our needs. Luckily, we've been pretty consistent so far and all of the tests I added pass with no backfilled changes.

The tests do the following:
- Check for the "Keep a changelog" intro bit
- Check that we only use headers that are either 1) a date and release or 2) one of the accepted headers from the keep -a-changelog spec (see `allowedHeaders`) in the test file or [read here for more info](https://keepachangelog.com/en/1.0.0/#how).
- Check for proper spacing after each header
- Check for the proper use of the `Unreleased` header: It can be either 1) commented out (no unreleased changes) or 2) uncommented with a new header or a new bullet for release notes.
- Checks for duplicate headers

cc @blittle 

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
