### PR TITLE
Default preloading queries

### DIFF
--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentType, JSXElementConstructor} from 'react';
+import React, {ComponentType, JSXElementConstructor, ReactElement} from 'react';
 import {
   renderToReadableStream,
   pipeToNodeWritable,
@@ -20,6 +20,8 @@ import {ServerComponentRequest} from './framework/Hydration/ServerComponentReque
 import {getCacheControlHeader} from './framework/cache';
 import {ServerResponse} from 'http';
 import {RenderCacheProvider} from './foundation/RenderCacheProvider';
+import {useRenderCacheData} from './foundation/RenderCacheProvider/hook';
+import type {PreloadCache} from './foundation/RenderCacheProvider/types';
 
 /**
  * react-dom/unstable-fizz provides different entrypoints based on runtime:
@@ -35,6 +37,14 @@ const isWorker = Boolean(renderToReadableStream);
  */
 const STREAM_ABORT_TIMEOUT_MS = 3000;
 
+type PreloadQueriesCache = {
+  [key: string]: PreloadCache;
+};
+/**
+ * Where we store query plans for each url request
+ */
+const preloadCaches: PreloadQueriesCache = {};
+
 const renderHydrogen: ServerHandler = (App, hook) => {
   /**
    * The render function is responsible for turning the provided `App` into an HTML string,
@@ -49,13 +59,14 @@ const renderHydrogen: ServerHandler = (App, hook) => {
       ? JSON.parse(url.searchParams?.get('state') ?? '{}')
       : {pathname: url.pathname, search: url.search};
 
-    const {ReactApp, helmetContext, componentResponse} = buildReactApp({
-      App,
-      state,
-      context,
-      request,
-      dev,
-    });
+    const {ReactApp, helmetContext, componentResponse, preloadCache} =
+      buildReactApp({
+        App,
+        state,
+        context,
+        request,
+        dev,
+      });
 
     const body = await renderApp(ReactApp, state, isReactHydrationRequest);
 
@@ -72,6 +83,8 @@ const renderHydrogen: ServerHandler = (App, hook) => {
       params = hook(params) || params;
     }
 
+    setPreloadCache(state.pathname, preloadCache);
+
     return {body, componentResponse, ...params};
   };
 
@@ -85,7 +98,7 @@ const renderHydrogen: ServerHandler = (App, hook) => {
   ) {
     const state = {pathname: url.pathname, search: url.search};
 
-    const {ReactApp, componentResponse} = buildReactApp({
+    const {ReactApp, componentResponse, preloadCache} = buildReactApp({
       App,
       state,
       context,
@@ -133,6 +146,8 @@ const renderHydrogen: ServerHandler = (App, hook) => {
           );
         },
         onCompleteAll() {
+          setPreloadCache(state.pathname, preloadCache);
+
           if (componentResponse.canStream() || response.writableEnded) return;
 
           writeHeadToServerResponse(response, componentResponse, didError);
@@ -181,7 +196,7 @@ const renderHydrogen: ServerHandler = (App, hook) => {
   ) {
     const state = JSON.parse(url.searchParams.get('state') || '{}');
 
-    const {ReactApp, componentResponse} = buildReactApp({
+    const {ReactApp, componentResponse, preloadCache} = buildReactApp({
       App,
       state,
       context,
@@ -220,6 +235,7 @@ const renderHydrogen: ServerHandler = (App, hook) => {
             componentResponse.cacheControlHeader
           );
           response.end(generateWireSyntaxFromRenderedHtml(writer.toString()));
+          setPreloadCache(state.pathname, preloadCache);
         },
         onError(error: any) {
           didError = error;
@@ -238,6 +254,10 @@ const renderHydrogen: ServerHandler = (App, hook) => {
   };
 };
 
+function setPreloadCache(requestUrl: string, cache: object) {
+  preloadCaches[requestUrl] = cache as PreloadCache;
+}
+
 function buildReactApp({
   App,
   state,
@@ -254,21 +274,41 @@ function buildReactApp({
   const helmetContext = {} as FilledContext;
   const componentResponse = new ServerComponentResponse();
   const renderCache = {};
+  const preloadCache = {};
 
   const ReactApp = (props: any) => (
-    <RenderCacheProvider cache={renderCache}>
-      <StaticRouter
-        location={{pathname: state.pathname, search: state.search}}
-        context={context}
-      >
-        <HelmetProvider context={helmetContext}>
-          <App {...props} request={request} response={componentResponse} />
-        </HelmetProvider>
-      </StaticRouter>
+    <RenderCacheProvider cache={renderCache} preloadCache={preloadCache}>
+      <PreloadQueryWrapper url={state.pathname}>
+        <StaticRouter
+          location={{pathname: state.pathname, search: state.search}}
+          context={context}
+        >
+          <HelmetProvider context={helmetContext}>
+            <App {...props} request={request} response={componentResponse} />
+          </HelmetProvider>
+        </StaticRouter>
+      </PreloadQueryWrapper>
     </RenderCacheProvider>
   );
 
-  return {helmetContext, ReactApp, componentResponse};
+  return {helmetContext, ReactApp, componentResponse, preloadCache};
+}
+
+function PreloadQueryWrapper({
+  url,
+  children,
+}: {
+  url: string;
+  children: ReactElement;
+}) {
+  const preloadCache = preloadCaches[url];
+  if (preloadCache) {
+    Object.keys(preloadCache).forEach((key) => {
+      const query = preloadCache[key];
+      useRenderCacheData(query.key, query.fetcher, false);
+    });
+  }
+  return children;
 }
 
 function extractHeadElements(helmetContext: FilledContext) {

--- a/packages/hydrogen/src/foundation/RenderCacheProvider/RenderCacheContext.tsx
+++ b/packages/hydrogen/src/foundation/RenderCacheProvider/RenderCacheContext.tsx
@@ -3,4 +3,5 @@ import type {RenderCacheProviderProps} from './types';
 
 export const RenderCacheContext = createContext<RenderCacheProviderProps>({
   cache: {},
+  preloadCache: {},
 });

--- a/packages/hydrogen/src/foundation/RenderCacheProvider/RenderCacheProvider.tsx
+++ b/packages/hydrogen/src/foundation/RenderCacheProvider/RenderCacheProvider.tsx
@@ -4,10 +4,16 @@ import type {RenderCacheProviderProps} from './types';
 
 export function RenderCacheProvider({
   cache,
+  preloadCache,
   children,
 }: RenderCacheProviderProps) {
   return (
-    <RenderCacheContext.Provider value={{cache}}>
+    <RenderCacheContext.Provider
+      value={{
+        cache,
+        preloadCache,
+      }}
+    >
       {children}
     </RenderCacheContext.Provider>
   );

--- a/packages/hydrogen/src/foundation/RenderCacheProvider/types.ts
+++ b/packages/hydrogen/src/foundation/RenderCacheProvider/types.ts
@@ -1,10 +1,20 @@
+import {QueryKey} from '../../types';
+
 export type RenderCache = {
   [key: string]: () => unknown;
+};
+
+export type PreloadCache = {
+  [key: string]: {
+    key: QueryKey;
+    fetcher: () => Promise<unknown>;
+  };
 };
 
 export type RenderCacheProviderProps = {
   /** A cache to hold all queries performed within a render request */
   cache: RenderCache;
+  preloadCache: PreloadCache;
   children?: React.ReactNode;
 };
 


### PR DESCRIPTION
### Description

Preloading queries is one of proposed way to prevent Suspense waterfalls while generating a SSR render or a RSC output.

Let's take a took at what a data suspense waterfall looks like from our starter template home page:

<img width="662" alt="Screen Shot 2021-12-07 at 2 30 01 PM" src="https://user-images.githubusercontent.com/2319002/145118542-8abb2640-b54a-4b9e-b8d5-3dad1a257cf4.png">

In the above example, 

* the rendering process started with `shopName` and `indexContent` query
* `indexContent` query blocks the discovery of `layoutContent` query
* `layoutContent` query blocks the discovery of `localization` query
* Finally, `localization` query blocks the discovery of `welcomeContent`

<img width="1638" alt="Screen Shot 2021-12-08 at 11 56 15 AM" src="https://user-images.githubusercontent.com/2319002/145275529-7aa94602-9f02-4248-851a-23772eeb1daa.png">

When we preload all these queries, the entire rendering process becomes limited only to the longest API fetch time.

<img width="539" alt="Screen Shot 2021-12-07 at 2 41 20 PM" src="https://user-images.githubusercontent.com/2319002/145119139-ee460696-cbdd-461e-8293-38ca943ee959.png">

Yes, you are looking at almost 500ms savings. However, this time saving depends on when SF API returns a response. (Note: the example does not have Cache (worker or Oxygen) turned on)

<img width="1139" alt="Screen Shot 2021-12-08 at 11 56 45 AM" src="https://user-images.githubusercontent.com/2319002/145275614-7fb2a7b3-2ee8-4874-a645-19a641491e00.png">

### Exploration

This PR is demonstrating a default way to preload queries. `RenderCache` is a temporary cache that bounds to a specific rendering pass. Once the rendering is complete, it will be discarded.

#### How it works

During a rendering request:

1. For each query call, store the query fetcher and the query key in a temporary cache `RenderCache`
2. When the rendering request completes, save the query plan generated as the preload query plan

On the next request of the same url, use the preload query plan generated to make the same query calls.

So, by default ...

* The preload query won't work until the second request of the same url
* It will make the same api calls for the giving url and respects the custom cache TTL if specified
* Preloading queries happens automatically without needing to change to starter template

### Other consideration

* Would need to a way to not include unique queries like customer or cart api (Most likely can pass a boolean in as part of `useQuery` option)
* Would need a way to define custom preloading query plan as an option - say you know exactly what queries to preload for the product template, you can pass in the query building function yourself to take care of preloading.
* This log makes a great starting point to develop debugging tool for suspense queries
* Possibly can become a tool to recommend preload query plan
* Explore batching queries into a single request - Our query key is a string concatenation of the GQL query, its variables, the storefront api token, storefront domain and storefront GQL version. 

## How to test

Use [`remove-react-query-with-logs`](https://github.com/Shopify/hydrogen/compare/preload-queries...remove-react-query-with-logs) branch to see the server logs like the ones provided in screenshoot.

If you like to test this with worker, you can run `yarn dev-worker` in root folder.

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
