### PR TITLE
feat: eslint rule no effects on server

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- New rule `hydrogen/no-effect-in-server-components`. This rule prevents using `useEffect` and `useLayoutEffect` in non-client components.
 
 ## 0.6.2 - 2021-11-10
 

--- a/packages/eslint-plugin/src/configs/hydrogen.ts
+++ b/packages/eslint-plugin/src/configs/hydrogen.ts
@@ -2,6 +2,7 @@ export default {
   plugins: ['hydrogen'],
   rules: {
     'hydrogen/no-state-in-server-components': 'error',
+    'hydrogen/no-effects-in-server-components': 'error',
     'hydrogen/prefer-image-component': 'error',
   },
 };

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,7 +1,9 @@
 import {noStateInServerComponents} from './no-state-in-server-components';
+import {noEffectsInServerComponents} from './no-effects-in-server-components';
 import {preferImageComponent} from './prefer-image-component';
 
 export const rules: {[key: string]: any} = {
+  'no-effects-in-server-components': noEffectsInServerComponents,
   'no-state-in-server-components': noStateInServerComponents,
   'prefer-image-component': preferImageComponent,
 };

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/README.md
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/README.md
@@ -1,6 +1,6 @@
-# Prevents `useState` and `useReducer` in React Server Components (`hydrogen/no-state-in-server-components`)
+# Prevents `useEffect` and `useLayoutEffect` in React Server Components (`hydrogen/no-effects-in-server-components`)
 
-The `useState` and `useReducer` state handling hooks do not function as expected in React Server Components because Server Components execute only once per request on the server.
+The `useEffect` and `useLayoutEffect` lifecycle hooks do not function as expected in React Server Components because Server Components execute only once per request on the server.
 
 ## Rule Details
 

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/README.md
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/README.md
@@ -4,35 +4,33 @@ The `useEffect` and `useLayoutEffect` lifecycle hooks do not function as expecte
 
 ## Rule Details
 
-This rule prevents using these hooks in files that do not end with the `.client` suffix that denotes a React Component that does not run on the server.
-
-Examples of **incorrect** code for this rule:
+This rule prevents using these hooks in files that do not end with the `.client` suffix.
 
 ```tsx
-// MyServerComponent.server.jsx
+// Examples of **incorrect** code for this rule:
 
-function MyServerComponent() {
-  const [state, setState] = useState();
+// MyComponent.jsx or MyComponent.server.jsx
+import {useEffect} from 'react';
+
+function MyNonClientComponent() {
+  useEffect(() => {
+    // code inside this useEffect will not execute as expected
+  });
+
   return null;
 }
 ```
 
 ```tsx
-// MyServerComponent.jsx
+// Examples of **correct** code for this rule:
 
-function MyServerComponent() {
-  const [state, setState] = useState();
-  return null;
-}
-```
-
-Examples of **correct** code for this rule:
-
-```tsx
 // MyClientComponent.client.jsx
+import {useEffect} from 'react';
 
 function MyClientComponent() {
-  const [state, setState] = useState();
+  useEffect(() => {
+    // in client components, this code will execute as expected
+  });
   return null;
 }
 ```

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/docs/details.md
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/docs/details.md
@@ -1,0 +1,3 @@
+## Rule Details
+
+This rule prevents using these hooks in files that do not end with the `.client` suffix that denotes a React Component that does not run on the server.

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/docs/details.md
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/docs/details.md
@@ -1,3 +1,3 @@
 ## Rule Details
 
-This rule prevents using these hooks in files that do not end with the `.client` suffix that denotes a React Component that does not run on the server.
+This rule prevents using these hooks in files that do not end with the `.client` suffix.

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/docs/overview.md
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/docs/overview.md
@@ -1,0 +1,3 @@
+# Prevents `useEffect` and `useLayoutEffect` in React Server Components (`hydrogen/no-effects-in-server-components`)
+
+The `useEffect` and `useLayoutEffect` lifecycle hooks do not function as expected in React Server Components because Server Components execute only once per request on the server.

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/examples/invalid.example.tsx
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/examples/invalid.example.tsx
@@ -1,0 +1,12 @@
+// Examples of **incorrect** code for this rule:
+
+// MyComponent.jsx or MyComponent.server.jsx
+import {useEffect} from 'react';
+
+function MyNonClientComponent() {
+  useEffect(() => {
+    // code inside this useEffect will not execute as expected
+  });
+
+  return null;
+}

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/examples/valid.example.tsx
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/examples/valid.example.tsx
@@ -1,0 +1,11 @@
+// Examples of **correct** code for this rule:
+
+// MyClientComponent.client.jsx
+import {useEffect} from 'react';
+
+function MyClientComponent() {
+  useEffect(() => {
+    // in client components, this code will execute as expected
+  });
+  return null;
+}

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/index.ts
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/index.ts
@@ -1,0 +1,1 @@
+export {noEffectsInServerComponents} from './no-effects-in-server-components';

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/no-effects-in-server-components.ts
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/no-effects-in-server-components.ts
@@ -2,20 +2,20 @@ import {AST_NODE_TYPES} from '@typescript-eslint/types';
 
 import {createRule, isClientComponent} from '../../utilities';
 
-const BANNED_HOOKS = ['useState', 'useReducer'];
+const BANNED_HOOKS = ['useEffect', 'useLayoutEffect'];
 
-export const noStateInServerComponents = createRule({
+export const noEffectsInServerComponents = createRule({
   name: `hydrogen/${__dirname}`,
   meta: {
     type: 'problem',
     docs: {
       description:
-        'Prevents `useState` and `useReducer` in React Server Components',
+        'Prevents `useEffect` and `useLayoutEffect` in React Server Components',
       category: 'Possible Errors',
       recommended: 'error',
     },
     messages: {
-      noStateInServerComponents: `Do not use {{hook}} in React Server Components.`,
+      noEffectsInServerComponents: `Do not use {{hook}} in React Server Components.`,
     },
     schema: [],
   },
@@ -31,7 +31,7 @@ export const noStateInServerComponents = createRule({
           context.report({
             node,
             data: {hook: node.callee.name},
-            messageId: 'noStateInServerComponents',
+            messageId: 'noEffectsInServerComponents',
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/no-effects-in-server-components/tests/no-effects-in-server-components.test.ts
+++ b/packages/eslint-plugin/src/rules/no-effects-in-server-components/tests/no-effects-in-server-components.test.ts
@@ -1,0 +1,124 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {AST_NODE_TYPES} from '@typescript-eslint/types';
+import {noEffectsInServerComponents} from '../no-effects-in-server-components';
+import dedent from 'dedent';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+function error(hookName: string) {
+  return {
+    type: AST_NODE_TYPES.CallExpression,
+    data: {hook: hookName},
+    messageId: 'noEffectsInServerComponents' as 'noEffectsInServerComponents',
+  };
+}
+
+ruleTester.run(
+  'hydrogen/no-effects-in-server-components',
+  noEffectsInServerComponents,
+  {
+    valid: [
+      {
+        code: dedent`
+        function ClientComponent() {
+          useEffect(() => {});
+          return null;
+        }
+      `,
+        filename: 'ClientComponent.client.tsx',
+      },
+      {
+        code: dedent`
+          function ClientComponent() {
+            useLayoutEffect(() => {});
+            return null;
+          }
+        `,
+        filename: 'ClientComponent.client.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            return null;
+          }
+        `,
+        filename: 'ServerComponent.server.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            const {foo} = useBar();
+            return null;
+          }
+        `,
+        filename: 'ServerComponent.server.tsx',
+      },
+    ],
+    invalid: [
+      {
+        code: dedent`
+          function ServerComponent() {
+            useEffect(() => {});
+            return null;
+          }
+        `,
+        errors: [error('useEffect')],
+        filename: 'ServerComponent.server.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useLayoutEffect(() => {});
+            return null;
+          }
+        `,
+        errors: [error('useLayoutEffect')],
+        filename: 'ServerComponent.server.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useEffect(() => {});
+            useLayoutEffect(() => {});
+            return null;
+          }
+        `,
+        errors: [error('useEffect'), error('useLayoutEffect')],
+        filename: 'ServerComponent.server.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useEffect(() => {});
+            return null;
+          }
+        `,
+        errors: [error('useEffect')],
+        filename: 'ServerComponent.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useEffect(() => {});
+            return null;
+          }
+        `,
+        errors: [error('useEffect')],
+        filename: 'ServerComponent.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useLayoutEffect(() => {});
+            useEffect(() => {});
+            return null;
+          }
+        `,
+        errors: [error('useLayoutEffect'), error('useEffect')],
+        filename: 'ServerComponent.tsx',
+      },
+    ],
+  }
+);

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/README.md
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/README.md
@@ -4,7 +4,7 @@ The `useState` and `useReducer` state handling hooks do not function as expected
 
 ## Rule Details
 
-This rule prevents using these hooks in files that do not end with the `.client` suffix that denotes a React Component that does not run on the server.
+This rule prevents using these hooks in files that do not end with the `.client` suffix.
 
 Examples of **incorrect** code for this rule:
 

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/details.md
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/details.md
@@ -1,3 +1,3 @@
 ## Rule Details
 
-This rule prevents using these hooks in files that do not end with the `.client` suffix that denotes a React Component that does not run on the server.
+This rule prevents using these hooks in files that do not end with the `.client` suffix.

--- a/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/overview.md
+++ b/packages/eslint-plugin/src/rules/no-state-in-server-components/docs/overview.md
@@ -1,3 +1,3 @@
 # Prevents `useState` and `useReducer` in React Server Components (`hydrogen/no-state-in-server-components`)
 
-The `useState` and `useReducer` state handling hooks do not function as expected in React Server Components because they execute once per request on the server.
+The `useState` and `useReducer` state handling hooks do not function as expected in React Server Components because Server Components execute only once per request on the server.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a new rule for banning `useEffect` and `useLayoutEffect` in the server. 

### Additional context

I think in the next hooks related rule, we can start to group common utilities as the logic will be similar. Right now there overlap between this rule and the state banning rule, but both are such a minimal amount of code it doesn't bother me yet. Will wait until the [third strike before starting to refactor](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)). 


<img width="807" alt="Screen Shot 2021-11-10 at 01 25 38" src="https://user-images.githubusercontent.com/462077/141276344-b417d92b-1767-4b62-9c38-e5829ca01d2e.png">
<img width="742" alt="Screen Shot 2021-11-10 at 01 27 12" src="https://user-images.githubusercontent.com/462077/141276352-39bcb33d-e9e8-4719-97c9-f664e3d085ae.png">

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
