### PR TITLE
fix(#253): update to react-helmet-async version that doesn't need context

### DIFF
--- a/packages/dev/src/App.server.jsx
+++ b/packages/dev/src/App.server.jsx
@@ -16,7 +16,7 @@ export default function App({...serverState}) {
     <Suspense fallback={<LoadingFallback />}>
       <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
         <CartProvider>
-          <DefaultSeo />
+          <DefaultSeo helmetData={serverState.helmetData} />
           <Switch>
             <DefaultRoutes
               pages={pages}

--- a/packages/dev/src/components/DefaultSeo.server.jsx
+++ b/packages/dev/src/components/DefaultSeo.server.jsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import Seo from './Seo.client';
 
-export default function SeoServer() {
+export default function DefaultSeo({helmetData}) {
   const {
     data: {
       shop: {name: shopName},
@@ -13,7 +13,7 @@ export default function SeoServer() {
     cache: {maxAge: 60 * 60 * 12, staleWhileRevalidate: 60 * 60 * 12},
   });
 
-  return <Seo shopName={shopName} />;
+  return <Seo shopName={shopName} helmetData={helmetData} />;
 }
 
 const QUERY = gql`

--- a/packages/dev/src/components/ProductDetails.client.jsx
+++ b/packages/dev/src/components/ProductDetails.client.jsx
@@ -104,12 +104,12 @@ function SizeChart() {
   );
 }
 
-export default function ProductDetails({product}) {
+export default function ProductDetails({product, helmetData}) {
   const initialVariant = flattenConnection(product.variants)[0];
 
   return (
     <>
-      <Seo product={product} />
+      <Seo product={product} helmetData={helmetData} />
       <Product product={product} initialVariantId={initialVariant.id}>
         <div className="grid grid-cols-1 md:grid-cols-[2fr,1fr] gap-x-8 my-16">
           <div className="md:hidden mt-5 mb-8">

--- a/packages/dev/src/components/Seo.client.jsx
+++ b/packages/dev/src/components/Seo.client.jsx
@@ -1,6 +1,6 @@
 import {useShop, Helmet} from '@shopify/hydrogen/client';
 
-export default function Seo({shopName, product}) {
+export default function Seo({shopName, product, helmetData}) {
   const {locale} = useShop();
   const lang = locale.split(/[-_]/)[0];
 
@@ -15,7 +15,7 @@ export default function Seo({shopName, product}) {
     const url = typeof window === 'undefined' ? '' : window.location.href;
 
     return (
-      <Helmet>
+      <Helmet helmetData={helmetData}>
         <title>{title}</title>
         <meta name="description" content={description} />
         {url && <meta property="og:url" content={url} />}
@@ -65,7 +65,11 @@ export default function Seo({shopName, product}) {
    * Useful for placing in the "main" <App> container.
    */
   return (
-    <Helmet defaultTitle={shopName} titleTemplate={`%s - ${shopName}`}>
+    <Helmet
+      defaultTitle={shopName}
+      titleTemplate={`%s - ${shopName}`}
+      helmetData={helmetData}
+    >
       <html lang={lang} />
       <meta property="og:site_name" content={shopName} />
     </Helmet>

--- a/packages/dev/src/pages/products/[handle].server.jsx
+++ b/packages/dev/src/pages/products/[handle].server.jsx
@@ -6,7 +6,7 @@ import ProductDetails from '../../components/ProductDetails.client';
 import NotFound from '../../components/NotFound.server';
 import Layout from '../../components/Layout.server';
 
-export default function Product({country = {isoCode: 'US'}}) {
+export default function Product({country = {isoCode: 'US'}, helmetData}) {
   const {handle} = useParams();
 
   const {data} = useShopQuery({
@@ -23,7 +23,7 @@ export default function Product({country = {isoCode: 'US'}}) {
 
   return (
     <Layout>
-      <ProductDetails product={data.product} />
+      <ProductDetails product={data.product} helmetData={helmetData} />
     </Layout>
   );
 }

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -94,7 +94,7 @@
     "magic-string": "^0.25.7",
     "node-fetch": "^2.6.1",
     "react-error-boundary": "^3.1.3",
-    "react-helmet-async": "^1.0.9",
+    "react-helmet-async": "^1.2.2",
     "react-query": "^3.18.1",
     "react-ssr-prepass": "^1.4.0",
     "vite-plugin-inspect": "^0.3.6"

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -4,7 +4,6 @@ import {createRoot} from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 import type {ClientHandler} from './types';
 import {ErrorBoundary} from 'react-error-boundary';
-import {HelmetProvider} from 'react-helmet-async';
 import {useServerResponse} from './framework/Hydration/Cache.client';
 import {ServerStateProvider, ServerStateRouter} from './client';
 import {QueryProvider} from './hooks';
@@ -30,6 +29,8 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
 
 export default renderHydrogen;
 
+// trigger
+
 function Content({clientWrapper: ClientWrapper}: {clientWrapper: any}) {
   const [serverState, setServerState] = useState({
     pathname: window.location.pathname,
@@ -43,13 +44,11 @@ function Content({clientWrapper: ClientWrapper}: {clientWrapper: any}) {
       setServerState={setServerState}
     >
       <QueryProvider>
-        <HelmetProvider>
-          <BrowserRouter>
-            <ServerStateRouter />
-            {/* @ts-ignore */}
-            <ClientWrapper>{response.read()}</ClientWrapper>
-          </BrowserRouter>
-        </HelmetProvider>
+        <BrowserRouter>
+          <ServerStateRouter />
+          {/* @ts-ignore */}
+          <ClientWrapper>{response.read()}</ClientWrapper>
+        </BrowserRouter>
       </QueryProvider>
     </ServerStateProvider>
   );

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -12,7 +12,7 @@ import type {ServerHandler} from './types';
 import {HydrationContext} from './framework/Hydration/HydrationContext.server';
 import type {ReactQueryHydrationContext} from './foundation/ShopifyProvider/types';
 import {generateWireSyntaxFromRenderedHtml} from './framework/Hydration/wire.server';
-import {FilledContext, HelmetProvider} from 'react-helmet-async';
+import {FilledContext, HelmetData} from 'react-helmet-async';
 import {Html} from './framework/Hydration/Html';
 import {HydrationWriter} from './framework/Hydration/writer.server';
 import {Renderer, Hydrator, Streamer} from './types';
@@ -260,9 +260,12 @@ function buildReactApp({
       location={{pathname: state.pathname, search: state.search}}
       context={context}
     >
-      <HelmetProvider context={helmetContext}>
-        <App {...props} request={request} response={componentResponse} />
-      </HelmetProvider>
+      <App
+        {...props}
+        request={request}
+        response={componentResponse}
+        helmetData={new HelmetData(helmetContext)}
+      />
     </StaticRouter>
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11178,10 +11178,10 @@ react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet-async@^1.0.9:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.1.2.tgz#653b7e6bbfdd239c5dcd6b8df2811c7a363b8334"
-  integrity sha512-LTTzDDkyIleT/JJ6T/uqx7Y8qi1EuPPSiJawQY/nHHz0h7SPDT6HxP1YDDQx/fzcVxCqpWEEMS3QdrSrNkJYhg==
+react-helmet-async@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.2.2.tgz#38d58d32ebffbc01ba42b5ad9142f85722492389"
+  integrity sha512-XgSQezeCbLfCxdZhDA3T/g27XZKnOYyOkruopTLSJj8RvFZwdXnM4djnfYaiBSDzOidDgTo1jcEozoRu/+P9UQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     invariant "^2.2.4"


### PR DESCRIPTION
### Description

Instead of relying on context, a `reactHelmet` data object is provided to every root page component. That object needs to be passed to any instance of the `<DefaultSeo>` or `<Seo>` component.

See https://github.com/staylor/react-helmet-async#usage-without-context for guidance on how it is implemented here.

**NOTE: This is a breaking change**

Removing context from entry-server.tsx and entry-client.tsx means that customers will have to update their `<Seo>` and `<DefaultSeo>` components to access a new `helmetData` object that is passed to the root page server components.

### Additional context

Tophat considerations

1. Make sure navigating to and from a product detail page updates the title in the browser.
2. Make sure that the page SSR's with the proper title. Go to a product detail page. View page source. Then update the source URL to include `?_bot`. Make sure the source code has a `<title>` tag that includes the product name.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
