### PR TITLE
fix: ensure to call waitUntil with proper "this" if present

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- fix: binding of waitUntil in playground/server-components-worker
 - fix: default to `retry: false` in `useQuery`
 - fix: starter template media gallery error when handling videos
 - fix: run graphiql middleware before vite, fixing graphiql

--- a/packages/playground/server-components-worker/worker.js
+++ b/packages/playground/server-components-worker/worker.js
@@ -30,7 +30,7 @@ addEventListener('fetch', (event) => {
         assetHandler,
         cache: caches.default,
         context: {
-            waitUntil: event.waitUntil ? (p) => event.waitUntil(p) : undefined,
+          waitUntil: event.waitUntil ? (p) => event.waitUntil(p) : undefined,
         },
       })
     );

--- a/packages/playground/server-components-worker/worker.js
+++ b/packages/playground/server-components-worker/worker.js
@@ -30,7 +30,7 @@ addEventListener('fetch', (event) => {
         assetHandler,
         cache: caches.default,
         context: {
-          waitUntil: event.waitUntil,
+            waitUntil: event.waitUntil ? (p) => event.waitUntil(p) : undefined,
         },
       })
     );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes the way we save a reference to `event.waitUntil` to ensure we preserve the correct `this` when calling

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
