### PR TITLE
fix(#243): fix graphiql by running graphiql middleware before vite

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - fix: default to `retry: false` in `useQuery`
 - fix: starter template media gallery error when handling videos
+- fix: run graphiql middleware before vite, fixing graphiql
 
 ## 0.6.4 - 2021-11-11
 

--- a/packages/hydrogen/src/framework/middleware.ts
+++ b/packages/hydrogen/src/framework/middleware.ts
@@ -14,18 +14,13 @@ type HydrogenMiddlewareArgs = {
   cache?: Cache;
 };
 
-/**
- * Provides middleware to Node.js Express-like servers. Used by the Hydrogen
- * Vite dev server plugin as well as production Node.js implementation.
- */
-export default function hydrogenMiddleware({
-  dev,
+export function graphiqlMiddleware({
   shopifyConfig,
-  cache,
-  indexTemplate,
-  getServerEntrypoint,
-  devServer,
-}: HydrogenMiddlewareArgs) {
+  dev,
+}: {
+  shopifyConfig: ShopifyConfig;
+  dev: boolean;
+}) {
   return async function (
     request: IncomingMessage,
     response: http.ServerResponse,
@@ -37,6 +32,26 @@ export default function hydrogenMiddleware({
       return respondWithGraphiql(response, shopifyConfig);
     }
 
+    next();
+  };
+}
+
+/**
+ * Provides middleware to Node.js Express-like servers. Used by the Hydrogen
+ * Vite dev server plugin as well as production Node.js implementation.
+ */
+export function hydrogenMiddleware({
+  dev,
+  cache,
+  indexTemplate,
+  getServerEntrypoint,
+  devServer,
+}: HydrogenMiddlewareArgs) {
+  return async function (
+    request: IncomingMessage,
+    response: http.ServerResponse,
+    next: NextFunction
+  ) {
     const url = new URL('http://' + request.headers.host + request.originalUrl);
 
     const isReactHydrationRequest = url.pathname === '/react';

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -1,7 +1,7 @@
 import type {Plugin} from 'vite';
 import path from 'path';
 import {promises as fs} from 'fs';
-import hydrogenMiddleware from '../middleware';
+import {hydrogenMiddleware, graphiqlMiddleware} from '../middleware';
 import type {HydrogenVitePluginOptions, ShopifyConfig} from '../../types';
 import {InMemoryCache} from '../cache/in-memory';
 
@@ -24,6 +24,15 @@ export default (
         const indexHtml = await fs.readFile(resolve('index.html'), 'utf-8');
         return await server.transformIndexHtml(url, indexHtml);
       }
+
+      // The default vite middleware rewrites the URL `/graphqil` to `/index.html`
+      // By running this middleware first, we avoid that.
+      server.middlewares.use(
+        graphiqlMiddleware({
+          shopifyConfig,
+          dev: true,
+        })
+      );
 
       return () =>
         server.middlewares.use(


### PR DESCRIPTION
### Description
Resolves #243. The default vite middleware rewrites the URL `/graphiql` to `/index.html`
Running the `/graphiql` middleware first prevents that.

### Additional context

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
