### PR TITLE
fix: hide CLI docs for shopify.dev

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -19,6 +19,7 @@ async function runCliGenerator(args: Partial<Options> = {}) {
         'Use the  `@shopify/hydrogen-cli` to quickly get up and running building hydrogen apps.',
       url: '/api/hydrogen/cli/index.md',
       entry: '../',
+      hidden: true,
     }),
     cliGenerator.section({
       title: 'Commands',
@@ -26,6 +27,7 @@ async function runCliGenerator(args: Partial<Options> = {}) {
       url: '/api/hydrogen/cli/commands/index.md',
       entry: 'commands',
       tableColumns: ['Command', 'Description'],
+      hidden: true,
     }),
     cliGenerator.section({
       title: 'Create',
@@ -33,6 +35,7 @@ async function runCliGenerator(args: Partial<Options> = {}) {
       url: '/api/hydrogen/cli/commands/create/index.md',
       entry: 'commands/create',
       tableColumns: ['Command', 'Description'],
+      hidden: true,
     }),
   ]);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

@mcvinci this addresses you comment here: https://github.com/Shopify/hydrogen/issues/46#issuecomment-963681731

### Additional context

This PR adds `hidden: true` to the CLI docs in order for those markdown files to be generated with the `hidden: true` frontmatter in shopify-dev.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
