### PR TITLE
fix: pull branch `main` before committing to `stackblitz`

### DIFF
--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -3,6 +3,7 @@ name: Publish to Stackblitz
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -17,5 +18,6 @@ jobs:
       - name: Push to stackblitz branch
         uses: EndBug/add-and-commit@v7.4.0
         with:
+          branch: main
           push: 'origin stackblitz --force'
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

My StackBlitz GH Action is failing: https://github.com/Shopify/hydrogen/runs/4175802205?check_suite_focus=true

Looks like it's trying to pull a `<version>` branch which doesn't exist.

This update tells it to just pull from `main` and commit to `stackblitz`.

I'm also gonna allow this to be run on `manual_dispatch` to make debugging easier. We will see if this works.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
