### PR TITLE
Update `graphql` dependency

### DIFF
--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install the packages
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
 
       - name: Build the code
         run: yarn build

--- a/packages/hydrogen-plugin-sanity/package.json
+++ b/packages/hydrogen-plugin-sanity/package.json
@@ -23,6 +23,6 @@
     "@shopify/hydrogen": "^0.4.0"
   },
   "dependencies": {
-    "graphql": "15.3.0"
+    "graphql": "^16.0.1"
   }
 }

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -87,7 +87,7 @@
     "connect": "^3.7.0",
     "es-module-lexer": "^0.9.0",
     "fast-glob": "^3.2.5",
-    "graphql": "^15.5.0",
+    "graphql": "^16.0.1",
     "html-dom-parser": "^1.0.1",
     "html-react-parser": "^1.2.6",
     "isomorphic-dompurify": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6635,15 +6635,15 @@ graphql-ws@^4.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-4.9.0.tgz#5cfd8bb490b35e86583d8322f5d5d099c26e365c"
   integrity sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==
 
-graphql@*, graphql@^15.5.0:
+graphql@*:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
   integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
 
-graphql@15.3.0:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
-  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
+graphql@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.1.tgz#93a13cd4e0e38ca8d0832e79614c8578bfd34f10"
+  integrity sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I was investigating our `graphql` dependencies and noticed that when trying to upgrade `graphql` to the lastest 16.x.x branch, we'd run into a `The engine "node" is incompatible with this module` error in the Github action for Node 15.

### Additional context

In order to fix this I added the [`--ignore-engines`](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-ignore-engines) flag in the `yarn install` step. Would anyone know of any reason not to add this flag?

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
