### PR TITLE
fix: new lines in hydration response

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix: new lines in hydration request break JSON.parse
 
 ## 0.6.3 - 2021-11-10
 

--- a/packages/hydrogen/src/framework/Hydration/Cache.client.ts
+++ b/packages/hydrogen/src/framework/Hydration/Cache.client.ts
@@ -136,7 +136,10 @@ function createManifestFromWirePayload(payload: string): WireManifest {
   return payload.split('\n').reduce((memo, row) => {
     const [key, ...values] = row.split(':');
 
-    memo[key] = JSON.parse(values.join(':'));
+    if (key) {
+      memo[key] = JSON.parse(values.join(':'));
+    }
+
     return memo;
   }, {} as Record<string, any>) as WireManifest;
 }

--- a/packages/hydrogen/src/framework/Hydration/__tests__/Cache.spec.tsx
+++ b/packages/hydrogen/src/framework/Hydration/__tests__/Cache.spec.tsx
@@ -13,6 +13,15 @@ it('handles DOM elements', async () => {
   expect(screen.getByText('hello')).toBeInTheDocument();
 });
 
+it('ignores new lines', async () => {
+  const tuples = [['$', 'div', null, {children: 'hello'}]];
+  const payload = `\nJ0:${JSON.stringify(tuples)}\n`;
+
+  render(await convertHydrationResponseToReactComponents(payload));
+
+  expect(screen.getByText('hello')).toBeInTheDocument();
+});
+
 it('handles DOM elements with arrays of children', async () => {
   const tuples = [
     [

--- a/packages/hydrogen/src/framework/Hydration/__tests__/wire.spec.ts
+++ b/packages/hydrogen/src/framework/Hydration/__tests__/wire.spec.ts
@@ -2,7 +2,7 @@ import {generateWireSyntaxFromRenderedHtml} from '../wire.server';
 
 it('renders normal html elements', () => {
   const input = `<div class="foo"><p id="bar">Hello!</p></div>`;
-  const output = `\nJ0:["$","div",null,{"className":"foo","children":["$","p",null,{"id":"bar","children":"Hello!"}]}]`;
+  const output = `J0:["$","div",null,{"className":"foo","children":["$","p",null,{"id":"bar","children":"Hello!"}]}]`;
 
   expect(generateWireSyntaxFromRenderedHtml(input)).toBe(output);
 });
@@ -98,7 +98,7 @@ J0:["$","div",null,{"className":"foo","children":["\\n    ",["$","@1",null,{"sid
 it('renders Client Components with nested props that have multiple children', () => {
   const input = `<div class="foo"><p>Bar</p><div>Baz</div></div>`;
 
-  const output = `\nJ0:["$","div",null,{"className":"foo","children":[["$","p",null,{"key":0,"children":"Bar"}],["$","div",null,{"key":1,"children":"Baz"}]]}]`;
+  const output = `J0:["$","div",null,{"className":"foo","children":[["$","p",null,{"key":0,"children":"Bar"}],["$","div",null,{"key":1,"children":"Baz"}]]}]`;
 
   expect(generateWireSyntaxFromRenderedHtml(input)).toBe(output);
 });

--- a/packages/hydrogen/src/framework/Hydration/wire.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/wire.server.ts
@@ -90,7 +90,7 @@ export function generateWireSyntaxFromRenderedHtml(html: string) {
         return `M${idx + 1}:${JSON.stringify(component)}`;
       })
       .join('\n') + `\nJ0:${JSON.stringify(wireModel)}`
-  );
+  ).trim();
 }
 
 function isDomNode(item: any) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

New lines in the wire/hydration response break in browser when calling `JSON.parse`.

This removes new lines from the server response and also makes the parsing logic in the frontend a bit more resilient in case this happens in the future again.

Closes #179 

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
