### PR TITLE
fix(dev): fix scroll to top on app first load

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## 0.6.4 - 2021-11-10
+
+- fix: fix scroll to top on app first load
+
 ## 0.6.3 - 2021-11-10
 
 - fix: add trailing slash to user components glob

--- a/packages/hydrogen/src/foundation/Router/ServerStateRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/ServerStateRouter.client.tsx
@@ -9,13 +9,16 @@ import {useServerState} from '../useServerState';
  * server state, which in turn fetches the correct server component.
  */
 export function ServerStateRouter() {
-  const {setServerState, pending} = useServerState() as ServerStateContextValue;
+  const {setServerState, pending, serverState} =
+    useServerState() as ServerStateContextValue;
   const [isNavigating, setIsNavigating] = useState(false);
   const location = useLocation();
 
   useEffect(() => {
-    setIsNavigating(true);
-    setServerState('pathname', location.pathname);
+    if (serverState.pathname !== location.pathname) {
+      setIsNavigating(true);
+      setServerState('pathname', location.pathname);
+    }
   }, [location.pathname, setServerState]);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixes #209 

<!-- Insert your description here and provide info about what issue this PR is solving -->
If a page transition occurs, `ServerStateRouter.client.tsx` triggers scroll to the top event (`scrollTo(0,0)`), this is fine except for one case; when a user scrolls down a then refreshes the page, in this case, the user should be in the same scroll position before refreshing the page as described in #209.

### Additional context
No
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
