### PR TITLE
chore: skip flaky test for productivity reasons

### DIFF
--- a/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
@@ -18,6 +18,7 @@ describe('<StarRating />', () => {
 
   /**
    * TODO: Fix the flakiness of this test, likely due to floating point math :)
+   * https://github.com/Shopify/hydrogen/issues/19
    */
   it.skip('renders the number of filled stars corresponding to the rating value', () => {
     const rating = getParsedMetafield({type: 'rating'});

--- a/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
@@ -16,7 +16,10 @@ describe('<StarRating />', () => {
     expect(component).toContainReactComponentTimes(Star, range);
   });
 
-  it('renders the number of filled stars corresponding to the rating value', () => {
+  /**
+   * TODO: Fix the flakiness of this test, likely due to floating point math :)
+   */
+  it.skip('renders the number of filled stars corresponding to the rating value', () => {
     const rating = getParsedMetafield({type: 'rating'});
     const component = mount(<StarRating rating={rating.value as Rating} />);
 


### PR DESCRIPTION
We have a ticket to revisit this #19

But in the meantime, this is hurting our productivity, as CI randomly fails in GH.