### PR TITLE
chore: improve Stackblitz publishing flow

### DIFF
--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Rename gitignore
         run: |
-          mv _gitignore .gitignore
+          mv packages/dev/_gitignore packages/dev/.gitignore
       - name: Push to stackblitz branch
         uses: EndBug/add-and-commit@v7.4.0
         with:

--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
+      - name: Rename gitignore
+        run: |
+          mv _gitignore .gitignore
       - name: Push to stackblitz branch
         uses: EndBug/add-and-commit@v7.4.0
         with:

--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -1,0 +1,18 @@
+name: Publish to Stackblitz
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish latest release to Stackblitz
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Push to stackblitz branch
+        uses: EndBug/add-and-commit@v7.4.0
+        with:
+          push: 'origin stackblitz --force'
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev-lib": "yarn workspace @shopify/hydrogen dev",
-    "dev-server": "VITE_INSPECT=1 yarn workspace dev dev",
+    "dev-server": "LOCAL_DEV=true VITE_INSPECT=1 yarn workspace dev dev",
     "build": "run-s build-lib build-dev build-cli",
     "build-lib": "yarn workspace @shopify/hydrogen build",
     "build-cli": "yarn workspace @shopify/hydrogen-cli build",

--- a/packages/create-hydrogen-app/scripts/tmp-copy-template-from-dev.js
+++ b/packages/create-hydrogen-app/scripts/tmp-copy-template-from-dev.js
@@ -12,7 +12,7 @@ const {copy} = require('./utils');
 
 const devPath = path.resolve(__dirname, '..', '..', 'dev');
 const templatePath = path.resolve(__dirname, '..', './template-hydrogen');
-const skipFiles = ['node_modules', 'dist'];
+const skipFiles = ['node_modules', 'dist', '.stackblitzrc'];
 
 // Remove the symlink and replace it with a folder
 fs.unlinkSync(templatePath);

--- a/packages/dev/.stackblitzrc
+++ b/packages/dev/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run dev"
+}

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "LOCAL_DEV=true vite",
+    "dev": "vite",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx src",
     "lint:css": "stylelint ./src/**/*.{css,sass,scss}",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

RE: #125 

Right now, I have to manually update our Stackblitz template in my personal template at https://hydrogen.new whenever we ship a release. This does not scale.

This PR:

- Runs a GH Action when we create a release. It renames `_gitignore` so it gets picked up properly by stackblitz and force pushes to the `stackblitz` branch
- Moves `LOCAL_DEV` to prefix the `dev-server` script in the root of the monorepo

You can test out this new flow: https://stackblitz.com/fork/github/shopify/hydrogen/tree/stackblitz/packages/dev

### Additional context

The `gitignore` shenanigans are to work around an interesting NPM publish behavior which renames `.gitignore` to `.npmignore` lolol https://github.com/npm/npm/issues/1862

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
