### PR TITLE
chore: request more repros in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,11 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behaviour:
+
+- Provide a link to a [StackBlitz sandbox](https://hydrogen.new) which reproduces the issue
+- OR: provide a link to a repository that reproduces the issue
+
+If you cannot do one of the above, list steps to reproduce the behaviour below:
 
 1. Go to '...'
 2. Click on '....'


### PR DESCRIPTION
We got StackBlitz. Let's use it to our advantage! 

My bet: 90% of the time when people go to reproduce the bug fix, they will find the true cause of the issue (and sometimes it's not Hydrogen related).