### PR TITLE
fix: cart decrease button removes at zero quantity

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- fix: cart decrease button removes at zero quantity
 - feat: upgrade to latest React 18 experimental version
 
 ## 0.8.0 - 2021-12-07

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
@@ -40,6 +40,12 @@ export function CartLineQuantityAdjustButton<
 
         const quantity =
           adjust === 'decrease' ? cartLine.quantity - 1 : cartLine.quantity + 1;
+
+        if (quantity <= 0) {
+          removeLines([cartLine.id]);
+          return;
+        }
+
         updateLines([{id: cartLine.id, quantity}]);
       }}
       {...passthroughProps}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Cart button update quantity button now removes item when decreased to zero.

### Additional context

Based on bug report here:

https://github.com/Shopify/hydrogen/issues/340

---

### Before submitting the PR, please make sure you do the following:

- [X] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository for your change, if needed
