### PR TITLE
fix: workaround for sourcemap warnings

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -104,6 +104,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - fix: invoke CartProvider callbacks before performing the GraphQL mutations
 - fix: fix the accessible label in the AddToCartButton component when an item is added to cart
 - fix: cart fetch to return stringified error
+- fix: remove sourcemap warnings
 
 ## 0.2.1 - 2021-10-12
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #140

The [sourcemaps fix in Vite](https://github.com/vitejs/vite/commit/8556ffe3c59952d7e64565422bf433699e97756e#diff-d1f942b9a74f586a80bca3733150b7c692a6460e8350bc19cbbad1d53f95b356) is not enough for us because that `id` parameter contains the querystring `?no-proxy`, and it breaks the sourcemap.

This PR implements a workaround on our side until it is fixed in Vite (I'll open PRs there soon). 

Apart from that, looks like `react-ssr-prepass` soucemap is broken so this also ignores it. I tried to read the proper sourcemap from a file next to the source code, but looks like it crashes in Jest and build... that's why Vite is ignoring it, probably.

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
