### PR TITLE
fix: Don't generate docs without flag

### DIFF
--- a/packages/generate-docs/src/DocsGen.ts
+++ b/packages/generate-docs/src/DocsGen.ts
@@ -142,10 +142,11 @@ export class DocsGen {
 
         await componentResult.docs(componentEntryBase);
 
-        await Promise.all([
-          componentResult.writeReadme(componentEntryBase),
-          componentResult.writeDevDoc(componentPaths.output),
-        ]);
+        await componentResult.writeReadme(componentEntryBase);
+
+        if (this.writeDocs) {
+          componentResult.writeDevDoc(componentPaths.output);
+        }
 
         listItems.push({
           name: `<a href="${componentUrl}">${name}</a>`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes a minor bug where we were still generating shopify.dev docs event without the flag. Thanks @mcvinci for letting me know about this.

### Additional context

The component doc generation needed to be wrapped in the conditional.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
