### PR TITLE
feat: support streaming in Workers runtimes where streaming is supported

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- feat: add support for streaming in Workers runtimes where streaming is supported
 
 ## 0.7.1 - 2021-12-02
 

--- a/packages/hydrogen/src/framework/runtime.ts
+++ b/packages/hydrogen/src/framework/runtime.ts
@@ -42,3 +42,12 @@ export function runDelayedFunction(fn: () => Promise<any>) {
 
   return context.waitUntil(fn());
 }
+
+export function supportsReadableStream() {
+  try {
+    new ReadableStream();
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR updates `handle-event` and `entry-server` logic to support streaming in Workers runtimes where `ReadableStream` is supported.

Previously, we only streamed responses back to Node.js runtimes where we had a pipeable `response` object.

Fixes #101 

### Additional context

A lot going on here! Here's a breakdown of what's happening:

- We update the `isStreamable` logic in `handle-event` to account for supporting `ReadableStream`
- We now `return` the values of `stream` and `hydrate`
- In `entry-server`, we refactor bodies of `stream` and `hydrate` to call `streamToWorkerResponse` and `streamToNodeResponse`
- In each of `streamToWorkerResponse` and `streamToNodeResponse`, we add various checks and forks to account for variability in response types. For example, we need to allow a developer to prevent streaming in order to return a custom page response. And for `/react` hydration requests, we need to buffer the responses and then pipe them through our wire syntax converter before responding.

**Note**: There is an open React bug which prevents proper streaming in workers runtimes. We'll want to hold off on shipping this until that is resolved. https://github.com/facebook/react/issues/22772

**Note**: Oxygen technically supports `ReadableStream` via polyfill, but official streaming is not yet supported. We need to find out if shipping this before official support lands will cause issues. E.g. will it just buffer and return the response like normal? cc @maxshirshin **UPDATE**: I tested it with `oxygen-run` and It works just fine 🔥 😎 

### 🎩 Tophat instructions

1. `cd packages/playground/server-components-worker`
2. `yarn build && yarn dev`

Notice that the contents stream in real fast 🔥 

To spice things up, you should update the `index.server.jsx` component to make a query and witness the Suspense fallback on the page as the content streams in:

```jsx
import {Link, useShopQuery} from '@shopify/hydrogen';

export default function Index() {
  const {data} = useShopQuery({query: `query { shop { name } }`});

  return (
    <>
      <h1>Home: {data.shop.name}</h1>
      <Link className="btn" to="/about">
        About
      </Link>
    </>
  );
}
```

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
