### PR TITLE
feat(useShopQuery): allow optional queries w/o API calls

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - fix: avoid repeating the same identifier for default and named exports
 - fix: remove sourcemap warnings
+- feat: allow `useShopQuery` to be skippable if no query is passed.
 
 ## 0.7.0 - 2021-11-22
 


### PR DESCRIPTION
### Description

Makes the `query` prop of `useShopQuery` optional so that users can work with dynamic queries without breaking the rules of hooks.

This spurred from `hydrogen-plugin-sanity`, where we auto-provision fresh Shopify data if there's any product referenced in the queried Sanity data. As we don't want to hit SFAPI when there's nothing to fetch, we needed to allow `query` to be undefined.

- [x] Settle on Typescript approach - should we determine `UseShopQueryResponse<T> | UseShopQueryResponse<undefined>` as the return type of the hook?

### Additional context

This was first implemented in [useSkippableShopQuery](https://github.com/sanity-io/hydrogen-plugin-sanity/commit/3d0c574f5c0daa1821d24f3c2ed7ada8d717d81f#diff-9458ca1d57fdaea35cfeab28b6801c1a1750bba22fa1535bb9b4ff930f32e342), but ideally, it'd be a part of Hydrogen's core.

See [Josh's comment on this PR](https://github.com/Shopify/hydrogen-archive/pull/749#discussion_r742929945) for more context into the long-term vision.

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] (Shopifolk only) Open a PR in the Shopify Dev Docs with updates to the Hydrogen documentation, if needed
