### PR TITLE
fix: add trailing slash to user components glob

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix: add trailing slash to user components glob
 
 ## 0.6.2 - 2021-11-10
 

--- a/packages/hydrogen/src/framework/Hydration/client-imports.ts
+++ b/packages/hydrogen/src/framework/Hydration/client-imports.ts
@@ -25,7 +25,7 @@ const allClientComponents = {
   ),
 };
 
-export default function importDevClientComponent(moduleId: string) {
+export default function importClientComponent(moduleId: string) {
   const modImport = allClientComponents[moduleId];
 
   if (!modImport) {

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-react-server-components-shim.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-react-server-components-shim.ts
@@ -79,9 +79,12 @@ export default () => {
 
         const importerToRootPath = path.relative(importerPath, config.root);
         const [importerToRootNested] =
-          importerToRootPath.match(/(\.\.\/)+/) || [];
+          importerToRootPath.match(/(\.\.\/)+(\.\.)?/) || [];
         const userPrefix = path.normalize(
-          path.join(importerPath, importerToRootNested)
+          path.join(
+            importerPath,
+            importerToRootNested.replace(/\/?$/, path.sep)
+          )
         );
         const userGlob = path.join(
           importerToRootPath,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #195 

Wrong import glob for user components in standalone apps (it's missing a trailing slash).

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
