### PR TITLE
fix: eliminate use of client component re-exports

### DIFF
--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - Wrap instances of `<Money>` in client components due to render prop usage
+- Eliminate use of `Link` client re-exports
 
 ## 0.6.1 - 2021-11-08
 

--- a/packages/dev/src/components/FeaturedCollection.server.jsx
+++ b/packages/dev/src/components/FeaturedCollection.server.jsx
@@ -1,6 +1,4 @@
-import {Image} from '@shopify/hydrogen/client';
-
-import {Link} from './Link.client';
+import {Image, Link} from '@shopify/hydrogen/client';
 
 export default function FeaturedCollection({collection}) {
   return collection ? (

--- a/packages/dev/src/components/Footer.server.jsx
+++ b/packages/dev/src/components/Footer.server.jsx
@@ -1,4 +1,4 @@
-import {Link} from './Link.client';
+import {Link} from '@shopify/hydrogen';
 
 export default function Footer({collection, product}) {
   return (

--- a/packages/dev/src/components/Link.client.jsx
+++ b/packages/dev/src/components/Link.client.jsx
@@ -1,1 +1,0 @@
-export {Link} from '@shopify/hydrogen/client';

--- a/packages/dev/src/components/ProductCard.server.jsx
+++ b/packages/dev/src/components/ProductCard.server.jsx
@@ -1,6 +1,5 @@
-import {Image} from '@shopify/hydrogen';
+import {Image, Link} from '@shopify/hydrogen';
 
-import {Link} from './Link.client';
 import MoneyCompareAtPrice from './MoneyCompareAtPrice.client';
 import MoneyPrice from './MoneyPrice.client';
 

--- a/packages/dev/src/components/Welcome.server.jsx
+++ b/packages/dev/src/components/Welcome.server.jsx
@@ -1,7 +1,5 @@
-import {useShopQuery, flattenConnection} from '@shopify/hydrogen';
+import {useShopQuery, flattenConnection, Link} from '@shopify/hydrogen';
 import gql from 'graphql-tag';
-
-import {Link} from './Link.client';
 
 function ExternalIcon() {
   return (

--- a/packages/dev/src/pages/Index.server.jsx
+++ b/packages/dev/src/pages/Index.server.jsx
@@ -3,10 +3,10 @@ import {
   flattenConnection,
   ProductProviderFragment,
   Image,
+  Link,
 } from '@shopify/hydrogen';
 import gql from 'graphql-tag';
 
-import {Link} from '../components/Link.client';
 import Layout from '../components/Layout.server';
 import FeaturedCollection from '../components/FeaturedCollection.server';
 import ProductCard from '../components/ProductCard.server';

--- a/packages/playground/server-components-worker/src/components/Link.client.jsx
+++ b/packages/playground/server-components-worker/src/components/Link.client.jsx
@@ -1,1 +1,0 @@
-export {Link} from 'react-router-dom';

--- a/packages/playground/server-components-worker/src/pages/index.server.jsx
+++ b/packages/playground/server-components-worker/src/pages/index.server.jsx
@@ -1,4 +1,4 @@
-import {Link} from '../components/Link.client';
+import {Link} from '@shopify/hydrogen';
 
 export default function Index() {
   return (

--- a/packages/playground/server-components/src/components/Link.client.jsx
+++ b/packages/playground/server-components/src/components/Link.client.jsx
@@ -1,1 +1,0 @@
-export {Link} from 'react-router-dom';

--- a/packages/playground/server-components/src/pages/index.server.jsx
+++ b/packages/playground/server-components/src/pages/index.server.jsx
@@ -1,4 +1,4 @@
-import {Link} from '../components/Link.client';
+import {Link} from '@shopify/hydrogen';
 
 export default function Index() {
   return (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since #67 was a thing, developers had to re-export client components from a local client component in their app in order to use a Hydrogen-provided client component, like `Link`.

No more, thanks to #7!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
