### PR TITLE
fix(#201): normalize POSIX separators to support windows

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix(#201): normalize POSIX separators to support windows
 
 ## 0.6.3 - 2021-11-10
 

--- a/packages/hydrogen/src/framework/plugins/__tests__/__snapshots__/vite-plugin-react-server-components-shim.spec.ts.snap
+++ b/packages/hydrogen/src/framework/plugins/__tests__/__snapshots__/vite-plugin-react-server-components-shim.spec.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transforms client-imports 1`] = `
+"// Transform relative paths to absolute in order
+// to match component IDs from ClientMarker.
+function normalizeComponentPaths(
+  componentObject: Record<string, undefined | (() => any)>,
+  prefix: string
+) {
+  return Object.entries(componentObject).reduce((acc, [key, value]) => {
+    acc[prefix + key.replace(/\\\\.\\\\.\\\\//gm, '')] = value;
+    return acc;
+  }, {} as typeof componentObject);
+}
+
+// These strings are replaced in a plugin with real globs
+// and paths that depend on the user project structure.
+const allClientComponents = {
+  ...normalizeComponentPaths(
+    // @ts-ignore
+    import.meta.glob('../../components/**/*.client.js'),
+    \`@shopify/\`
+  ),
+  ...normalizeComponentPaths(
+    // @ts-ignore
+    import.meta.glob('../../../src/**/*.client.[jt]sx'),
+    \`./\`
+  ),
+};
+
+export default function importClientComponent(moduleId: string) {
+  const modImport = allClientComponents[moduleId];
+
+  if (!modImport) {
+    throw new Error(\`Could not find client component \${moduleId}\`);
+  }
+
+  return modImport();
+}
+"
+`;

--- a/packages/hydrogen/src/framework/plugins/__tests__/vite-plugin-react-server-components-shim.spec.ts
+++ b/packages/hydrogen/src/framework/plugins/__tests__/vite-plugin-react-server-components-shim.spec.ts
@@ -1,0 +1,52 @@
+import middleware from '../vite-plugin-react-server-components-shim';
+import fs from 'fs';
+import path from 'path';
+import {resolve} from '../resolver';
+
+jest.mock('../resolver');
+
+(resolve as any).mockImplementation(() => '@shopify/hydrogen');
+
+let m: any;
+
+beforeEach(() => {
+  m = middleware();
+  m.configResolved({
+    root: '.',
+  });
+});
+
+it('only transforms client-imports', function () {
+  expect(m.transform('', '')).toBe(undefined);
+});
+
+it('transforms client-imports', function () {
+  const code = fs.readFileSync(
+    path.resolve(__dirname, '../../Hydration/client-imports.ts'),
+    'utf8'
+  );
+  const result = m.transform(code, '/Hydration/client-imports');
+
+  expect(result).toMatchSnapshot();
+});
+
+it('throws an error when non-Server components load Server components', async function () {
+  await expect(m.resolveId('.server.tsx', '.client.tsx')).rejects.toThrow();
+
+  await expect(m.resolveId('.server.jsx', '.client.jsx')).rejects.toThrow();
+});
+
+it('passes when server components import client components', async function () {
+  m.resolveId('.client.tsx', '.server.tsx');
+  m.resolveId('.client.jsx', '.server.jsx');
+});
+
+it('throws an error when client components load hydrogen from the server-only entrypoint', async function () {
+  await expect(
+    m.resolveId('@shopify/hydrogen', '.client.tsx')
+  ).rejects.toThrow();
+
+  await expect(
+    m.resolveId('@shopify/hydrogen', '.client.jsx')
+  ).rejects.toThrow();
+});

--- a/packages/hydrogen/src/framework/plugins/resolver.ts
+++ b/packages/hydrogen/src/framework/plugins/resolver.ts
@@ -1,0 +1,3 @@
+export function resolve(path: string) {
+  return require.resolve(path);
+}

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-react-server-components-shim.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-react-server-components-shim.ts
@@ -1,4 +1,5 @@
 import type {Plugin, ResolvedConfig} from 'vite';
+import {normalizePath} from 'vite';
 import path from 'path';
 import {proxyClientComponent} from '../server-components';
 
@@ -77,7 +78,9 @@ export default () => {
         const hydrogenPath = path.dirname(require.resolve('@shopify/hydrogen'));
         const importerPath = path.join(hydrogenPath, 'framework', 'Hydration');
 
-        const importerToRootPath = path.relative(importerPath, config.root);
+        const importerToRootPath = normalizePath(
+          path.relative(importerPath, config.root)
+        );
         const [importerToRootNested] =
           importerToRootPath.match(/(\.\.\/)+(\.\.)?/) || [];
         const userPrefix = path.normalize(
@@ -100,10 +103,10 @@ export default () => {
         );
 
         return code
-          .replace('__USER_COMPONENTS_PREFIX__', userPrefix)
-          .replace('__USER_COMPONENTS_GLOB__', userGlob)
-          .replace('__LIB_COMPONENTS_PREFIX__', libPrefix)
-          .replace('__LIB_COMPONENTS_GLOB__', libGlob);
+          .replace('__USER_COMPONENTS_PREFIX__', normalizePath(userPrefix))
+          .replace('__USER_COMPONENTS_GLOB__', normalizePath(userGlob))
+          .replace('__LIB_COMPONENTS_PREFIX__', normalizePath(libPrefix))
+          .replace('__LIB_COMPONENTS_GLOB__', normalizePath(libGlob));
       }
     },
   } as Plugin;

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-react-server-components-shim.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-react-server-components-shim.ts
@@ -2,6 +2,7 @@ import type {Plugin, ResolvedConfig} from 'vite';
 import {normalizePath} from 'vite';
 import path from 'path';
 import {proxyClientComponent} from '../server-components';
+import {resolve} from './resolver';
 
 export default () => {
   let config: ResolvedConfig;
@@ -75,7 +76,7 @@ export default () => {
        */
       if (id.includes('/Hydration/client-imports')) {
         // eslint-disable-next-line node/no-missing-require
-        const hydrogenPath = path.dirname(require.resolve('@shopify/hydrogen'));
+        const hydrogenPath = path.dirname(resolve('@shopify/hydrogen'));
         const importerPath = path.join(hydrogenPath, 'framework', 'Hydration');
 
         const importerToRootPath = normalizePath(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #201 by normalizing the POSIX separators

### Additional context

Also added some tests to vite-plugin-react-server-components-shim.ts. These validate not only the transformation, but also some of our import rules (no server components from client components).

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
