### PR TITLE
fix: avoid repeating the same identifier for default and named exports

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix: avoid repeating the same identifier for default and named exports
 
 ## 0.7.0 - 2021-11-22
 

--- a/packages/hydrogen/src/framework/__tests__/proxy-client-component.spec.ts
+++ b/packages/hydrogen/src/framework/__tests__/proxy-client-component.spec.ts
@@ -7,9 +7,9 @@ it('wraps default exports for dev', async () => {
       src: `export default function() {}`,
     })
   ).toBe(`import {wrapInClientMarker} from '@shopify/hydrogen/marker';
-import Counter from '/path/to/Counter.client.jsx?no-proxy';
+import * as allImports from '/path/to/Counter.client.jsx?no-proxy';
 
-export default wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: Counter, named: false });
+export default wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: allImports['default'], named: false });
 `);
 });
 
@@ -20,10 +20,10 @@ it('wraps named exports', async () => {
       src: `export function Counter() {}\nexport const Clicker = () => {};`,
     })
   ).toBe(`import {wrapInClientMarker} from '@shopify/hydrogen/marker';
-import * as namedImports from '/path/to/Counter.client.jsx?no-proxy';
+import * as allImports from '/path/to/Counter.client.jsx?no-proxy';
 
-export const Counter = wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: namedImports['Counter'], named: true });
-export const Clicker = wrapInClientMarker({ name: 'Clicker', id: '/path/to/Counter.client.jsx', component: namedImports['Clicker'], named: true });
+export const Counter = wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: allImports['Counter'], named: true });
+export const Clicker = wrapInClientMarker({ name: 'Clicker', id: '/path/to/Counter.client.jsx', component: allImports['Clicker'], named: true });
 `);
 });
 
@@ -34,10 +34,10 @@ it('combines default and named exports', async () => {
       src: `export default function() {}\nexport const Clicker = () => {};`,
     })
   ).toBe(`import {wrapInClientMarker} from '@shopify/hydrogen/marker';
-import Counter, * as namedImports from '/path/to/Counter.client.jsx?no-proxy';
+import * as allImports from '/path/to/Counter.client.jsx?no-proxy';
 
-export default wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: Counter, named: false });
-export const Clicker = wrapInClientMarker({ name: 'Clicker', id: '/path/to/Counter.client.jsx', component: namedImports['Clicker'], named: true });
+export default wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: allImports['default'], named: false });
+export const Clicker = wrapInClientMarker({ name: 'Clicker', id: '/path/to/Counter.client.jsx', component: allImports['Clicker'], named: true });
 `);
 });
 
@@ -48,10 +48,10 @@ it('does not wrap non-component exports', async () => {
       src: `export default function() {}\nexport const MyFragment = 'fragment myFragment on MyQuery { id }';`,
     })
   ).toBe(`import {wrapInClientMarker} from '@shopify/hydrogen/marker';
-import Counter from '/path/to/Counter.client.jsx?no-proxy';
+import * as allImports from '/path/to/Counter.client.jsx?no-proxy';
 
 export {MyFragment} from '/path/to/Counter.client.jsx?no-proxy';
-export default wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: Counter, named: false });
+export default wrapInClientMarker({ name: 'Counter', id: '/path/to/Counter.client.jsx', component: allImports['default'], named: false });
 `);
 });
 

--- a/packages/hydrogen/src/framework/server-components.ts
+++ b/packages/hydrogen/src/framework/server-components.ts
@@ -3,6 +3,8 @@ import {promises as fs} from 'fs';
 import {transformWithEsbuild} from 'vite';
 import MagicString from 'magic-string';
 
+const DEFAULT_EXPORT = 'default';
+
 export async function proxyClientComponent({
   id,
   src,
@@ -10,8 +12,6 @@ export async function proxyClientComponent({
   id: string;
   src?: string;
 }) {
-  const defaultComponentName = id.split('/').pop()?.split('.').shift();
-
   // Modify the import ID to avoid infinite wraps
   const importFrom = `${id}?no-proxy`;
 
@@ -23,92 +23,48 @@ export async function proxyClientComponent({
 
   const {code} = await transformWithEsbuild(src, id);
   const [, exportStatements] = parse(code);
-  const hasDefaultExport = exportStatements.includes('default');
 
-  // Split namedImports in components to wrap and everything else (e.g. GQL Fragments)
-  const namedImports = exportStatements.reduce(
-    (acc, i) => {
-      if (i !== 'default') {
-        // Add here any other naming pattern for a non-component export
-        if (/^use[A-Z]|Fragment$|Context$|^[A-Z_]+$/.test(i)) {
-          acc.other.push(i);
-        } else {
-          acc.components.push(i);
-        }
-      }
+  // Classify exports in components to wrap vs. everything else (e.g. GQL Fragments)
+  const otherExports = [] as string[];
+  const componentExports = [] as string[];
+  for (const key of exportStatements) {
+    if (
+      key !== DEFAULT_EXPORT &&
+      /^use[A-Z]|Fragment$|Context$|^[A-Z_]+$/.test(key)
+    ) {
+      otherExports.push(key);
+    } else {
+      componentExports.push(key);
+    }
+  }
 
-      return acc;
-    },
-    {components: [] as string[], other: [] as string[]}
-  );
-
-  if (!hasDefaultExport && namedImports.components.length === 0) {
+  if (componentExports.length === 0) {
     return `export * from '${importFrom}';\n`;
   }
 
   const s = new MagicString(
-    `import {wrapInClientMarker} from '@shopify/hydrogen/marker';`
+    `import {wrapInClientMarker} from '@shopify/hydrogen/marker';\n` +
+      `import * as allImports from '${importFrom}';\n\n`
   );
-
-  s.append('\nimport ');
-
-  if (hasDefaultExport) {
-    s.append(defaultComponentName!);
-    if (namedImports.components.length > 0) {
-      s.append(', ');
-    }
-  }
-
-  if (namedImports.components.length) {
-    s.append('* as namedImports');
-  }
-
-  s.append(` from '${importFrom}';\n\n`);
 
   // Re-export other stuff directly without wrapping
-  if (namedImports.other.length > 0) {
-    s.append(
-      `export {${namedImports.other.join(', ')}} from '${importFrom}';\n`
-    );
+  if (otherExports.length > 0) {
+    s.append(`export {${otherExports.join(', ')}} from '${importFrom}';\n`);
   }
 
-  if (hasDefaultExport) {
-    s.append(
-      generateComponentExport({
-        id,
-        componentName: defaultComponentName!,
-        isDefault: true,
-      })
-    );
-  }
+  // Wrap components in Client Marker
+  componentExports.forEach((key) => {
+    const isDefault = key === DEFAULT_EXPORT;
+    const componentName = isDefault
+      ? (id.split('/').pop()?.split('.').shift() as string)
+      : key;
 
-  namedImports.components.forEach((name) =>
     s.append(
-      generateComponentExport({
-        id,
-        componentName: name,
-        isDefault: false,
-      })
-    )
-  );
+      `export ${
+        isDefault ? DEFAULT_EXPORT : `const ${componentName} =`
+      } wrapInClientMarker({ name: '${componentName}', id: '${id}', component: allImports['${key}'], named: ${!isDefault} });\n`
+    );
+  });
 
   return s.toString();
-}
-
-function generateComponentExport({
-  id,
-  isDefault,
-  componentName,
-}: {
-  id: string;
-  isDefault: boolean;
-  componentName: string;
-}) {
-  const component = isDefault
-    ? componentName
-    : `namedImports['${componentName}']`;
-
-  return `export ${
-    isDefault ? 'default' : `const ${componentName} =`
-  } wrapInClientMarker({ name: '${componentName}', id: '${id}', component: ${component}, named: ${!isDefault} });\n`;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #289 

The same identifier was declared twice in every file that had default export + named export.
This PR simplifies all the component proxy code and also avoids repeating the same identifier.

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
