### PR TITLE
refactor: remove Intl polyfill

### DIFF
--- a/packages/hydrogen/src/hooks/useMoney/hooks.tsx
+++ b/packages/hydrogen/src/hooks/useMoney/hooks.tsx
@@ -38,21 +38,6 @@ export type UseMoneyValue = {
   original: MoneyV2;
 };
 
-// TODO: Remove this when Oxygen supports Intl properly (oxygen-sws#527)
-const NARROW_SYMBOL_MAP: Partial<Record<MoneyV2['currencyCode'], string>> = {
-  USD: '$',
-  AUD: '$',
-  CAD: '$',
-  NZD: '$',
-  EUR: '€',
-  GBP: '£',
-  INR: '₹',
-  RUB: '₽',
-  CNY: '¥',
-  JPY: '¥',
-  BRL: 'R$',
-};
-
 /**
  * The `useMoney` hook takes a [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) and returns a
  * default-formatted string of the amount with the correct currency indicator, along with some of the parts provided by
@@ -99,7 +84,6 @@ export function useMoney(money: MoneyV2): UseMoneyValue {
         money.currencyCode,
       currencyNarrowSymbol:
         narrowParts.find((part) => part.type === 'currency')?.value ?? // e.g. "$"
-        NARROW_SYMBOL_MAP[money.currencyCode] ??
         '',
       parts: baseParts,
       localizedString: value,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Looks like Oxygen already supports Intl narrow symbols after oxygen-sws#616

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
