### PR TITLE
feat: format CLI output with prettier

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,9 @@
     "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
     "inquirer": "^8.1.2",
-    "minimist": "^1.2.5"
+    "minimist": "^1.2.5",
+    "prettier": "^2.4.1",
+    "@shopify/prettier-config": "^1.1.2"
   },
   "devDependencies": {
     "@types/change-case": "^2.3.1",

--- a/packages/cli/src/utilities/format.ts
+++ b/packages/cli/src/utilities/format.ts
@@ -1,0 +1,12 @@
+import prettier from 'prettier';
+
+const PRETTIER_CONFIG = {
+  ...require('@shopify/prettier-config'),
+};
+
+export function formatFile(content: string) {
+  // TODO: Search for local project config with fallback to Shopify
+  const formattedContent = prettier.format(content, PRETTIER_CONFIG);
+
+  return formattedContent;
+}

--- a/packages/cli/src/utilities/index.ts
+++ b/packages/cli/src/utilities/index.ts
@@ -6,6 +6,7 @@ export * from './error';
 export * from './feature';
 export {merge} from './merge';
 export {componentName, validComponentName} from './react';
+export {formatFile} from './format';
 
 const DEFAULT_SUBCOMMANDS = {
   create: 'app',
@@ -26,16 +27,4 @@ export function parseCliArguments(rawInputs?: string[]) {
     mode: debug ? 'debug' : 'default',
     command: [command, subcommand].join('/'),
   };
-}
-
-export function formatFile(file: string) {
-  const match = file.match(/^[^\S\n]*(?=\S)/gm);
-  const indent = match && Math.min(...match.map((el) => el.length));
-
-  if (indent) {
-    const regexp = new RegExp(`^.{${indent}}`, 'gm');
-    return file.replace(regexp, '').trim() + '\n';
-  }
-
-  return file.trim() + '\n';
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR replaces my custom format file utility with `prettier`.

### Additional context

I use this in the docs generator and was surprised that it was fast and worked really well (the existing function does not). 

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
