### PR TITLE
Remove Server Context

### DIFF
--- a/packages/cli/src/commands/create/app/templates/App-server-jsx.ts
+++ b/packages/cli/src/commands/create/app/templates/App-server-jsx.ts
@@ -15,13 +15,11 @@ export default function () {
     return (
       <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
         <Suspense fallback="Loading...">
-          <Switch>
-            <DefaultRoutes
-              pages={pages}
-              serverState={serverState}
-              fallback={() => <div>Not found</div>}
-            />
-          </Switch>
+          <DefaultRoutes
+            pages={pages}
+            serverState={serverState}
+            fallback={() => <div>Not found</div>}
+          />
         </Suspense>
       </ShopifyServerProvider>
     );

--- a/packages/dev/src/App.server.jsx
+++ b/packages/dev/src/App.server.jsx
@@ -16,7 +16,7 @@ export default function App({...serverState}) {
     <Suspense fallback={<LoadingFallback />}>
       <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
         <CartProvider>
-          <DefaultSeo />
+          <DefaultSeo helmetData={serverState.helmetData} />
           <Switch>
             <DefaultRoutes
               pages={pages}

--- a/packages/dev/src/App.server.jsx
+++ b/packages/dev/src/App.server.jsx
@@ -1,5 +1,4 @@
 import {ShopifyServerProvider, DefaultRoutes} from '@shopify/hydrogen';
-import {Switch} from 'react-router-dom';
 import {Suspense} from 'react';
 
 import shopifyConfig from '../shopify.config';
@@ -17,13 +16,11 @@ export default function App({...serverState}) {
       <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
         <CartProvider>
           <DefaultSeo helmetData={serverState.helmetData} />
-          <Switch>
-            <DefaultRoutes
-              pages={pages}
-              serverState={serverState}
-              fallback={<NotFound />}
-            />
-          </Switch>
+          <DefaultRoutes
+            pages={pages}
+            serverState={serverState}
+            fallback={<NotFound />}
+          />
         </CartProvider>
       </ShopifyServerProvider>
     </Suspense>

--- a/packages/dev/src/components/DefaultSeo.server.jsx
+++ b/packages/dev/src/components/DefaultSeo.server.jsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 import Seo from './Seo.client';
 
-export default function SeoServer() {
+export default function DefaultSeo({helmetData}) {
   const {
     data: {
       shop: {name: shopName},
@@ -13,7 +13,7 @@ export default function SeoServer() {
     cache: {maxAge: 60 * 60 * 12, staleWhileRevalidate: 60 * 60 * 12},
   });
 
-  return <Seo shopName={shopName} />;
+  return <Seo shopName={shopName} helmetData={helmetData} />;
 }
 
 const QUERY = gql`

--- a/packages/dev/src/components/ProductDetails.client.jsx
+++ b/packages/dev/src/components/ProductDetails.client.jsx
@@ -104,12 +104,12 @@ function SizeChart() {
   );
 }
 
-export default function ProductDetails({product}) {
+export default function ProductDetails({product, helmetData}) {
   const initialVariant = flattenConnection(product.variants)[0];
 
   return (
     <>
-      <Seo product={product} />
+      <Seo product={product} helmetData={helmetData} />
       <Product product={product} initialVariantId={initialVariant.id}>
         <div className="grid grid-cols-1 md:grid-cols-[2fr,1fr] gap-x-8 my-16">
           <div className="md:hidden mt-5 mb-8">

--- a/packages/dev/src/components/Seo.client.jsx
+++ b/packages/dev/src/components/Seo.client.jsx
@@ -1,6 +1,6 @@
 import {useShop, Helmet} from '@shopify/hydrogen/client';
 
-export default function Seo({shopName, product}) {
+export default function Seo({shopName, product, helmetData}) {
   const {locale} = useShop();
   const lang = locale.split(/[-_]/)[0];
 
@@ -15,7 +15,7 @@ export default function Seo({shopName, product}) {
     const url = typeof window === 'undefined' ? '' : window.location.href;
 
     return (
-      <Helmet>
+      <Helmet helmetData={helmetData}>
         <title>{title}</title>
         <meta name="description" content={description} />
         {url && <meta property="og:url" content={url} />}
@@ -65,7 +65,11 @@ export default function Seo({shopName, product}) {
    * Useful for placing in the "main" <App> container.
    */
   return (
-    <Helmet defaultTitle={shopName} titleTemplate={`%s - ${shopName}`}>
+    <Helmet
+      defaultTitle={shopName}
+      titleTemplate={`%s - ${shopName}`}
+      helmetData={helmetData}
+    >
       <html lang={lang} />
       <meta property="og:site_name" content={shopName} />
     </Helmet>

--- a/packages/dev/src/pages/collections/[handle].server.jsx
+++ b/packages/dev/src/pages/collections/[handle].server.jsx
@@ -5,7 +5,6 @@ import {
   flattenConnection,
   RawHtml,
 } from '@shopify/hydrogen';
-import {useParams} from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import LoadMoreProducts from '../../components/LoadMoreProducts.client';
@@ -16,8 +15,9 @@ import NotFound from '../../components/NotFound.server';
 export default function Collection({
   country = {isoCode: 'US'},
   collectionProductCount = 24,
+  params,
 }) {
-  const {handle} = useParams();
+  const {handle} = params;
   const {data} = useShopQuery({
     query: QUERY,
     variables: {

--- a/packages/dev/src/pages/pages/[handle].server.jsx
+++ b/packages/dev/src/pages/pages/[handle].server.jsx
@@ -1,12 +1,11 @@
-import {useParams} from 'react-router-dom';
 import {useShopQuery, RawHtml} from '@shopify/hydrogen';
 import gql from 'graphql-tag';
 
 import Layout from '../../components/Layout.server';
 import NotFound from '../../components/NotFound.server';
 
-export default function Page() {
-  const {handle} = useParams();
+export default function Page({params}) {
+  const {handle} = params;
   const {data} = useShopQuery({query: QUERY, variables: {handle}});
 
   if (!data.pageByHandle) {

--- a/packages/dev/src/pages/products/[handle].server.jsx
+++ b/packages/dev/src/pages/products/[handle].server.jsx
@@ -6,7 +6,7 @@ import ProductDetails from '../../components/ProductDetails.client';
 import NotFound from '../../components/NotFound.server';
 import Layout from '../../components/Layout.server';
 
-export default function Product({country = {isoCode: 'US'}}) {
+export default function Product({country = {isoCode: 'US'}, helmetData}) {
   const {handle} = useParams();
 
   const {data} = useShopQuery({
@@ -23,7 +23,7 @@ export default function Product({country = {isoCode: 'US'}}) {
 
   return (
     <Layout>
-      <ProductDetails product={data.product} />
+      <ProductDetails product={data.product} helmetData={helmetData} />
     </Layout>
   );
 }

--- a/packages/dev/src/pages/products/[handle].server.jsx
+++ b/packages/dev/src/pages/products/[handle].server.jsx
@@ -1,13 +1,16 @@
 import {useShopQuery, ProductProviderFragment} from '@shopify/hydrogen';
-import {useParams} from 'react-router-dom';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';
 import NotFound from '../../components/NotFound.server';
 import Layout from '../../components/Layout.server';
 
-export default function Product({country = {isoCode: 'US'}, helmetData}) {
-  const {handle} = useParams();
+export default function Product({
+  country = {isoCode: 'US'},
+  params,
+  helmetData,
+}) {
+  const {handle} = params;
 
   const {data} = useShopQuery({
     query: QUERY,

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -84,6 +84,7 @@
     "vite": "^2.7.0"
   },
   "dependencies": {
+    "path-to-regexp": "^6.2.0",
     "@vitejs/plugin-react": "^1.1.1",
     "connect": "^3.7.0",
     "es-module-lexer": "^0.9.0",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -95,7 +95,8 @@
     "magic-string": "^0.25.7",
     "node-fetch": "^2.6.1",
     "react-error-boundary": "^3.1.3",
-    "react-helmet-async": "^1.0.9",
+    "react-helmet-async": "^1.2.2",
+    "react-query": "^3.18.1",
     "react-ssr-prepass": "^1.4.0",
     "vite-plugin-inspect": "^0.3.6"
   }

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -1,1 +1,11 @@
-export {Link} from 'react-router-dom';
+import React from 'react';
+import {isServer} from '../../utilities';
+import {Link as RRLink} from 'react-router-dom';
+
+export function Link(props: any) {
+  return isServer() ? (
+    <a href={props.to} {...props} to={null} />
+  ) : (
+    <RRLink {...props} />
+  );
+}

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -28,8 +28,6 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
 
 export default renderHydrogen;
 
-// trigger
-
 function Content({clientWrapper: ClientWrapper}: {clientWrapper: any}) {
   const [serverState, setServerState] = useState({
     pathname: window.location.pathname,

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -4,7 +4,6 @@ import {createRoot} from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 import type {ClientHandler} from './types';
 import {ErrorBoundary} from 'react-error-boundary';
-import {HelmetProvider} from 'react-helmet-async';
 import {useServerResponse} from './framework/Hydration/Cache.client';
 import {ServerStateProvider, ServerStateRouter} from './client';
 
@@ -29,6 +28,8 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
 
 export default renderHydrogen;
 
+// trigger
+
 function Content({clientWrapper: ClientWrapper}: {clientWrapper: any}) {
   const [serverState, setServerState] = useState({
     pathname: window.location.pathname,
@@ -41,13 +42,11 @@ function Content({clientWrapper: ClientWrapper}: {clientWrapper: any}) {
       serverState={serverState}
       setServerState={setServerState}
     >
-      <HelmetProvider>
-        <BrowserRouter>
-          <ServerStateRouter />
-          {/* @ts-ignore */}
-          <ClientWrapper>{response.read()}</ClientWrapper>
-        </BrowserRouter>
-      </HelmetProvider>
+      <BrowserRouter>
+        <ServerStateRouter />
+        {/* @ts-ignore */}
+        <ClientWrapper>{response.read()}</ClientWrapper>
+      </BrowserRouter>
     </ServerStateProvider>
   );
 }

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -7,7 +7,6 @@ import {
 import {renderToString} from 'react-dom/server';
 import {getErrorMarkup} from './utilities/error';
 import ssrPrepass from 'react-ssr-prepass';
-import {StaticRouter} from 'react-router-dom';
 import type {ServerHandler} from './types';
 import {HydrationContext} from './framework/Hydration/HydrationContext.server';
 import {generateWireSyntaxFromRenderedHtml} from './framework/Hydration/wire.server';
@@ -257,17 +256,12 @@ function buildReactApp({
 
   const ReactApp = (props: any) => (
     <RenderCacheProvider cache={renderCache}>
-      <StaticRouter
-        location={{pathname: state.pathname, search: state.search}}
-        context={context}
-      >
-        <App
-          {...props}
-          request={request}
-          response={componentResponse}
-          helmetData={new HelmetData(helmetContext)}
-        />
-      </StaticRouter>
+      <App
+        {...props}
+        request={request}
+        response={componentResponse}
+        helmetData={new HelmetData(helmetContext)}
+      />
     </RenderCacheProvider>
   );
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -11,7 +11,7 @@ import {StaticRouter} from 'react-router-dom';
 import type {ServerHandler} from './types';
 import {HydrationContext} from './framework/Hydration/HydrationContext.server';
 import {generateWireSyntaxFromRenderedHtml} from './framework/Hydration/wire.server';
-import {FilledContext, HelmetProvider} from 'react-helmet-async';
+import {FilledContext, HelmetData} from 'react-helmet-async';
 import {Html} from './framework/Hydration/Html';
 import {HydrationWriter} from './framework/Hydration/writer.server';
 import {Renderer, Hydrator, Streamer} from './types';
@@ -261,9 +261,12 @@ function buildReactApp({
         location={{pathname: state.pathname, search: state.search}}
         context={context}
       >
-        <HelmetProvider context={helmetContext}>
-          <App {...props} request={request} response={componentResponse} />
-        </HelmetProvider>
+        <App
+          {...props}
+          request={request}
+          response={componentResponse}
+          helmetData={new HelmetData(helmetContext)}
+        />
       </StaticRouter>
     </RenderCacheProvider>
   );

--- a/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
+++ b/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
@@ -1,5 +1,5 @@
 import React, {ReactElement, useMemo} from 'react';
-import {Route, Switch, useRouteMatch} from 'react-router-dom';
+import {matchPath} from '../../utilities/match_path';
 
 export type ImportGlobEagerOutput = Record<string, Record<'default', any>>;
 
@@ -18,21 +18,28 @@ export function DefaultRoutes({
   serverState: Record<string, any>;
   fallback?: ReactElement;
 }) {
-  const {path} = useRouteMatch();
+  const basePath = '/';
+
   const routes = useMemo(
-    () => createRoutesFromPages(pages, path),
-    [pages, path]
+    () => createRoutesFromPages(pages, basePath),
+    [pages, basePath]
   );
 
-  return (
-    <Switch>
-      {routes.map((route) => (
-        <Route key={route.path} exact={route.exact} path={route.path}>
-          <route.component {...serverState} />
-        </Route>
-      ))}
-      {fallback && <Route path="*">{fallback}</Route>}
-    </Switch>
+  let foundRoute, foundRouteDetails;
+
+  for (let i = 0; i < routes.length; i++) {
+    foundRouteDetails = matchPath(serverState.pathname, routes[i]);
+
+    if (foundRouteDetails) {
+      foundRoute = routes[i];
+      break;
+    }
+  }
+
+  return foundRoute ? (
+    <foundRoute.component params={foundRouteDetails.params} {...serverState} />
+  ) : (
+    fallback
   );
 }
 

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -57,13 +57,11 @@ export default function App({...serverState}) {
     <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
       <Suspense fallback="Loading...">
         <DefaultSeo />
-        <Switch>
-          <DefaultRoutes
-            pages={pages}
-            serverState={serverState}
-            fallback={<NotFound />}
-          />
-        </Switch>
+        <DefaultRoutes
+          pages={pages}
+          serverState={serverState}
+          fallback={<NotFound />}
+        />
       </Suspense>
     </ShopifyServerProvider>
   );

--- a/packages/hydrogen/src/utilities/match_path.ts
+++ b/packages/hydrogen/src/utilities/match_path.ts
@@ -1,0 +1,72 @@
+import {pathToRegexp, Key, TokensToRegexpOptions} from 'path-to-regexp';
+
+// Modified from React Router v5
+// https://github.com/remix-run/react-router/blob/v5/packages/react-router/modules/matchPath.js
+
+const cache: any = {};
+const cacheLimit = 10000;
+let cacheCount = 0;
+
+interface MatchPathOptions extends TokensToRegexpOptions {
+  path?: string;
+  exact?: boolean;
+}
+
+function compilePath(
+  path: string,
+  options: MatchPathOptions
+): {regexp: RegExp; keys: Array<Key>} {
+  const cacheKey = `${options.end}${options.strict}${options.sensitive}`;
+  const pathCache = cache[cacheKey] || (cache[cacheKey] = {});
+
+  if (pathCache[path]) return pathCache[path];
+
+  const keys: Array<Key> = [];
+  const regexp = pathToRegexp(path, keys, options);
+  const result = {regexp, keys};
+
+  if (cacheCount < cacheLimit) {
+    pathCache[path] = result;
+    cacheCount++;
+  }
+
+  return result;
+}
+
+/**
+ * Public API for matching a URL pathname to a path.
+ */
+export function matchPath(pathname: string, options: MatchPathOptions = {}) {
+  const {path, exact = false, strict = false, sensitive = false} = options;
+
+  const paths: Array<any> = [].concat(path as any);
+
+  return paths.reduce((matched, path) => {
+    if (!path && path !== '') return null;
+    if (matched) return matched;
+
+    const {regexp, keys} = compilePath(path, {
+      end: exact,
+      strict,
+      sensitive,
+    });
+    const match = regexp.exec(pathname);
+
+    if (!match) return null;
+
+    const [url, ...values] = match;
+    const isExact = pathname === url;
+
+    if (exact && !isExact) return null;
+
+    return {
+      path, // the path used to match
+      url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+      isExact, // whether or not we matched exactly
+      params: keys.reduce((memo: any, key, index) => {
+        memo[key.name] = values[index];
+        return memo;
+      }, {}),
+    };
+  }, null);
+}

--- a/packages/playground/server-components-worker/src/App.server.jsx
+++ b/packages/playground/server-components-worker/src/App.server.jsx
@@ -9,13 +9,11 @@ export default function App({...serverState}) {
   return (
     <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
       <Suspense fallback={'Loading...'}>
-        <Switch>
-          <DefaultRoutes
-            pages={pages}
-            serverState={serverState}
-            fallback="Not Found"
-          />
-        </Switch>
+        <DefaultRoutes
+          pages={pages}
+          serverState={serverState}
+          fallback="Not Found"
+        />
       </Suspense>
     </ShopifyServerProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10606,6 +10606,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,7 +550,7 @@
     core-js-pure "^3.19.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -3596,6 +3596,11 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3675,6 +3680,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -4943,6 +4962,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detective@^5.2.0:
   version "5.2.0"
@@ -8268,6 +8292,11 @@ jpeg-js@^0.4.2:
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
   integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -9109,6 +9138,14 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
@@ -9307,6 +9344,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.46.0:
   version "1.46.0"
@@ -9580,6 +9622,13 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.30:
   version "3.1.30"
@@ -10089,6 +10138,11 @@ object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -11136,10 +11190,10 @@ react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet-async@^1.0.9:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.1.2.tgz#653b7e6bbfdd239c5dcd6b8df2811c7a363b8334"
-  integrity sha512-LTTzDDkyIleT/JJ6T/uqx7Y8qi1EuPPSiJawQY/nHHz0h7SPDT6HxP1YDDQx/fzcVxCqpWEEMS3QdrSrNkJYhg==
+react-helmet-async@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.2.2.tgz#38d58d32ebffbc01ba42b5ad9142f85722492389"
+  integrity sha512-XgSQezeCbLfCxdZhDA3T/g27XZKnOYyOkruopTLSJj8RvFZwdXnM4djnfYaiBSDzOidDgTo1jcEozoRu/+P9UQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     invariant "^2.2.4"
@@ -11161,6 +11215,15 @@ react-property@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
   integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
+
+react-query@^3.18.1:
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.0.tgz#43477ac6d117d850354e6db80dcca6d5c1b36728"
+  integrity sha512-g6L90FeCLzz6+53CbVKYJALBiZR5icOYPjqGGiNgHNeufcnddLZaQGE9wheclk10k6g+o+Dd4/jAtswhjVblXw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
 
 react-reconciler@^0.26.2:
   version "0.26.2"
@@ -11604,6 +11667,11 @@ remedial@^1.0.7:
   resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
   integrity sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -11808,17 +11876,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -13614,6 +13682,14 @@ unixify@1.0.0:
   integrity sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=
   dependencies:
     normalize-path "^2.1.1"
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Proof of concept branch that removes server context. Before we can merge this, we need to understand the breaking changes. We also need to understand the long term React plan for server context and server state. Some of our existing context's might stick around.

Implemented so far:

✅ React Helmet - React Helmet context has been removed. Any page that uses `<Seo>` must get a  `helmetData` prop from the root page component.
✅ React Router - React Router server context has been removed. Any server component that wants to use a data from the URL needs to get it from a `param` prop passed to the page component. This is a breaking change, no more `useParams()` inside server components.
❌ Cart Provider