### PR TITLE
fix: flakey <StarRating /> test

### DIFF
--- a/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
@@ -16,18 +16,14 @@ describe('<StarRating />', () => {
     expect(component).toContainReactComponentTimes(Star, range);
   });
 
-  /**
-   * TODO: Fix the flakiness of this test, likely due to floating point math :)
-   * https://github.com/Shopify/hydrogen/issues/19
-   */
-  it.skip('renders the number of filled stars corresponding to the rating value', () => {
+  it('renders the number of filled stars corresponding to the rating value', () => {
     const rating = getParsedMetafield({type: 'rating'});
     const component = mount(<StarRating rating={rating.value as Rating} />);
 
     // The number of completely filled stars should be the integer value of the rating
     // minus the minumum scale value, plus one (since the scale is inclusive)
     const numberOfCompletelyFilledStars =
-      parseInt((rating.value as any).value) -
+      parseInt((rating.value as any).value, 10) -
       (rating.value as any).scale_min +
       1;
     const partialStarFill = (parseFloat((rating.value as any).value) % 1) * 100;

--- a/packages/hydrogen/src/utilities/tests/metafields.ts
+++ b/packages/hydrogen/src/utilities/tests/metafields.ts
@@ -126,7 +126,7 @@ export function getMetafieldValue(type: MetafieldType) {
       return JSON.stringify({
         scale_max: max,
         scale_min: min,
-        value: faker.datatype.float({min, max}),
+        value: faker.datatype.float({min, max, precision: 0.0001}),
       });
     default:
       return JSON.stringify(faker.datatype.json());


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes: https://github.com/Shopify/hydrogen/issues/19

This assertion was failing periodically:

```tsx
expect(component).toContainReactComponentTimes(Star, 1, {
  percentFilled: partialStarFill,
});
```

This would fail when `partialStarFill` was 0 because the `.toContainReactComponentTimes` would find all the empty stars instead of 1 partially-filled star.

To solve this I added decimal points to the `rating` value returned from `getParsedMetafield` to be larger than 2 (the default in `faker`) which removes the chance that the modulus will return with no remainder.

### Additional context

Please check my math.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
