### PR TITLE
feat: remove react router from the server code

### DIFF
--- a/packages/dev/src/App.server.jsx
+++ b/packages/dev/src/App.server.jsx
@@ -1,5 +1,4 @@
 import {ShopifyServerProvider, DefaultRoutes} from '@shopify/hydrogen';
-import {Switch} from 'react-router-dom';
 import {Suspense} from 'react';
 
 import shopifyConfig from '../shopify.config';
@@ -17,13 +16,15 @@ export default function App({...serverState}) {
       <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
         <CartProvider>
           <DefaultSeo />
-          <Switch>
-            <DefaultRoutes
-              pages={pages}
-              serverState={serverState}
-              fallback={<NotFound />}
-            />
-          </Switch>
+          <DefaultRoutes
+            location={{
+              pathname: serverState.pathname,
+              search: serverState.search,
+            }}
+            pages={pages}
+            serverState={serverState}
+            fallback={<NotFound />}
+          />
         </CartProvider>
       </ShopifyServerProvider>
     </Suspense>

--- a/packages/dev/src/App.server.jsx
+++ b/packages/dev/src/App.server.jsx
@@ -17,10 +17,6 @@ export default function App({...serverState}) {
         <CartProvider>
           <DefaultSeo />
           <DefaultRoutes
-            location={{
-              pathname: serverState.pathname,
-              search: serverState.search,
-            }}
             pages={pages}
             serverState={serverState}
             fallback={<NotFound />}

--- a/packages/dev/src/components/NotFound.server.jsx
+++ b/packages/dev/src/components/NotFound.server.jsx
@@ -75,6 +75,7 @@ const QUERY = gql`
     $numProductVariantSellingPlanAllocations: Int!
     $numProductSellingPlanGroups: Int!
     $numProductSellingPlans: Int!
+    $includeReferenceMetafieldDetails: Boolean = false
   ) @inContext(country: $country) {
     products(first: 3) {
       edges {

--- a/packages/dev/src/pages/collections/[handle].server.jsx
+++ b/packages/dev/src/pages/collections/[handle].server.jsx
@@ -5,7 +5,6 @@ import {
   flattenConnection,
   RawHtml,
 } from '@shopify/hydrogen';
-import {useParams} from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import LoadMoreProducts from '../../components/LoadMoreProducts.client';

--- a/packages/dev/src/pages/collections/[handle].server.jsx
+++ b/packages/dev/src/pages/collections/[handle].server.jsx
@@ -15,9 +15,10 @@ import NotFound from '../../components/NotFound.server';
 
 export default function Collection({
   country = {isoCode: 'US'},
+  params,
   collectionProductCount = 24,
 }) {
-  const {handle} = useParams();
+  const {handle} = params;
   const {data} = useShopQuery({
     query: QUERY,
     variables: {

--- a/packages/dev/src/pages/pages/[handle].server.jsx
+++ b/packages/dev/src/pages/pages/[handle].server.jsx
@@ -5,8 +5,8 @@ import gql from 'graphql-tag';
 import Layout from '../../components/Layout.server';
 import NotFound from '../../components/NotFound.server';
 
-export default function Page() {
-  const {handle} = useParams();
+export default function Page({params}) {
+  const {handle} = params;
   const {data} = useShopQuery({query: QUERY, variables: {handle}});
 
   if (!data.pageByHandle) {

--- a/packages/dev/src/pages/pages/[handle].server.jsx
+++ b/packages/dev/src/pages/pages/[handle].server.jsx
@@ -1,4 +1,3 @@
-import {useParams} from 'react-router-dom';
 import {useShopQuery, RawHtml} from '@shopify/hydrogen';
 import gql from 'graphql-tag';
 

--- a/packages/dev/src/pages/products/[handle].server.jsx
+++ b/packages/dev/src/pages/products/[handle].server.jsx
@@ -6,8 +6,8 @@ import ProductDetails from '../../components/ProductDetails.client';
 import NotFound from '../../components/NotFound.server';
 import Layout from '../../components/Layout.server';
 
-export default function Product({country = {isoCode: 'US'}}) {
-  const {handle} = useParams();
+export default function Product({params, country = {isoCode: 'US'}}) {
+  const {handle} = params;
 
   const {data} = useShopQuery({
     query: QUERY,

--- a/packages/dev/src/pages/products/[handle].server.jsx
+++ b/packages/dev/src/pages/products/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, ProductProviderFragment} from '@shopify/hydrogen';
-import {useParams} from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';

--- a/packages/dev/src/pages/redirect.server.jsx
+++ b/packages/dev/src/pages/redirect.server.jsx
@@ -1,0 +1,9 @@
+export default function Redirect({response}) {
+  response.redirect('/');
+
+  return (
+    <div>
+      <h1>This page has been moved to /</h1>
+    </div>
+  );
+}

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -83,6 +83,7 @@
     "vite": "^2.6.14"
   },
   "dependencies": {
+    "path-to-regexp": "^6.2.0",
     "@vitejs/plugin-react": "^1.1.0",
     "connect": "^3.7.0",
     "es-module-lexer": "^0.9.0",

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -4,7 +4,7 @@ import {Link as RRLink} from 'react-router-dom';
 
 export function Link(props: any) {
   return isServer() ? (
-    <a href={props.to} {...{...props, to: null}} />
+    <a href={props.to} {...props} to={null} />
   ) : (
     <RRLink {...props} />
   );

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -1,1 +1,11 @@
-export {Link} from 'react-router-dom';
+import React from 'react';
+import {isServer} from '../../utilities';
+import {Link as RRLink} from 'react-router-dom';
+
+export function Link(props: any) {
+  return isServer() ? (
+    <a href={props.to} {...{...props, to: null}} />
+  ) : (
+    <RRLink {...props} />
+  );
+}

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -1,7 +1,7 @@
 import React, {Suspense, useState} from 'react';
 // @ts-ignore
 import {createRoot} from 'react-dom';
-import {BrowserRouter} from 'react-router-dom';
+import {BrowserRouter, Switch} from 'react-router-dom';
 import type {ClientHandler} from './types';
 import {ErrorBoundary} from 'react-error-boundary';
 import {HelmetProvider} from 'react-helmet-async';
@@ -47,7 +47,9 @@ function Content({clientWrapper: ClientWrapper}: {clientWrapper: any}) {
           <BrowserRouter>
             <ServerStateRouter />
             {/* @ts-ignore */}
-            <ClientWrapper>{response.read()}</ClientWrapper>
+            <Switch>
+              <ClientWrapper>{response.read()}</ClientWrapper>
+            </Switch>
           </BrowserRouter>
         </HelmetProvider>
       </QueryProvider>

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -7,7 +7,6 @@ import {
 import {renderToString} from 'react-dom/server';
 import {getErrorMarkup} from './utilities/error';
 import ssrPrepass from 'react-ssr-prepass';
-import {StaticRouter} from 'react-router-dom';
 import type {ServerHandler} from './types';
 import {HydrationContext} from './framework/Hydration/HydrationContext.server';
 import type {ReactQueryHydrationContext} from './foundation/ShopifyProvider/types';
@@ -256,14 +255,9 @@ function buildReactApp({
   const componentResponse = new ServerComponentResponse();
 
   const ReactApp = (props: any) => (
-    <StaticRouter
-      location={{pathname: state.pathname, search: state.search}}
-      context={context}
-    >
-      <HelmetProvider context={helmetContext}>
-        <App {...props} request={request} response={componentResponse} />
-      </HelmetProvider>
-    </StaticRouter>
+    <HelmetProvider context={helmetContext}>
+      <App {...props} request={request} response={componentResponse} />
+    </HelmetProvider>
   );
 
   return {helmetContext, ReactApp, componentResponse};

--- a/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
+++ b/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
@@ -10,12 +10,10 @@ export type ImportGlobEagerOutput = Record<string, Record<'default', any>>;
  * @see https://vitejs.dev/guide/features.html#glob-import
  */
 export function DefaultRoutes({
-  location,
   pages,
   serverState,
   fallback,
 }: {
-  location: Location;
   pages: ImportGlobEagerOutput;
   serverState: Record<string, any>;
   fallback?: ReactElement;
@@ -30,7 +28,7 @@ export function DefaultRoutes({
   let foundRoute, foundRouteDetails;
 
   for (let i = 0; i < routes.length; i++) {
-    foundRouteDetails = matchPath(location.pathname, routes[i]);
+    foundRouteDetails = matchPath(serverState.pathname, routes[i]);
 
     if (foundRouteDetails) {
       foundRoute = routes[i];
@@ -43,11 +41,6 @@ export function DefaultRoutes({
   ) : (
     fallback
   );
-}
-
-interface Location {
-  pathname: string;
-  searcH: string;
 }
 
 interface HydrogenRoute {

--- a/packages/hydrogen/src/hooks/useProductOptions/__tests__/useProductOptions.spec.tsx
+++ b/packages/hydrogen/src/hooks/useProductOptions/__tests__/useProductOptions.spec.tsx
@@ -238,7 +238,7 @@ it('supports selecting a selling plan', () => {
     return (
       <>
         {(sellingPlanGroups ?? []).map((sellingPlanGroup) => (
-          <>
+          <React.Fragment key={sellingPlanGroup.name}>
             <h2>{sellingPlanGroup.name}</h2>
             <ul>
               {sellingPlanGroup.sellingPlans.map((sellingPlan) => {
@@ -251,7 +251,7 @@ it('supports selecting a selling plan', () => {
                 );
               })}
             </ul>
-          </>
+          </React.Fragment>
         ))}
         <div data-testid="selectedSellingPlan">
           {JSON.stringify(selectedSellingPlan)}

--- a/packages/hydrogen/src/utilities/match_path.ts
+++ b/packages/hydrogen/src/utilities/match_path.ts
@@ -52,8 +52,6 @@ export function matchPath(pathname: string, options: MatchPathOptions = {}) {
     });
     const match = regexp.exec(pathname);
 
-    console.log(path, pathname, match);
-
     if (!match) return null;
 
     const [url, ...values] = match;

--- a/packages/hydrogen/src/utilities/match_path.ts
+++ b/packages/hydrogen/src/utilities/match_path.ts
@@ -1,0 +1,74 @@
+import {pathToRegexp, Key, TokensToRegexpOptions} from 'path-to-regexp';
+
+// Modified from React Router v5
+// https://github.com/remix-run/react-router/blob/v5/packages/react-router/modules/matchPath.js
+
+const cache: any = {};
+const cacheLimit = 10000;
+let cacheCount = 0;
+
+interface MatchPathOptions extends TokensToRegexpOptions {
+  path?: string;
+  exact?: boolean;
+}
+
+function compilePath(
+  path: string,
+  options: MatchPathOptions
+): {regexp: RegExp; keys: Array<Key>} {
+  const cacheKey = `${options.end}${options.strict}${options.sensitive}`;
+  const pathCache = cache[cacheKey] || (cache[cacheKey] = {});
+
+  if (pathCache[path]) return pathCache[path];
+
+  const keys: Array<Key> = [];
+  const regexp = pathToRegexp(path, keys, options);
+  const result = {regexp, keys};
+
+  if (cacheCount < cacheLimit) {
+    pathCache[path] = result;
+    cacheCount++;
+  }
+
+  return result;
+}
+
+/**
+ * Public API for matching a URL pathname to a path.
+ */
+export function matchPath(pathname: string, options: MatchPathOptions = {}) {
+  const {path, exact = false, strict = false, sensitive = false} = options;
+
+  const paths: Array<any> = [].concat(path as any);
+
+  return paths.reduce((matched, path) => {
+    if (!path && path !== '') return null;
+    if (matched) return matched;
+
+    const {regexp, keys} = compilePath(path, {
+      end: exact,
+      strict,
+      sensitive,
+    });
+    const match = regexp.exec(pathname);
+
+    console.log(path, pathname, match);
+
+    if (!match) return null;
+
+    const [url, ...values] = match;
+    const isExact = pathname === url;
+
+    if (exact && !isExact) return null;
+
+    return {
+      path, // the path used to match
+      url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+      isExact, // whether or not we matched exactly
+      params: keys.reduce((memo: any, key, index) => {
+        memo[key.name] = values[index];
+        return memo;
+      }, {}),
+    };
+  }, null);
+}

--- a/packages/playground/server-components/__tests__/server-components.spec.ts
+++ b/packages/playground/server-components/__tests__/server-components.spec.ts
@@ -10,6 +10,7 @@ it('shows the homepage, navigates to about, and increases the count', async () =
 });
 
 it('follows synchronous redirects', async () => {
+  console.log(viteTestUrl);
   await page.goto(viteTestUrl + '/redirected');
   expect(await page.url()).toContain('/about');
   expect(await page.textContent('h1')).toContain('About');

--- a/packages/playground/server-components/src/App.server.jsx
+++ b/packages/playground/server-components/src/App.server.jsx
@@ -1,5 +1,4 @@
 import {ShopifyServerProvider, DefaultRoutes} from '@shopify/hydrogen';
-import {Switch} from 'react-router-dom';
 import shopifyConfig from '../shopify.config';
 import {Suspense} from 'react';
 
@@ -7,16 +6,14 @@ export default function App({...serverState}) {
   const pages = import.meta.globEager('./pages/**/*.server.[jt]sx');
 
   return (
-    <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
-      <Suspense fallback={'Loading...'}>
-        <Switch>
-          <DefaultRoutes
-            pages={pages}
-            serverState={serverState}
-            fallback="Not Found"
-          />
-        </Switch>
-      </Suspense>
-    </ShopifyServerProvider>
+    <Suspense fallback={'Loading...'}>
+      <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
+        <DefaultRoutes
+          pages={pages}
+          serverState={serverState}
+          fallback="Not Found"
+        />
+      </ShopifyServerProvider>
+    </Suspense>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10594,6 +10594,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"


### PR DESCRIPTION
RSC doesn't yet support server context, so we need to remove all context on the server
to support the official RSC.

### Additional context

This POC's option 3 inside the RFC Doc (not yet public): https://docs.google.com/document/d/1rZlAvAIymBKIjs0tJCo3dRLWvtgHuA3f5VQsuFza7iU/edit

If we decide to implement our own router in the client as well, this PR will still provide a good starting point, because RR is gone from the server.

I have not yet updated the docs or added tests.

This PR does introduce breaking changes, most importantly:

1. Remove `<Switch>` from `App.server.jsx`
2. Remove any references to `useParams()` from `react-router-dom` in all server components. Instead, `params` is now passed as a property to the root page server component.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
