### PR TITLE
[WIP] Collection-related components

### DIFF
--- a/packages/dev/src/components/CollectionDetails.client.jsx
+++ b/packages/dev/src/components/CollectionDetails.client.jsx
@@ -3,6 +3,7 @@ import {Collection, Product} from '@shopify/hydrogen/client';
 export default function CollectionDetails({collection}) {
   return (
     <Collection collection={collection}>
+      <Collection.Image />
       <Collection.Title className="font-bold text-4xl md:text-5xl text-gray-900 mb-6 mt-6" />
       <Collection.Description className="text-2xl" />
 

--- a/packages/dev/src/components/CollectionDetails.client.jsx
+++ b/packages/dev/src/components/CollectionDetails.client.jsx
@@ -1,0 +1,16 @@
+import {Collection, Product} from '@shopify/hydrogen/client';
+
+export default function CollectionDetails({collection}) {
+  return (
+    <Collection collection={collection}>
+      <Collection.Title className="font-bold text-4xl md:text-5xl text-gray-900 mb-6 mt-6" />
+      <Collection.Description className="text-2xl" />
+
+      <Collection.Products className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
+        <Product.Title />
+        <Product.SelectedVariant.Image />
+        <Product.SelectedVariant.Price />
+      </Collection.Products>
+    </Collection>
+  );
+}

--- a/packages/dev/src/pages/collections/[handle].server.jsx
+++ b/packages/dev/src/pages/collections/[handle].server.jsx
@@ -2,16 +2,13 @@ import {
   MediaFileFragment,
   ProductProviderFragment,
   useShopQuery,
-  flattenConnection,
-  RawHtml,
 } from '@shopify/hydrogen';
 import {useParams} from 'react-router-dom';
 import gql from 'graphql-tag';
 
-import LoadMoreProducts from '../../components/LoadMoreProducts.client';
 import Layout from '../../components/Layout.server';
-import ProductCard from '../../components/ProductCard.server';
 import NotFound from '../../components/NotFound.server';
+import CollectionDetails from '../../components/CollectionDetails.client';
 
 export default function Collection({
   country = {isoCode: 'US'},
@@ -31,31 +28,9 @@ export default function Collection({
     return <NotFound />;
   }
 
-  const collection = data.collection;
-  const products = flattenConnection(collection.products);
-  const hasNextPage = data.collection.products.pageInfo.hasNextPage;
-
   return (
     <Layout>
-      <h1 className="font-bold text-4xl md:text-5xl text-gray-900 mb-6 mt-6">
-        {collection.title}
-      </h1>
-      <RawHtml string={collection.descriptionHtml} className="text-2xl" />
-      <p className="text-sm text-gray-500 mt-5 mb-5">
-        {products.length} {products.length > 1 ? 'products' : 'product'}
-      </p>
-
-      <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
-        {products.map((product) => (
-          <li key={product.id}>
-            <ProductCard product={product} />
-          </li>
-        ))}
-      </ul>
-
-      {hasNextPage && (
-        <LoadMoreProducts startingCount={collectionProductCount} />
-      )}
+      <CollectionDetails collection={data.collection} />
     </Layout>
   );
 }

--- a/packages/dev/src/pages/collections/[handle].server.jsx
+++ b/packages/dev/src/pages/collections/[handle].server.jsx
@@ -1,8 +1,4 @@
-import {
-  MediaFileFragment,
-  ProductProviderFragment,
-  useShopQuery,
-} from '@shopify/hydrogen';
+import {useShopQuery, CollectionProviderFragment} from '@shopify/hydrogen';
 import {useParams} from 'react-router-dom';
 import gql from 'graphql-tag';
 
@@ -15,12 +11,13 @@ export default function Collection({
   collectionProductCount = 24,
 }) {
   const {handle} = useParams();
+  console.log('QUERY', CollectionProviderFragment);
   const {data} = useShopQuery({
     query: QUERY,
     variables: {
       handle,
       country: country.isoCode,
-      numProducts: collectionProductCount,
+      numCollectionProducts: collectionProductCount,
     },
   });
 
@@ -39,7 +36,7 @@ const QUERY = gql`
   query CollectionDetails(
     $handle: String!
     $country: CountryCode
-    $numProducts: Int!
+    $numCollectionProducts: Int!
     $numProductMetafields: Int = 0
     $numProductVariants: Int = 250
     $numProductMedia: Int = 6
@@ -49,24 +46,9 @@ const QUERY = gql`
     $numProductSellingPlans: Int = 0
   ) @inContext(country: $country) {
     collection(handle: $handle) {
-      id
-      title
-      descriptionHtml
-
-      products(first: $numProducts) {
-        edges {
-          node {
-            vendor
-            ...ProductProviderFragment
-          }
-        }
-        pageInfo {
-          hasNextPage
-        }
-      }
+      ...CollectionProviderFragment
     }
   }
 
-  ${MediaFileFragment}
-  ${ProductProviderFragment}
+  ${CollectionProviderFragment}
 `;

--- a/packages/hydrogen/src/components/CollectionDescription/CollectionDescription.client.tsx
+++ b/packages/hydrogen/src/components/CollectionDescription/CollectionDescription.client.tsx
@@ -1,0 +1,23 @@
+import React, {ElementType} from 'react';
+import {RawHtml} from '../RawHtml';
+import {Props} from '../types';
+import {useCollection} from '../../hooks';
+
+/**
+ * The `CollectionDescription` component renders a `RawHtml` component with
+ * the collection's [`descriptionHtml`](/api/storefront/reference/products/collection).
+ * It must be a descendent of the `CollectionProvider` component.
+ */
+export function CollectionDescription<TTag extends ElementType = 'div'>(
+  props: Props<TTag>
+) {
+  const collection = useCollection();
+
+  if (collection == null) {
+    throw new Error('Expected a ProductProvider context, but none was found');
+  }
+
+  return collection.descriptionHtml ? (
+    <RawHtml string={collection.descriptionHtml} {...props} />
+  ) : null;
+}

--- a/packages/hydrogen/src/components/CollectionDescription/index.ts
+++ b/packages/hydrogen/src/components/CollectionDescription/index.ts
@@ -1,0 +1,1 @@
+export {CollectionDescription} from './CollectionDescription.client';

--- a/packages/hydrogen/src/components/CollectionImage/CollectionImage.client.tsx
+++ b/packages/hydrogen/src/components/CollectionImage/CollectionImage.client.tsx
@@ -1,0 +1,24 @@
+import React, {ElementType} from 'react';
+import {Image, ImagePropsWeControl} from '../Image';
+import {Props} from '../types';
+import {useCollection} from '../../hooks';
+import {ImageSizeOptions} from '../../utilities';
+
+/**
+ * The `CollectionImage` component renders a `Image` component with
+ * the collection's [`image`](/api/storefront/reference/products/collection).
+ * It must be a descendent of the `CollectionProvider` component.
+ */
+export function CollectionImage<TTag extends ElementType = 'img'>(
+  props: Props<TTag, ImagePropsWeControl> & {options?: ImageSizeOptions}
+) {
+  const collection = useCollection();
+
+  if (collection == null) {
+    throw new Error('Expected a ProductProvider context, but none was found');
+  }
+
+  return collection.image ? (
+    <Image image={collection.image as any} {...props} />
+  ) : null;
+}

--- a/packages/hydrogen/src/components/CollectionImage/index.ts
+++ b/packages/hydrogen/src/components/CollectionImage/index.ts
@@ -1,0 +1,1 @@
+export {CollectionImage} from './CollectionImage.client';

--- a/packages/hydrogen/src/components/CollectionProducts/CollectionProducts.client.tsx
+++ b/packages/hydrogen/src/components/CollectionProducts/CollectionProducts.client.tsx
@@ -9,7 +9,7 @@ export interface CollectionProductsProps {
    */
   as?: 'ul';
   /** A `ReactNode` element or a function that takes a product as an argument and returns a `ReactNode`. */
-  children: ReactNode | ((line: Cart['lines'][1]) => ReactNode);
+  children: ReactNode | ((product: any) => ReactNode);
 }
 
 /**

--- a/packages/hydrogen/src/components/CollectionProducts/CollectionProducts.client.tsx
+++ b/packages/hydrogen/src/components/CollectionProducts/CollectionProducts.client.tsx
@@ -1,0 +1,32 @@
+import React, {ReactNode} from 'react';
+import {useCollection} from '../../hooks';
+import {ProductProvider} from '../ProductProvider';
+
+export function CollectionProducts({children}: {children: ReactNode}) {
+  const collection = useCollection();
+
+  if (collection == null) {
+    throw new Error('Expected a ProductProvider context, but none was found');
+  }
+
+  if (collection.products == null) {
+    return null;
+  }
+
+  return (
+    <>
+      {collection.products.map((product) => {
+        const initialVariant = product.variants.edges[0].node;
+        return (
+          <ProductProvider
+            key={product.id}
+            product={product}
+            initialVariantId={initialVariant.id}
+          >
+            {children}
+          </ProductProvider>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/hydrogen/src/components/CollectionProducts/CollectionProducts.client.tsx
+++ b/packages/hydrogen/src/components/CollectionProducts/CollectionProducts.client.tsx
@@ -1,32 +1,53 @@
-import React, {ReactNode} from 'react';
+import React, {ElementType, ReactNode, Fragment, cloneElement} from 'react';
 import {useCollection} from '../../hooks';
 import {ProductProvider} from '../ProductProvider';
+import {Props} from '../types';
 
-export function CollectionProducts({children}: {children: ReactNode}) {
+export interface CollectionProductsProps {
+  /** A `ReactNode` element. Valid values: `ul` or `undefined`. If `ul`, then each child will
+   * be wrapped with a `li` element.
+   */
+  as?: 'ul';
+  /** A `ReactNode` element or a function that takes a product as an argument and returns a `ReactNode`. */
+  children: ReactNode | ((line: Cart['lines'][1]) => ReactNode);
+}
+
+/**
+ * The `CollectionProducts` component iterates over each product in a collecton and renders its `children` within
+ * a `ProductProvider` for each product. It also provides render props in the case where `children` is a function.
+ */
+export function CollectionProducts<TTag extends ElementType>(
+  props: Props<TTag> & CollectionProductsProps
+) {
   const collection = useCollection();
 
   if (collection == null) {
-    throw new Error('Expected a ProductProvider context, but none was found');
+    throw new Error(
+      'Expected a CollectionProvider context, but none was found'
+    );
   }
 
-  if (collection.products == null) {
-    return null;
-  }
+  const {as, children, ...passthroughProps} = props;
+
+  const Wrapper = as ? as : 'ul';
+  const ChildWrapper = Wrapper === 'ul' ? 'li' : Fragment;
 
   return (
-    <>
-      {collection.products.map((product) => {
-        const initialVariant = product.variants.edges[0].node;
+    <Wrapper {...passthroughProps}>
+      {(collection.products ?? []).map((product) => {
         return (
-          <ProductProvider
-            key={product.id}
-            product={product}
-            initialVariantId={initialVariant.id}
-          >
-            {children}
-          </ProductProvider>
+          <ChildWrapper key={product.id}>
+            <ProductProvider
+              product={product}
+              initialVariantId={product.variants.edges[0].node.id}
+            >
+              {typeof children === 'function'
+                ? cloneElement(children(product))
+                : children}
+            </ProductProvider>
+          </ChildWrapper>
         );
       })}
-    </>
+    </Wrapper>
   );
 }

--- a/packages/hydrogen/src/components/CollectionProducts/index.ts
+++ b/packages/hydrogen/src/components/CollectionProducts/index.ts
@@ -1,0 +1,1 @@
+export {CollectionProducts} from './CollectionProducts.client';

--- a/packages/hydrogen/src/components/CollectionProvider/CollectionFragment.graphql
+++ b/packages/hydrogen/src/components/CollectionProvider/CollectionFragment.graphql
@@ -1,0 +1,19 @@
+#import '../Image/ImageFragment.graphql'
+#import '../ProductProvider/ProductProviderFragment.graphql'
+
+fragment CollectionFragment on Collection {
+  descriptionHtml
+  handle
+  id
+  image {
+    ...ImageFragment
+  }
+  title
+  products(first: 10) {
+    edges {
+      node {
+        ...ProductProviderFragment
+      }
+    }
+  }
+}

--- a/packages/hydrogen/src/components/CollectionProvider/CollectionFragment.ts
+++ b/packages/hydrogen/src/components/CollectionProvider/CollectionFragment.ts
@@ -1,0 +1,17 @@
+import * as Types from '../../graphql/types/types';
+
+import {ImageFragmentFragment} from '../Image/ImageFragment';
+import {ProductProviderFragmentFragment} from '../ProductProvider/ProductProviderFragment';
+export type CollectionFragmentFragment = {__typename?: 'Collection'} & Pick<
+  Types.Collection,
+  'descriptionHtml' | 'handle' | 'id' | 'title'
+> & {
+    image?: Types.Maybe<{__typename?: 'Image'} & ImageFragmentFragment>;
+    products: {__typename?: 'ProductConnection'} & {
+      edges: Array<
+        {__typename?: 'ProductEdge'} & {
+          node: {__typename?: 'Product'} & ProductProviderFragmentFragment;
+        }
+      >;
+    };
+  };

--- a/packages/hydrogen/src/components/CollectionProvider/CollectionProvider.client.tsx
+++ b/packages/hydrogen/src/components/CollectionProvider/CollectionProvider.client.tsx
@@ -1,19 +1,23 @@
 import React, {ReactNode, useMemo} from 'react';
 import {flattenConnection} from '../..';
-import {CollectionFragmentFragment} from './CollectionFragment';
+import {CollectionProviderFragmentFragment} from './CollectionProviderFragment';
 import {CollectionContext} from './context';
+import {CollectionProviderFragment as Fragment} from '../../graphql/graphql-constants';
 
 export function CollectionProvider({
   collection,
   children,
 }: {
-  collection: CollectionFragmentFragment;
+  collection: CollectionProviderFragmentFragment;
   children: ReactNode;
 }) {
   const value = useMemo(() => {
+    const products = flattenConnection(collection.products);
     return {
       ...collection,
-      products: flattenConnection(collection.products),
+      products,
+      productCount: products.length,
+      hasNextPage: collection.products.pageInfo.hasNextPage,
     };
   }, [collection]);
 
@@ -23,3 +27,6 @@ export function CollectionProvider({
     </CollectionContext.Provider>
   );
 }
+
+CollectionProvider.Fragment = Fragment;
+export const CollectionProviderFragment = Fragment;

--- a/packages/hydrogen/src/components/CollectionProvider/CollectionProvider.client.tsx
+++ b/packages/hydrogen/src/components/CollectionProvider/CollectionProvider.client.tsx
@@ -1,0 +1,25 @@
+import React, {ReactNode, useMemo} from 'react';
+import {flattenConnection} from '../..';
+import {CollectionFragmentFragment} from './CollectionFragment';
+import {CollectionContext} from './context';
+
+export function CollectionProvider({
+  collection,
+  children,
+}: {
+  collection: CollectionFragmentFragment;
+  children: ReactNode;
+}) {
+  const value = useMemo(() => {
+    return {
+      ...collection,
+      products: flattenConnection(collection.products),
+    };
+  }, [collection]);
+
+  return (
+    <CollectionContext.Provider value={value}>
+      {children}
+    </CollectionContext.Provider>
+  );
+}

--- a/packages/hydrogen/src/components/CollectionProvider/CollectionProviderFragment.graphql
+++ b/packages/hydrogen/src/components/CollectionProvider/CollectionProviderFragment.graphql
@@ -1,7 +1,7 @@
 #import '../Image/ImageFragment.graphql'
 #import '../ProductProvider/ProductProviderFragment.graphql'
 
-fragment CollectionFragment on Collection {
+fragment CollectionProviderFragment on Collection {
   descriptionHtml
   handle
   id
@@ -9,11 +9,14 @@ fragment CollectionFragment on Collection {
     ...ImageFragment
   }
   title
-  products(first: 10) {
+  products(first: $numCollectionProducts) {
     edges {
       node {
         ...ProductProviderFragment
       }
+    }
+    pageInfo {
+      hasNextPage
     }
   }
 }

--- a/packages/hydrogen/src/components/CollectionProvider/CollectionProviderFragment.ts
+++ b/packages/hydrogen/src/components/CollectionProvider/CollectionProviderFragment.ts
@@ -2,10 +2,9 @@ import * as Types from '../../graphql/types/types';
 
 import {ImageFragmentFragment} from '../Image/ImageFragment';
 import {ProductProviderFragmentFragment} from '../ProductProvider/ProductProviderFragment';
-export type CollectionFragmentFragment = {__typename?: 'Collection'} & Pick<
-  Types.Collection,
-  'descriptionHtml' | 'handle' | 'id' | 'title'
-> & {
+export type CollectionProviderFragmentFragment = {
+  __typename?: 'Collection';
+} & Pick<Types.Collection, 'descriptionHtml' | 'handle' | 'id' | 'title'> & {
     image?: Types.Maybe<{__typename?: 'Image'} & ImageFragmentFragment>;
     products: {__typename?: 'ProductConnection'} & {
       edges: Array<
@@ -13,5 +12,6 @@ export type CollectionFragmentFragment = {__typename?: 'Collection'} & Pick<
           node: {__typename?: 'Product'} & ProductProviderFragmentFragment;
         }
       >;
+      pageInfo: {__typename?: 'PageInfo'} & Pick<Types.PageInfo, 'hasNextPage'>;
     };
   };

--- a/packages/hydrogen/src/components/CollectionProvider/context.ts
+++ b/packages/hydrogen/src/components/CollectionProvider/context.ts
@@ -1,0 +1,13 @@
+import {createContext} from 'react';
+import {CollectionFragmentFragment} from './CollectionFragment';
+
+type CollectionContextType = Omit<
+  Partial<CollectionFragmentFragment>,
+  'products'
+> & {
+  products?: CollectionFragmentFragment['products']['edges'][0]['node'][];
+};
+
+export const CollectionContext = createContext<CollectionContextType | null>(
+  null
+);

--- a/packages/hydrogen/src/components/CollectionProvider/context.ts
+++ b/packages/hydrogen/src/components/CollectionProvider/context.ts
@@ -1,11 +1,12 @@
 import {createContext} from 'react';
-import {CollectionFragmentFragment} from './CollectionFragment';
+import {CollectionProviderFragmentFragment} from './CollectionProviderFragment';
 
 type CollectionContextType = Omit<
-  Partial<CollectionFragmentFragment>,
+  Partial<CollectionProviderFragmentFragment>,
   'products'
 > & {
-  products?: CollectionFragmentFragment['products']['edges'][0]['node'][];
+  products?: CollectionProviderFragmentFragment['products']['edges'][0]['node'][];
+  hasNextPage?: boolean;
 };
 
 export const CollectionContext = createContext<CollectionContextType | null>(

--- a/packages/hydrogen/src/components/CollectionProvider/index.ts
+++ b/packages/hydrogen/src/components/CollectionProvider/index.ts
@@ -1,0 +1,2 @@
+export {CollectionProvider} from './CollectionProvider.client';
+export {CollectionContext} from './context';

--- a/packages/hydrogen/src/components/CollectionProvider/index.ts
+++ b/packages/hydrogen/src/components/CollectionProvider/index.ts
@@ -1,2 +1,5 @@
-export {CollectionProvider} from './CollectionProvider.client';
+export {
+  CollectionProvider,
+  CollectionProviderFragment,
+} from './CollectionProvider.client';
 export {CollectionContext} from './context';

--- a/packages/hydrogen/src/components/CollectionTitle/CollectionTitle.client.tsx
+++ b/packages/hydrogen/src/components/CollectionTitle/CollectionTitle.client.tsx
@@ -1,0 +1,26 @@
+import React, {ElementType} from 'react';
+import {useCollection} from '../../hooks';
+import {Props} from '../types';
+
+export function CollectionTitle<TTag extends ElementType = 'span'>(
+  /** The `as` prop is an HTML element to wrap the title. If not specified, then the
+   * title is wrapped in a `span` element.
+   */
+  props: Props<TTag>
+) {
+  const collection = useCollection();
+
+  if (collection == null) {
+    throw new Error(
+      'Expected a CollectionProvider context, but none was found'
+    );
+  }
+
+  const {as, ...passthroughProps} = props;
+
+  const Wrapper = as ? as : 'span';
+
+  return collection.title ? (
+    <Wrapper {...passthroughProps}>{collection.title}</Wrapper>
+  ) : null;
+}

--- a/packages/hydrogen/src/components/CollectionTitle/index.ts
+++ b/packages/hydrogen/src/components/CollectionTitle/index.ts
@@ -1,0 +1,1 @@
+export {CollectionTitle} from './CollectionTitle.client';

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -40,7 +40,7 @@ export interface ExternalImageProps extends BaseImageProps {
 
 export type ImageProps = MediaImageProps | ExternalImageProps;
 
-type PropsWeControl = 'src' | 'width' | 'height';
+export type PropsWeControl = 'src' | 'width' | 'height';
 
 function convertShopifyImageData({
   image,

--- a/packages/hydrogen/src/components/Image/index.ts
+++ b/packages/hydrogen/src/components/Image/index.ts
@@ -1,1 +1,7 @@
-export {Image, ImageProps, ImageFragment, MediaImageProps} from './Image';
+export {
+  Image,
+  ImageProps,
+  ImageFragment,
+  MediaImageProps,
+  PropsWeControl as ImagePropsWeControl,
+} from './Image';

--- a/packages/hydrogen/src/components/SelectedVariantImage/SelectedVariantImage.client.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantImage/SelectedVariantImage.client.tsx
@@ -1,7 +1,7 @@
 import React, {ElementType} from 'react';
 import {useProduct} from '../ProductProvider';
 import {Props} from '../types';
-import {Image} from '../Image';
+import {Image, ImagePropsWeControl} from '../Image';
 import {ImageSizeOptions} from '../../utilities';
 
 /**
@@ -9,7 +9,7 @@ import {ImageSizeOptions} from '../../utilities';
  * It must be a descendent of a `ProductProvider` component.
  */
 export function SelectedVariantImage<TTag extends ElementType = 'img'>(
-  props: Props<TTag> & {options?: ImageSizeOptions}
+  props: Props<TTag, ImagePropsWeControl> & {options?: ImageSizeOptions}
 ) {
   const product = useProduct();
 

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -126,3 +126,8 @@ CartLine.Quantity = CartLineQuantity;
 CartLine.QuantityAdjustButton = CartLineQuantityAdjustButton;
 CartLine.SelectedOptions = CartLineSelectedOptions;
 CartLine.Attributes = CartLineAttributes;
+
+export {CollectionProvider, CollectionContext} from './CollectionProvider';
+export {CollectionTitle} from './CollectionTitle';
+export {CollectionDescription} from './CollectionDescription';
+export {CollectionProducts} from './CollectionProducts';

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -127,17 +127,24 @@ CartLine.QuantityAdjustButton = CartLineQuantityAdjustButton;
 CartLine.SelectedOptions = CartLineSelectedOptions;
 CartLine.Attributes = CartLineAttributes;
 
-export {CollectionProvider, CollectionContext} from './CollectionProvider';
+export {
+  CollectionProvider,
+  CollectionContext,
+  CollectionProviderFragment,
+} from './CollectionProvider';
 export {CollectionTitle} from './CollectionTitle';
 export {CollectionDescription} from './CollectionDescription';
 export {CollectionProducts} from './CollectionProducts';
+export {CollectionImage} from './CollectionImage';
 
 import {CollectionProvider} from './CollectionProvider';
 import {CollectionTitle} from './CollectionTitle';
 import {CollectionDescription} from './CollectionDescription';
 import {CollectionProducts} from './CollectionProducts';
+import {CollectionImage} from './CollectionImage';
 
 export const Collection: Function & Record<string, any> = CollectionProvider;
 Collection.Title = CollectionTitle;
 Collection.Description = CollectionDescription;
 Collection.Products = CollectionProducts;
+Collection.Image = CollectionImage;

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -131,3 +131,13 @@ export {CollectionProvider, CollectionContext} from './CollectionProvider';
 export {CollectionTitle} from './CollectionTitle';
 export {CollectionDescription} from './CollectionDescription';
 export {CollectionProducts} from './CollectionProducts';
+
+import {CollectionProvider} from './CollectionProvider';
+import {CollectionTitle} from './CollectionTitle';
+import {CollectionDescription} from './CollectionDescription';
+import {CollectionProducts} from './CollectionProducts';
+
+export const Collection: Function & Record<string, any> = CollectionProvider;
+Collection.Title = CollectionTitle;
+Collection.Description = CollectionDescription;
+Collection.Products = CollectionProducts;

--- a/packages/hydrogen/src/graphql/graphql-constants.ts
+++ b/packages/hydrogen/src/graphql/graphql-constants.ts
@@ -1977,6 +1977,635 @@ fragment ImageFragment on Image {
 `;
 
 /**
+ *```
+ *
+ * fragment CollectionFragment on Collection {
+ *   descriptionHtml
+ *   handle
+ *   id
+ *   image {
+ *     ...ImageFragment
+ *   }
+ *   title
+ *   products(first: 10) {
+ *     edges {
+ *       node {
+ *         ...ProductProviderFragment
+ *       }
+ *     }
+ *   }
+ * }
+ * fragment ImageFragment on Image {
+ *   id
+ *   url
+ *   altText
+ *   width
+ *   height
+ * }
+ *
+ *
+ * fragment ProductProviderFragment on Product  {
+ *   compareAtPriceRange {
+ *     maxVariantPrice {
+ *       ...MoneyFragment
+ *     }
+ *     minVariantPrice {
+ *       ...MoneyFragment
+ *     }
+ *   }
+ *   descriptionHtml
+ *   handle
+ *   id
+ *   media(first: $numProductMedia) {
+ *     edges {
+ *       node {
+ *         ...MediaFileFragment
+ *       }
+ *     }
+ *   }
+ *   metafields(first: $numProductMetafields) {
+ *     edges {
+ *       node {
+ *         ...MetafieldFragment
+ *       }
+ *     }
+ *   }
+ *   priceRange {
+ *     maxVariantPrice {
+ *       ...MoneyFragment
+ *     }
+ *     minVariantPrice {
+ *       ...MoneyFragment
+ *     }
+ *   }
+ *   title
+ *   variants(first: $numProductVariants) {
+ *     edges {
+ *       node {
+ *         ...VariantFragment
+ *       }
+ *     }
+ *   }
+ *   sellingPlanGroups(first: $numProductSellingPlanGroups) {
+ *     edges {
+ *       node {
+ *         ...SellingPlanGroupsFragment
+ *       }
+ *     }
+ *   }
+ * }
+ *
+ *
+ * fragment MediaFileFragment on Media {
+ *   ... on MediaImage {
+ *     mediaContentType
+ *     image {
+ *       ...ImageFragment
+ *     }
+ *   }
+ *   ... on Video {
+ *     mediaContentType
+ *     ...VideoFragment
+ *   }
+ *   ... on ExternalVideo {
+ *     mediaContentType
+ *     ...ExternalVideoFragment
+ *   }
+ *   ... on Model3d {
+ *     mediaContentType
+ *     ...Model3DFragment
+ *   }
+ * }
+ *
+ * fragment MetafieldFragment on Metafield {
+ *   id
+ *   type
+ *   namespace
+ *   key
+ *   value
+ *   createdAt
+ *   updatedAt
+ *   description
+ * }
+ *
+ * fragment VariantFragment on ProductVariant {
+ *   id
+ *   title
+ *   availableForSale
+ *   image {
+ *     ...ImageFragment
+ *   }
+ *   ...UnitPriceFragment
+ *   priceV2 {
+ *     ...MoneyFragment
+ *   }
+ *   compareAtPriceV2 {
+ *     ...MoneyFragment
+ *   }
+ *   selectedOptions {
+ *     name
+ *     value
+ *   }
+ *   metafields(first: $numProductVariantMetafields) {
+ *     edges {
+ *       node {
+ *         ...MetafieldFragment
+ *       }
+ *     }
+ *   }
+ *   sellingPlanAllocations(first: $numProductVariantSellingPlanAllocations) {
+ *     edges {
+ *       node {
+ *         priceAdjustments {
+ *           compareAtPrice {
+ *             ...MoneyFragment
+ *           }
+ *           perDeliveryPrice {
+ *             ...MoneyFragment
+ *           }
+ *           price {
+ *             ...MoneyFragment
+ *           }
+ *           unitPrice {
+ *             ...MoneyFragment
+ *           }
+ *         }
+ *         sellingPlan {
+ *           ...SellingPlanFragment
+ *         }
+ *       }
+ *     }
+ *   }
+ * }
+ *
+ *
+ * fragment SellingPlanGroupsFragment on SellingPlanGroup {
+ *   sellingPlans(first:$numProductSellingPlans) {
+ *     edges {
+ *       node {
+ *         ...SellingPlanFragment
+ *       }
+ *     }
+ *   }
+ *   appName
+ *   name
+ *   options {
+ *     name
+ *     values
+ *   }
+ * }
+ * fragment MoneyFragment on MoneyV2 {
+ *   currencyCode
+ *   amount
+ * }
+ * fragment ImageFragment on Image {
+ *   id
+ *   url
+ *   altText
+ *   width
+ *   height
+ * }
+ *
+ * fragment VideoFragment on Video {
+ *   id
+ *   previewImage {
+ *     url
+ *   }
+ *   sources {
+ *     mimeType
+ *     url
+ *   }
+ * }
+ *
+ * fragment ExternalVideoFragment on ExternalVideo {
+ *   id
+ *   embeddedUrl
+ *   host
+ * }
+ *
+ * fragment Model3DFragment on Model3d {
+ *   id
+ *   alt
+ *   mediaContentType
+ *   previewImage {
+ *     url
+ *   }
+ *   sources {
+ *     url
+ *   }
+ * }
+ *
+ *
+ * fragment SellingPlanFragment on SellingPlan {
+ *   id
+ *   description
+ *   name
+ *   options {
+ *     name
+ *     value
+ *   }
+ *   priceAdjustments {
+ *     orderCount
+ *     adjustmentValue {
+ *       ...on SellingPlanFixedAmountPriceAdjustment {
+ *         adjustmentAmount {
+ *           ...MoneyFragment
+ *         }
+ *       }
+ *       ...on SellingPlanFixedPriceAdjustment {
+ *         price {
+ *           ...MoneyFragment
+ *         }
+ *       }
+ *       ...on SellingPlanPercentagePriceAdjustment {
+ *         adjustmentPercentage
+ *       }
+ *     }
+ *   }
+ *   recurringDeliveries
+ * }
+ * fragment MoneyFragment on MoneyV2 {
+ *   currencyCode
+ *   amount
+ * }
+ * fragment ImageFragment on Image {
+ *   id
+ *   url
+ *   altText
+ *   width
+ *   height
+ * }
+ *
+ *
+ * fragment UnitPriceFragment on ProductVariant {
+ *   unitPriceMeasurement {
+ *     measuredType
+ *     quantityUnit
+ *     quantityValue
+ *     referenceUnit
+ *     referenceValue
+ *   }
+ *   unitPrice {
+ *     ...MoneyFragment
+ *   }
+ * }
+ * fragment MoneyFragment on MoneyV2 {
+ *   currencyCode
+ *   amount
+ * }
+ * fragment MoneyFragment on MoneyV2 {
+ *   currencyCode
+ *   amount
+ * }
+ *
+ * fragment SellingPlanFragment on SellingPlan {
+ *   id
+ *   description
+ *   name
+ *   options {
+ *     name
+ *     value
+ *   }
+ *   priceAdjustments {
+ *     orderCount
+ *     adjustmentValue {
+ *       ...on SellingPlanFixedAmountPriceAdjustment {
+ *         adjustmentAmount {
+ *           ...MoneyFragment
+ *         }
+ *       }
+ *       ...on SellingPlanFixedPriceAdjustment {
+ *         price {
+ *           ...MoneyFragment
+ *         }
+ *       }
+ *       ...on SellingPlanPercentagePriceAdjustment {
+ *         adjustmentPercentage
+ *       }
+ *     }
+ *   }
+ *   recurringDeliveries
+ * }
+ * fragment MoneyFragment on MoneyV2 {
+ *   currencyCode
+ *   amount
+ * }
+ *```
+ */
+export const CollectionFragment: string = `
+fragment CollectionFragment on Collection {
+  descriptionHtml
+  handle
+  id
+  image {
+    ...ImageFragment
+  }
+  title
+  products(first: 10) {
+    edges {
+      node {
+        ...ProductProviderFragment
+      }
+    }
+  }
+}
+fragment ImageFragment on Image {
+  id
+  url
+  altText
+  width
+  height
+}
+
+
+fragment ProductProviderFragment on Product  {
+  compareAtPriceRange {
+    maxVariantPrice {
+      ...MoneyFragment
+    }
+    minVariantPrice {
+      ...MoneyFragment
+    }
+  }
+  descriptionHtml
+  handle
+  id
+  media(first: $numProductMedia) {
+    edges {
+      node {
+        ...MediaFileFragment
+      }
+    }
+  }
+  metafields(first: $numProductMetafields) {
+    edges {
+      node {
+        ...MetafieldFragment
+      }
+    }
+  }
+  priceRange {
+    maxVariantPrice {
+      ...MoneyFragment
+    }
+    minVariantPrice {
+      ...MoneyFragment
+    }
+  }
+  title
+  variants(first: $numProductVariants) {
+    edges {
+      node {
+        ...VariantFragment
+      }
+    }
+  }
+  sellingPlanGroups(first: $numProductSellingPlanGroups) {
+    edges {
+      node {
+        ...SellingPlanGroupsFragment
+      }
+    }
+  }
+}
+
+
+fragment MediaFileFragment on Media {
+  ... on MediaImage {
+    mediaContentType
+    image {
+      ...ImageFragment
+    }
+  }
+  ... on Video {
+    mediaContentType
+    ...VideoFragment
+  }
+  ... on ExternalVideo {
+    mediaContentType
+    ...ExternalVideoFragment
+  }
+  ... on Model3d {
+    mediaContentType
+    ...Model3DFragment
+  }
+}
+
+fragment MetafieldFragment on Metafield {
+  id
+  type
+  namespace
+  key
+  value
+  createdAt
+  updatedAt
+  description
+}
+
+fragment VariantFragment on ProductVariant {
+  id
+  title
+  availableForSale
+  image {
+    ...ImageFragment
+  }
+  ...UnitPriceFragment
+  priceV2 {
+    ...MoneyFragment
+  }
+  compareAtPriceV2 {
+    ...MoneyFragment
+  }
+  selectedOptions {
+    name
+    value
+  }
+  metafields(first: $numProductVariantMetafields) {
+    edges {
+      node {
+        ...MetafieldFragment
+      }
+    }
+  }
+  sellingPlanAllocations(first: $numProductVariantSellingPlanAllocations) {
+    edges {
+      node {
+        priceAdjustments {
+          compareAtPrice {
+            ...MoneyFragment
+          }
+          perDeliveryPrice {
+            ...MoneyFragment
+          }
+          price {
+            ...MoneyFragment
+          }
+          unitPrice {
+            ...MoneyFragment
+          }
+        }
+        sellingPlan {
+          ...SellingPlanFragment
+        }
+      }
+    }
+  }
+}
+
+
+fragment SellingPlanGroupsFragment on SellingPlanGroup {
+  sellingPlans(first:$numProductSellingPlans) {
+    edges {
+      node {
+        ...SellingPlanFragment
+      }
+    }
+  }
+  appName
+  name
+  options {
+    name
+    values
+  }
+}
+fragment MoneyFragment on MoneyV2 {
+  currencyCode
+  amount
+}
+fragment ImageFragment on Image {
+  id
+  url
+  altText
+  width
+  height
+}
+
+fragment VideoFragment on Video {
+  id
+  previewImage {
+    url
+  }
+  sources {
+    mimeType
+    url
+  }
+}
+
+fragment ExternalVideoFragment on ExternalVideo {
+  id
+  embeddedUrl
+  host
+}
+
+fragment Model3DFragment on Model3d {
+  id
+  alt
+  mediaContentType
+  previewImage {
+    url
+  }
+  sources {
+    url
+  }
+}
+
+
+fragment SellingPlanFragment on SellingPlan {
+  id
+  description
+  name
+  options {
+    name
+    value
+  }
+  priceAdjustments {
+    orderCount
+    adjustmentValue {
+      ...on SellingPlanFixedAmountPriceAdjustment {
+        adjustmentAmount {
+          ...MoneyFragment
+        }
+      }
+      ...on SellingPlanFixedPriceAdjustment {
+        price {
+          ...MoneyFragment
+        }
+      }
+      ...on SellingPlanPercentagePriceAdjustment {
+        adjustmentPercentage
+      }
+    }
+  }
+  recurringDeliveries
+}
+fragment MoneyFragment on MoneyV2 {
+  currencyCode
+  amount
+}
+fragment ImageFragment on Image {
+  id
+  url
+  altText
+  width
+  height
+}
+
+
+fragment UnitPriceFragment on ProductVariant {
+  unitPriceMeasurement {
+    measuredType
+    quantityUnit
+    quantityValue
+    referenceUnit
+    referenceValue
+  }
+  unitPrice {
+    ...MoneyFragment
+  }
+}
+fragment MoneyFragment on MoneyV2 {
+  currencyCode
+  amount
+}
+fragment MoneyFragment on MoneyV2 {
+  currencyCode
+  amount
+}
+
+fragment SellingPlanFragment on SellingPlan {
+  id
+  description
+  name
+  options {
+    name
+    value
+  }
+  priceAdjustments {
+    orderCount
+    adjustmentValue {
+      ...on SellingPlanFixedAmountPriceAdjustment {
+        adjustmentAmount {
+          ...MoneyFragment
+        }
+      }
+      ...on SellingPlanFixedPriceAdjustment {
+        price {
+          ...MoneyFragment
+        }
+      }
+      ...on SellingPlanPercentagePriceAdjustment {
+        adjustmentPercentage
+      }
+    }
+  }
+  recurringDeliveries
+}
+fragment MoneyFragment on MoneyV2 {
+  currencyCode
+  amount
+}`;
+
+/**
 *```
 * fragment ExternalVideoFragment on ExternalVideo {
 *   id

--- a/packages/hydrogen/src/graphql/graphql-constants.ts
+++ b/packages/hydrogen/src/graphql/graphql-constants.ts
@@ -1979,7 +1979,7 @@ fragment ImageFragment on Image {
 /**
  *```
  *
- * fragment CollectionFragment on Collection {
+ * fragment CollectionProviderFragment on Collection {
  *   descriptionHtml
  *   handle
  *   id
@@ -1987,11 +1987,14 @@ fragment ImageFragment on Image {
  *     ...ImageFragment
  *   }
  *   title
- *   products(first: 10) {
+ *   products(first: $numCollectionProducts) {
  *     edges {
  *       node {
  *         ...ProductProviderFragment
  *       }
+ *     }
+ *     pageInfo {
+ *       hasNextPage
  *     }
  *   }
  * }
@@ -2292,8 +2295,8 @@ fragment ImageFragment on Image {
  * }
  *```
  */
-export const CollectionFragment: string = `
-fragment CollectionFragment on Collection {
+export const CollectionProviderFragment: string = `
+fragment CollectionProviderFragment on Collection {
   descriptionHtml
   handle
   id
@@ -2301,11 +2304,14 @@ fragment CollectionFragment on Collection {
     ...ImageFragment
   }
   title
-  products(first: 10) {
+  products(first: $numCollectionProducts) {
     edges {
       node {
         ...ProductProviderFragment
       }
+    }
+    pageInfo {
+      hasNextPage
     }
   }
 }

--- a/packages/hydrogen/src/hooks/index.ts
+++ b/packages/hydrogen/src/hooks/index.ts
@@ -5,3 +5,4 @@ export {useQuery, QueryProvider} from './useQuery';
 export {useMoney} from './useMoney';
 export {useMeasurement} from './useMeasurement';
 export {useParsedMetafields} from './useParsedMetafields';
+export {useCollection} from './useCollection';

--- a/packages/hydrogen/src/hooks/useCollection/index.ts
+++ b/packages/hydrogen/src/hooks/useCollection/index.ts
@@ -1,0 +1,1 @@
+export {useCollection} from './useCollection';

--- a/packages/hydrogen/src/hooks/useCollection/useCollection.ts
+++ b/packages/hydrogen/src/hooks/useCollection/useCollection.ts
@@ -1,0 +1,8 @@
+import {useContext} from 'react';
+import {CollectionContext} from '../../components';
+
+export function useCollection() {
+  const context = useContext(CollectionContext);
+
+  return context;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is a WIP PR attempting to build out collection-related components: 
- `CollectionProvider`: sets up a collection context for all children
- `CollectionTitle`: renders the collection title, must be used as a child of the `CollectionProvider`
- `CollectionDescription`: renders the collection's description HTML in a `RawHtml` component, must be used as a child of the `CollectionProvider`
- `CollectionImage`: renders the collection's image in a `Image` component, must be used as a child of the `CollectionProvider`
- `CollectionProducts`: renders the children for _each_ product. Each child is wrapped in a `ProductProvider`.

You can see this in action in a really scrappy `CollectionDetails.client` component in the starter template. 

Feedback welcome! I'll be OOO until Nov 17 and will be able to address feedback then. 

### Notes

- I am really looking forward to RSC supporting context. Once it does, we can change many of these client components to server components. Currently, all these components are client ones, which really front-loads everything to the client 😓 
- I'm envisioning other components like:
    - `CollectionLoadMore`: for incrementally loading more products. Similar to the `LoadMore.client` component in the startertemplate.
    - `CollectionNext`/`CollectionPrevious`: for loading the next X or previous Y products in a collection
    - `CollectionSort` : for sorting products by sort key

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
