### PR TITLE
fix: variable not declared in 404 page. Closes #298

### DIFF
--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - Use `eslint-plugin-hydrogen` recommended config for JS linting
+- fix: 404 Page > Variable not declared
 
 ## 0.7.0 - 2021-11-22
 

--- a/packages/dev/src/components/NotFound.server.jsx
+++ b/packages/dev/src/components/NotFound.server.jsx
@@ -68,6 +68,7 @@ export default function NotFound({country = {isoCode: 'US'}}) {
 const QUERY = gql`
   query NotFoundProductDetails(
     $country: CountryCode
+    $includeReferenceMetafieldDetails: Boolean = false
     $numProductMetafields: Int!
     $numProductVariants: Int!
     $numProductMedia: Int!


### PR DESCRIPTION
I'm fixing the issue below on the 404 page. I've added the fix in the CHANGELOG.md too.

Issue: https://github.com/Shopify/hydrogen/issues/298

**Before**

![Screen Shot 2021-11-23 at 6 10 37 PM](https://user-images.githubusercontent.com/610598/143144944-9dc7bb9f-d454-4743-ba4b-3ade1bd994a2.png)

**After**

![Screen Shot 2021-11-23 at 6 10 51 PM](https://user-images.githubusercontent.com/610598/143144951-f6795bac-cbab-45fb-a447-60e4e9dcf52b.png)