### PR TITLE
feat: ESLint rule for `prefer-use-query`

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,7 +33,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.0.0"
+    "prettier": "^2.0.0",
+    "change-case": "^4.1.2"
   },
   "devDependencies": {
     "@types/dedent": "^0.7.0",

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,9 +1,11 @@
 import {noStateInServerComponents} from './no-state-in-server-components';
 import {noEffectsInServerComponents} from './no-effects-in-server-components';
 import {preferImageComponent} from './prefer-image-component';
+import {preferUseQuery} from './prefer-use-query';
 
 export const rules: {[key: string]: any} = {
   'no-effects-in-server-components': noEffectsInServerComponents,
   'no-state-in-server-components': noStateInServerComponents,
   'prefer-image-component': preferImageComponent,
+  'prefer-use-query': preferUseQuery,
 };

--- a/packages/eslint-plugin/src/rules/prefer-use-query/docs/details.md
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/docs/details.md
@@ -1,0 +1,5 @@
+## Rule Details
+
+Prefer using `@shopify/hydrogen` `useQuery` hook in place of `fetch`'.
+
+This rule prevents using `fetch` directly when inside a React component. In `@shopify/hydrogen` apps we suggests using the `useQuery` hook from the `@shopify/hydrogen` SDK.

--- a/packages/eslint-plugin/src/rules/prefer-use-query/docs/overview.md
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/docs/overview.md
@@ -1,0 +1,3 @@
+# Prefer using @shopify/hydrogen `useQuery` hook in place of `fetch` (`hydrogen/prefer-use-fetch`)
+
+Using `fetch` improperly when fetching data in React components can lead to unknown performance problems. The `useQuery` hook from the `@shopify/hydrogen` SDK comes with intelligent cache defaults and other built-in features to enable the most performant experience. Learn more about the `useQuery` hook in the [Shopify.dev docs](https://shopify.dev/api/hydrogen/hooks/global/usequery).

--- a/packages/eslint-plugin/src/rules/prefer-use-query/examples/invalid.example.tsx
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/examples/invalid.example.tsx
@@ -1,0 +1,15 @@
+// Examples of **incorrect** code for this rule:
+
+import {Button} from '@shopify/hydrogen';
+
+export function SomeReactComponent() {
+  useEffect(() => {
+    const fetchData = async () => {
+      const result = await fetch('https://my.api.com');
+    };
+
+    fetchData();
+  }, []);
+
+  return <Button>Click me</Button>;
+}

--- a/packages/eslint-plugin/src/rules/prefer-use-query/examples/valid.example.tsx
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/examples/valid.example.tsx
@@ -1,0 +1,13 @@
+// Examples of **correct** code for this rule:
+
+import {useQuery} from '@shopify/hydrogen';
+
+export default function Page() {
+  const {data} = useQuery(['unique', 'key'], async () => {
+    const response = await fetch('https://my.api.com');
+
+    return await response.json();
+  });
+
+  return <h1>{data.title}</h1>;
+}

--- a/packages/eslint-plugin/src/rules/prefer-use-query/index.ts
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/index.ts
@@ -1,0 +1,1 @@
+export {preferUseQuery} from './prefer-use-query';

--- a/packages/eslint-plugin/src/rules/prefer-use-query/prefer-use-query.ts
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/prefer-use-query.ts
@@ -1,0 +1,126 @@
+import {AST_NODE_TYPES, TSESTree} from '@typescript-eslint/types';
+import {pascalCase} from 'change-case';
+
+import {createRule} from '../../utilities';
+
+const FETCH_FUNCTION_NAME = 'fetch';
+const USE_QUERY_COMPONENT_NAME = 'useQuery';
+const HYDROGEN_MODULE_SOURCE = '@shopify/hydrogen';
+
+export const preferUseQuery = createRule({
+  name: `hydrogen/${__dirname}`,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: `Prefer using \`${HYDROGEN_MODULE_SOURCE}\` \`${USE_QUERY_COMPONENT_NAME}\` hook in place of \`${FETCH_FUNCTION_NAME}\`.`,
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    messages: {
+      preferUseQuery: `Use the \`${HYDROGEN_MODULE_SOURCE}\` \`${USE_QUERY_COMPONENT_NAME}\` hook in place of \`${FETCH_FUNCTION_NAME}\`.`,
+      importUseQuery: `Import the \`${USE_QUERY_COMPONENT_NAME}\` from ${HYDROGEN_MODULE_SOURCE}.`,
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: function (context) {
+    let hydrogenImportNode: TSESTree.ImportDeclaration | undefined;
+    let lastImportNode: TSESTree.ImportDeclaration;
+    let inReactComponent = false;
+    let inUseQuery = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (hydrogenImportNode) {
+          return;
+        }
+
+        hydrogenImportNode =
+          node.source.value === HYDROGEN_MODULE_SOURCE ? node : undefined;
+        lastImportNode = node;
+      },
+      FunctionDeclaration(node) {
+        inReactComponent = looksLikeReactComponent(node);
+      },
+      'FunctionDeclaration:exit': function (node) {
+        inReactComponent = looksLikeReactComponent(node) && false;
+      },
+      CallExpression(node) {
+        if (!inReactComponent) {
+          return;
+        }
+
+        if (is('useQuery', node)) {
+          inUseQuery = true;
+        }
+
+        if (is('fetch', node) && !inUseQuery) {
+          context.report({
+            node,
+            messageId: 'preferUseQuery',
+            suggest: [
+              {
+                messageId: 'importUseQuery',
+                fix: function (fixer) {
+                  if (hydrogenImportNode) {
+                    if (
+                      hydrogenImportNode.specifiers.some(
+                        (specifier) =>
+                          specifier.local.name === USE_QUERY_COMPONENT_NAME
+                      )
+                    ) {
+                      return [];
+                    }
+
+                    const lastSpecifier =
+                      hydrogenImportNode.specifiers[
+                        hydrogenImportNode.specifiers.length - 1
+                      ];
+
+                    const importFix = fixer.insertTextAfter(
+                      lastSpecifier,
+                      `, ${USE_QUERY_COMPONENT_NAME}`
+                    );
+
+                    return [importFix];
+                  }
+
+                  const importFix = lastImportNode
+                    ? fixer.insertTextAfter(
+                        lastImportNode,
+                        `import {${USE_QUERY_COMPONENT_NAME}} from '${HYDROGEN_MODULE_SOURCE}';\n\n`
+                      )
+                    : fixer.insertTextBefore(
+                        context.getAncestors()[0],
+                        `import {${USE_QUERY_COMPONENT_NAME}} from '${HYDROGEN_MODULE_SOURCE}';\n\n`
+                      );
+
+                  return [importFix];
+                },
+              },
+            ],
+          });
+        }
+      },
+      'CallExpression:exit': function (node) {
+        if (is('useQuery', node)) {
+          inUseQuery = false;
+        }
+      },
+    };
+  },
+});
+
+function looksLikeReactComponent(node: TSESTree.FunctionDeclaration) {
+  if (!node.id) {
+    return false;
+  }
+
+  return node.id.name === pascalCase(node.id.name);
+}
+
+function is(name: string, node: TSESTree.CallExpression) {
+  return (
+    node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === name
+  );
+}

--- a/packages/eslint-plugin/src/rules/prefer-use-query/tests/prefer-use-query.test.ts
+++ b/packages/eslint-plugin/src/rules/prefer-use-query/tests/prefer-use-query.test.ts
@@ -1,0 +1,149 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {AST_NODE_TYPES} from '@typescript-eslint/types';
+import {preferUseQuery} from '../prefer-use-query';
+import dedent from 'dedent';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+function error(options: {suggestion?: string} = {}) {
+  const suggestions = options.suggestion
+    ? {
+        suggestions: [
+          {
+            output: dedent`
+          ${options.suggestion}
+        `,
+            messageId: 'importUseQuery' as const,
+          },
+        ],
+      }
+    : {};
+  return {
+    type: AST_NODE_TYPES.CallExpression,
+    messageId: 'preferUseQuery' as const,
+    ...suggestions,
+  };
+}
+
+ruleTester.run('hydrogen/prefer-use-query', preferUseQuery, {
+  valid: [
+    {
+      code: dedent`
+        fetch();
+      `,
+    },
+    {
+      code: dedent`
+        const {data} = useQuery(['unique', 'key'], async () => {
+          const response = await fetch('https://my.api.com');
+        
+          return await response.json();
+        });
+      `,
+    },
+    {
+      code: dedent`
+        import {useQuery} from '@shopify/hydrogen';
+
+        export default function Page() {
+          const {data} = useQuery(['unique', 'key'], async () => {
+            const response = await fetch('https://my.api.com');
+        
+            return await response.json();
+          });
+        
+          return <h1>{data.title}</h1>;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        function SomeReactComponent() {
+          useEffect(() => {
+            const fetchData = async () => {
+              const result = await fetch('https://my.api.com');
+            };
+        
+            fetchData();
+          }, []);
+          
+          return null;
+        }
+      `,
+      errors: [error()],
+    },
+    {
+      code: dedent`
+        export function SomeOtherReactComponent() {
+          await fetch('https://my.api.com');
+          
+          return null;
+        }
+      `,
+      errors: [error()],
+    },
+    {
+      code: dedent`
+        import {useQuery} from '@shopify/hydrogen';
+
+        function SomeReactComponent() {
+          useEffect(() => {
+            const fetchData = async () => {
+              const result = await fetch('https://my.api.com');
+            };
+        
+            fetchData();
+          }, []);
+          
+          return null;
+        }
+      `,
+      errors: [error()],
+    },
+    {
+      code: dedent`
+        import {Button} from '@shopify/hydrogen';
+
+        function SomeReactComponent() {
+          useEffect(() => {
+            const fetchData = async () => {
+              const result = await fetch('https://my.api.com');
+            };
+        
+            fetchData();
+          }, []);
+          
+          return <Button>Click me</Button>;
+        }
+      `,
+      errors: [
+        error({
+          suggestion: `
+            import {Button, useQuery} from '@shopify/hydrogen';
+
+            function SomeReactComponent() {
+              useEffect(() => {
+                const fetchData = async () => {
+                  const result = await fetch('https://my.api.com');
+                };
+            
+                fetchData();
+              }, []);
+              
+              return <Button>Click me</Button>;
+            }
+          `,
+        }),
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds an ESLint rule to suggest `useQuery` instead of using `fetch` directly.

Opening this as a draft. we will want to wait for https://github.com/Shopify/hydrogen/issues/256 to resolve.

<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context

For reviewers: Any test cases I might be missing?

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
