### PR TITLE
fix: default to retry: false in react-query

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix: default to `retry: false` in `useQuery`
 
 ## 0.6.4 - 2021-11-11
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Today if a developer has logic for fetching and processing data in `useQuery` but doesn't properly handle error responses, react-query will assume the request has failed and continue running the query. 

In development, this appears to the developer as if the page is hanging/not responding. This is not a great developer experience, not to mention it spams the 3P API.

This defaults to not retrying the query.

We will soon be removing react-query anyway #23 but this should be good for now.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
