### PR TITLE
chore: allow merge commit messages

### DIFF
--- a/scripts/verify-commit.js
+++ b/scripts/verify-commit.js
@@ -9,10 +9,11 @@ const msgPath = process.env.GIT_PARAMS;
 const msg = require('fs').readFileSync(msgPath, 'utf-8').trim();
 
 const releaseRE = /^v\d/;
+const mergeRE = /^Merge branch/;
 const commitRE =
   /^(revert: )?(feat|fix|docs|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(\(.+\))?: .{1,50}/;
 
-if (!releaseRE.test(msg) && !commitRE.test(msg)) {
+if (!releaseRE.test(msg) && !commitRE.test(msg) && !mergeRE.test(msg)) {
   console.log();
   console.error(
     `  ${chalk.bgRed.white(' ERROR ')} ${chalk.red(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Merge commits are not allowed in the `verify-commint.js` script. For example, when trying to merge `main` branch in your current feature branch. The default message would be `Merge branch main into...`.

@cartogram Would this break anything in the generated changelogs?

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
