### PR TITLE
chore: tell linter to ignore auto-gen types file which is super noisy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@
 const {defineConfig} = require('eslint-define-config');
 
 module.exports = defineConfig({
+  ignorePatterns: ['**/graphql/types/types.ts'],
   root: true,
   plugins: ['eslint-plugin-tsdoc'],
   extends: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Our linter is aggressive with the auto-generated `graphql/types` file, and it's very very noisy in CI.

This PR tells the linter to ignore it.