### PR TITLE
Fix: Prevent error when store has no products

### DIFF
--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
-- fix: add check for products.length in `Welcom.server.jsx`
+- fix: add check for products.length in `Welcome.server.jsx`
 
 ## 0.6.4 - 2021-11-11
 

--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
 
 - fix: add check for products.length in `Welcome.server.jsx`
 

--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+- fix: add check for products.length in `Welcom.server.jsx`
+
 ## 0.6.4 - 2021-11-11
 
 - No updates. Transitive dependency bump.

--- a/packages/dev/src/components/Welcome.server.jsx
+++ b/packages/dev/src/components/Welcome.server.jsx
@@ -113,7 +113,7 @@ export default function Welcome() {
   const products = data && flattenConnection(data.products);
   const collections = data && flattenConnection(data.collections);
 
-  const firstProduct = products ? products[0].handle : '';
+  const firstProduct = products && products.length ? products[0].handle : '';
   const totalProducts = products && products.length;
   const firstCollection = collections[0] ? collections[0].handle : '';
   const totalCollections = collections && collections.length;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When connecting to a new store without products the homepage does not render.
The empty array for products returns truthy and this causes the error.


![image](https://user-images.githubusercontent.com/31767869/141788919-62cd589a-fafd-40c3-a792-379524e95672.png)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
