### PR TITLE
feat: Generate component overview tables in shopify-dev docs

### DIFF
--- a/packages/generate-docs/src/DocsGen.ts
+++ b/packages/generate-docs/src/DocsGen.ts
@@ -317,11 +317,13 @@ function getComponentType(path: string) {
     if (require.resolve(`${path}.client.tsx`)) {
       return 'Client';
     }
+  } catch {}
 
+  try {
     if (require.resolve(`${path}.server.tsx`)) {
       return 'Server';
     }
-  } catch {
-    return 'Shared';
-  }
+  } catch {}
+
+  return 'Shared';
 }

--- a/packages/generate-docs/src/index.ts
+++ b/packages/generate-docs/src/index.ts
@@ -1,1 +1,2 @@
 export {DocsGen, Options} from './DocsGen';
+export {Column} from './types';

--- a/packages/generate-docs/src/types.ts
+++ b/packages/generate-docs/src/types.ts
@@ -1,3 +1,9 @@
+export enum Column {
+  ComponentName = 'Component name',
+  ComponentType = 'Component type',
+  Description = 'Description',
+}
+
 export interface Packages {
   [key: string]: string;
 }

--- a/packages/hydrogen/src/components/CartEstimatedCost/CartEstimatedCost.client.tsx
+++ b/packages/hydrogen/src/components/CartEstimatedCost/CartEstimatedCost.client.tsx
@@ -11,7 +11,7 @@ export interface CartEstimatedCostProps {
 }
 
 /**
- * The [CartEstimatedCost](/api/storefront/reference/cart/cartestimatedcost) component renders a `Money` component with the
+ * The `CartEstimatedCost` component renders a `Money` component with the
  * cost associated with the `amountType` prop. If no `amountType` prop is specified, then it defaults to `totalAmount`.
  * If `children` is a function, then it will pass down the render props provided by the parent component.
  */

--- a/packages/hydrogen/src/components/CartEstimatedCost/README.md
+++ b/packages/hydrogen/src/components/CartEstimatedCost/README.md
@@ -1,6 +1,6 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/components/CartEstimatedCost and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/master/content/internal/operations/hydrogen-reference-docs.md. -->
 
-The [CartEstimatedCost](/api/storefront/reference/cart/cartestimatedcost) component renders a `Money` component with the
+The `CartEstimatedCost` component renders a `Money` component with the
 cost associated with the `amountType` prop. If no `amountType` prop is specified, then it defaults to `totalAmount`.
 If `children` is a function, then it will pass down the render props provided by the parent component.
 

--- a/packages/hydrogen/src/components/LocalizationProvider/index.ts
+++ b/packages/hydrogen/src/components/LocalizationProvider/index.ts
@@ -1,2 +1,3 @@
+export {LocalizationProvider} from './LocalizationProvider.server';
 export {useCountry} from '../../hooks/useCountry/useCountry';
 export {useAvailableCountries} from '../../hooks/useAvailableCountries/useAvailableCountries';

--- a/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
+++ b/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
@@ -12,9 +12,7 @@ export interface ProductPriceProps {
 
 /**
  * The `ProductPrice` component renders a `Money` component with the product
- * [`priceRange`](/api/storefront/reference/products/productpricerange)'s `maxVariantPrice`
- * or `minVariantPrice`, for either the regular price or compare at price range.
- * It must be a descendent of the `ProductProvider` component.
+ * [`priceRange`](/api/storefront/reference/products/productpricerange)'s `maxVariantPrice` or `minVariantPrice`, for either the regular price or compare at price range. It must be a descendent of the `ProductProvider` component.
  */
 export function ProductPrice<TTag extends ElementType>(
   props: Props<TTag> & ProductPriceProps

--- a/packages/hydrogen/src/components/ProductPrice/README.md
+++ b/packages/hydrogen/src/components/ProductPrice/README.md
@@ -1,9 +1,7 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/components/ProductPrice and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/master/content/internal/operations/hydrogen-reference-docs.md. -->
 
 The `ProductPrice` component renders a `Money` component with the product
-[`priceRange`](/api/storefront/reference/products/productpricerange)'s `maxVariantPrice`
-or `minVariantPrice`, for either the regular price or compare at price range.
-It must be a descendent of the `ProductProvider` component.
+[`priceRange`](/api/storefront/reference/products/productpricerange)'s `maxVariantPrice` or `minVariantPrice`, for either the regular price or compare at price range. It must be a descendent of the `ProductProvider` component.
 
 ## Example code
 

--- a/packages/hydrogen/src/components/UnitPrice/README.md
+++ b/packages/hydrogen/src/components/UnitPrice/README.md
@@ -1,8 +1,7 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/components/UnitPrice and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/master/content/internal/operations/hydrogen-reference-docs.md. -->
 
 The `UnitPrice` component renders a string with a [UnitPrice](/themes/pricing-payments/unit-pricing) as the
-[Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from
-the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
+[Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
 
 If `children` is a function, then it will provide render props for the `children` corresponding to the object
 returned by the `useMoney` hook and the `UnitPriceMeasurement` object.

--- a/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
@@ -18,8 +18,7 @@ export interface UnitPriceProps {
 
 /**
  * The `UnitPrice` component renders a string with a [UnitPrice](/themes/pricing-payments/unit-pricing) as the
- * [Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from
- * the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
+ * [Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
  *
  * If `children` is a function, then it will provide render props for the `children` corresponding to the object
  * returned by the `useMoney` hook and the `UnitPriceMeasurement` object.

--- a/packages/hydrogen/src/foundation/useQuery/README.md
+++ b/packages/hydrogen/src/foundation/useQuery/README.md
@@ -34,8 +34,8 @@ The `useQuery` hook takes the following arguments:
 
 The `options` object accepts the following properties:
 
-| Key     | Required | Description                                                                             |
-| ------- | -------- | --------------------------------------------------------------------------------------- |
+| Key     | Required | Description                                                                                            |
+| ------- | -------- | ------------------------------------------------------------------------------------------------------ |
 | `cache` | No       | An object describing the [cache policy](/custom-storefronts/hydrogen/framework/cache) for the request. |
 
 ## Related hooks

--- a/packages/hydrogen/src/hooks/useCountry/README.md
+++ b/packages/hydrogen/src/hooks/useCountry/README.md
@@ -49,7 +49,7 @@ This hook returns an array with the following elements:
 
 ## Related components
 
-- [`LocalizationProvider`](/api/hydrogen/components/cart/cartprovider)
+- [`LocalizationProvider`](/api/hydrogen/components/localization/localizationprovider)
 
 ## Related hooks
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -96,7 +96,8 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     // Primitive
     generator.section({
       title: 'Primitive components',
-      intro: 'Primitive components are the building blocks for different component types, including products, variants, and cart.',
+      intro:
+        'Primitive components are the building blocks for different component types, including products, variants, and cart.',
       description:
         'Get familiar with the primitive components included in Hydrogen.',
       url: '/api/hydrogen/components/primitive/index.md',
@@ -117,7 +118,8 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     // Global
     generator.section({
       title: 'Global components',
-      intro: 'Global components are React components that relate to your entire app.',
+      intro:
+        'Global components are React components that relate to your entire app.',
       description:
         'Get familiar with the global components included in Hydrogen.',
       url: '/api/hydrogen/components/global/index.md',
@@ -127,7 +129,8 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     // Product and variant
     generator.section({
       title: 'Product and variant components',
-      intro: 'Products are the goods, digital downloads, services, and gift cards that a merchant sells. If a product has options, like size or color, then merchants can add a variant for each combination of options. Each combination of option values for a product can be a variant for that product. For example, a t-shirt might be available for purchase in blue and green. The blue t-shirt and the green t-shirt are variants.',
+      intro:
+        'Products are the goods, digital downloads, services, and gift cards that a merchant sells. If a product has options, like size or color, then merchants can add a variant for each combination of options. Each combination of option values for a product can be a variant for that product. For example, a t-shirt might be available for purchase in blue and green. The blue t-shirt and the green t-shirt are variants.',
       description:
         'Get familiar with the product and variant components included in Hydrogen.',
       url: '/api/hydrogen/components/product-variant/index.md',
@@ -177,7 +180,8 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     // Localization
     generator.section({
       title: 'Localization components',
-      intro: 'Localization can help merchants expand their business to a global audience by creating shopping experiences in local languages and currencies.',
+      intro:
+        'Localization can help merchants expand their business to a global audience by creating shopping experiences in local languages and currencies.',
       description:
         'Get familiar with the localization components included in Hydrogen.',
       url: '/api/hydrogen/components/localization/index.md',

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -365,7 +365,6 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
 }
 
 export default async function runAll(args: Partial<Options> = {}) {
-  // return Promise.all([runCliGenerator(args)]).catch(
   return Promise.all([runHydrogenGenerator(args), runCliGenerator(args)]).catch(
     (error) => {
       logger.error(error);

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,6 +1,6 @@
 import {resolve} from 'path';
 // eslint-disable-next-line node/no-missing-import
-import {DocsGen, Options} from '../packages/generate-docs';
+import {DocsGen, Options, Column} from '../packages/generate-docs';
 
 const ROOT = resolve('.');
 const logger = console;
@@ -10,6 +10,12 @@ async function runCliGenerator(args: Partial<Options> = {}) {
     inputRootPath: ROOT,
     packageName: 'cli',
     ...args,
+  });
+
+  const CommandsTable = await cliGenerator.table({
+    title: 'Commands',
+    description: 'The Hydrogen CLI has the following commands',
+    columns: [Column.ComponentName, Column.Description],
   });
 
   await Promise.all([
@@ -26,7 +32,7 @@ async function runCliGenerator(args: Partial<Options> = {}) {
       description: 'Command reference for the `@shopify/hydrogen-cli`',
       url: '/api/hydrogen/cli/commands/index.md',
       entry: 'commands',
-      tableColumns: ['Command', 'Description'],
+      tables: [CommandsTable],
       hidden: true,
     }),
     cliGenerator.section({
@@ -34,11 +40,16 @@ async function runCliGenerator(args: Partial<Options> = {}) {
       description: 'Create command reference from the `@shopify/hydrogen-cli`',
       url: '/api/hydrogen/cli/commands/create/index.md',
       entry: 'commands/create',
-      tableColumns: ['Command', 'Description'],
       hidden: true,
+      tables: [CommandsTable],
     }),
   ]);
 }
+
+const COMPONENTS_TABLE = {
+  title: 'Reference',
+  columns: [Column.ComponentName, Column.ComponentType, Column.Description],
+};
 
 async function runHydrogenGenerator(args: Partial<Options> = {}) {
   const generator = new DocsGen({
@@ -46,6 +57,33 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     packageName: 'hydrogen',
     ...args,
   });
+
+  // Tables
+  const primitiveComponentsTable = await generator.table({
+    ...COMPONENTS_TABLE,
+    description: 'Hydrogen includes the following primitive components:',
+  });
+
+  const cartComponentsTable = await generator.table({
+    ...COMPONENTS_TABLE,
+    description: 'Hydrogen includes the following cart components:',
+  });
+
+  const productAndVariantTable = await generator.table({
+    ...COMPONENTS_TABLE,
+    description:
+      'Hydrogen includes the following product and variant components:',
+  });
+
+  const localizationTable = await generator.table({
+    ...COMPONENTS_TABLE,
+    description: 'Hydrogen includes the following localization components:',
+  });
+  const globalComponentsTable = await generator.table({
+    ...COMPONENTS_TABLE,
+    description: 'Hydrogen includes the following global components:',
+  });
+
   await Promise.all([
     // Components
     generator.section({
@@ -59,7 +97,7 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     generator.section({
       title: 'Primitive',
       description:
-        'Get familiar with the Hydrogen primitive components included in Hydrogen.',
+        'Primitive components are the building blocks for different component types, including products, variants, and cart.',
       url: '/api/hydrogen/components/primitive/index.md',
       entry: [
         'components/ExternalVideo',
@@ -73,6 +111,7 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'components/UnitPrice',
         'components/Video',
       ],
+      tables: [primitiveComponentsTable],
     }),
     // Global
     generator.section({
@@ -80,7 +119,8 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
       description:
         'Get familiar with the Hydrogen global components included in Hydrogen.',
       url: '/api/hydrogen/components/global/index.md',
-      entry: 'foundation/ShopifyProvider',
+      entry: ['foundation/ShopifyProvider'],
+      tables: [globalComponentsTable],
     }),
     // Product and variant
     generator.section({
@@ -102,10 +142,13 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'components/SelectedVariantShopPayButton',
         'components/SelectedVariantUnitPrice',
       ],
+      tables: [productAndVariantTable],
     }),
     // Cart
     generator.section({
-      title: 'Cart',
+      title: 'Cart components',
+      intro:
+        'A cart contains the merchandise that a customer intends to purchase and the estimated cost associated with the cart. When a customer is ready to purchase their items, they can proceed to checkout.',
       description:
         'Get familiar with the Hydrogen cart components included in Hydrogen.',
       url: '/api/hydrogen/components/cart/index.md',
@@ -126,6 +169,7 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'components/CartProvider',
         'components/CartShopPayButton',
       ],
+      tables: [cartComponentsTable],
     }),
     // Localization
     generator.section({
@@ -133,7 +177,8 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
       description:
         'Get familiar with the Hydrogen localization components included in Hydrogen.',
       url: '/api/hydrogen/components/localization/index.md',
-      entry: 'components/LocalizationProvider',
+      entry: ['components/LocalizationProvider'],
+      tables: [localizationTable],
     }),
 
     // Hooks
@@ -312,6 +357,7 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
 }
 
 export default async function runAll(args: Partial<Options> = {}) {
+  // return Promise.all([runCliGenerator(args)]).catch(
   return Promise.all([runHydrogenGenerator(args), runCliGenerator(args)]).catch(
     (error) => {
       logger.error(error);

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -95,9 +95,10 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     }),
     // Primitive
     generator.section({
-      title: 'Primitive',
+      title: 'Primitive components',
+      intro: 'Primitive components are the building blocks for different component types, including products, variants, and cart.',
       description:
-        'Primitive components are the building blocks for different component types, including products, variants, and cart.',
+        'Get familiar with the primitive components included in Hydrogen.',
       url: '/api/hydrogen/components/primitive/index.md',
       entry: [
         'components/ExternalVideo',
@@ -115,18 +116,20 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     }),
     // Global
     generator.section({
-      title: 'Global',
+      title: 'Global components',
+      intro: 'Global components are React components that relate to your entire app.',
       description:
-        'Get familiar with the Hydrogen global components included in Hydrogen.',
+        'Get familiar with the global components included in Hydrogen.',
       url: '/api/hydrogen/components/global/index.md',
       entry: ['foundation/ShopifyProvider'],
       tables: [globalComponentsTable],
     }),
     // Product and variant
     generator.section({
-      title: 'Product and variant',
+      title: 'Product and variant components',
+      intro: 'Products are the goods, digital downloads, services, and gift cards that a merchant sells. If a product has options, like size or color, then merchants can add a variant for each combination of options. Each combination of option values for a product can be a variant for that product. For example, a t-shirt might be available for purchase in blue and green. The blue t-shirt and the green t-shirt are variants.',
       description:
-        'Get familiar with the Hydrogen product and variant components included in Hydrogen.',
+        'Get familiar with the product and variant components included in Hydrogen.',
       url: '/api/hydrogen/components/product-variant/index.md',
       entry: [
         'components/ProductDescription',
@@ -150,7 +153,7 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
       intro:
         'A cart contains the merchandise that a customer intends to purchase and the estimated cost associated with the cart. When a customer is ready to purchase their items, they can proceed to checkout.',
       description:
-        'Get familiar with the Hydrogen cart components included in Hydrogen.',
+        'Get familiar with the cart components included in Hydrogen.',
       url: '/api/hydrogen/components/cart/index.md',
       entry: [
         'components/AddToCartButton',
@@ -173,9 +176,10 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
     }),
     // Localization
     generator.section({
-      title: 'Localization',
+      title: 'Localization components',
+      intro: 'Localization can help merchants expand their business to a global audience by creating shopping experiences in local languages and currencies.',
       description:
-        'Get familiar with the Hydrogen localization components included in Hydrogen.',
+        'Get familiar with the localization components included in Hydrogen.',
       url: '/api/hydrogen/components/localization/index.md',
       entry: ['components/LocalizationProvider'],
       tables: [localizationTable],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a new method on the `DocsGen` Class for producing the tables of components found on overview pages, such as:

- https://shopify.dev/api/hydrogen/components/localization
- https://shopify.dev/api/hydrogen/components/primitive
- https://shopify.dev/api/hydrogen/components/cart
- https://shopify.dev/api/hydrogen/components/localization
- https://shopify.dev/api/hydrogen/components/global

### Additional context

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
