### PR TITLE
[Hydrogen starter template]: Add descriptions for components

### DIFF
--- a/packages/dev/src/components/Button.client.jsx
+++ b/packages/dev/src/components/Button.client.jsx
@@ -25,7 +25,7 @@ const ExternalIcon = () => (
 );
 
 /**
- * Sets the primary and secondary classes for button components
+ * A client component that sets the primary and secondary classes for button components
  */
 export default function Button({
   className,

--- a/packages/dev/src/components/Button.client.jsx
+++ b/packages/dev/src/components/Button.client.jsx
@@ -24,6 +24,9 @@ const ExternalIcon = () => (
   </svg>
 );
 
+/**
+ * Sets the primary and secondary classes for button components
+ */
 export default function Button({
   className,
   label,

--- a/packages/dev/src/components/Cart.client.jsx
+++ b/packages/dev/src/components/Cart.client.jsx
@@ -14,7 +14,7 @@ import CartIconWithItems from './CartIconWithItems.client';
 import {BUTTON_PRIMARY_CLASSES} from './Button.client';
 
 /**
- * Contains the merchandise that a customer intends to purchase, and the estimated cost associated with the cart
+ * A client component that contains the merchandise that a customer intends to purchase, and the estimated cost associated with the cart
  */
 export default function Cart() {
   const {isCartOpen, closeCart} = useCartUI();

--- a/packages/dev/src/components/Cart.client.jsx
+++ b/packages/dev/src/components/Cart.client.jsx
@@ -13,6 +13,9 @@ import {useCartUI} from './CartUIProvider.client';
 import CartIconWithItems from './CartIconWithItems.client';
 import {BUTTON_PRIMARY_CLASSES} from './Button.client';
 
+/**
+ * Contains the merchandise that a customer intends to purchase, and the estimated cost associated with the cart
+ */
 export default function Cart() {
   const {isCartOpen, closeCart} = useCartUI();
   const itemCount = useCartLinesTotalQuantity();

--- a/packages/dev/src/components/CartIcon.jsx
+++ b/packages/dev/src/components/CartIcon.jsx
@@ -1,3 +1,6 @@
+/**
+ * Specifies the icon to represent a cart
+ */
 export default function CartIcon() {
   return (
     <svg

--- a/packages/dev/src/components/CartIcon.jsx
+++ b/packages/dev/src/components/CartIcon.jsx
@@ -1,5 +1,5 @@
 /**
- * Specifies the icon to represent a cart
+ * A shared component that specifies the icon to represent a cart
  */
 export default function CartIcon() {
   return (

--- a/packages/dev/src/components/CartIconWithItems.client.jsx
+++ b/packages/dev/src/components/CartIconWithItems.client.jsx
@@ -3,7 +3,7 @@ import {useCartLinesTotalQuantity} from '@shopify/hydrogen/client';
 import CartIcon from './CartIcon';
 
 /**
- * Specifies the icon to use if a cart contains merchandise
+ * A client component that specifies the icon to use if a cart contains merchandise
  */
 export default function CartIconWithItems() {
   const itemCount = useCartLinesTotalQuantity();

--- a/packages/dev/src/components/CartIconWithItems.client.jsx
+++ b/packages/dev/src/components/CartIconWithItems.client.jsx
@@ -2,6 +2,9 @@ import {useCartLinesTotalQuantity} from '@shopify/hydrogen/client';
 
 import CartIcon from './CartIcon';
 
+/**
+ * Specifies the icon to use if a cart contains merchandise
+ */
 export default function CartIconWithItems() {
   const itemCount = useCartLinesTotalQuantity();
 

--- a/packages/dev/src/components/CartProvider.client.jsx
+++ b/packages/dev/src/components/CartProvider.client.jsx
@@ -4,7 +4,7 @@ import {CartProvider as ShopifyCartProvider} from '@shopify/hydrogen/client';
 import CartUIProvider, {useCartUI} from './CartUIProvider.client';
 
 /**
- * Creates a cart object and provides callbacks that can be accessed by any descendent component using the `useCart` hook and related hooks
+ * A client component that creates a cart object and provides callbacks that can be accessed by any descendent component using the `useCart` hook and related hooks
  */
 export default function CartProvider({children, numCartLines}) {
   return (

--- a/packages/dev/src/components/CartProvider.client.jsx
+++ b/packages/dev/src/components/CartProvider.client.jsx
@@ -3,6 +3,9 @@ import {CartProvider as ShopifyCartProvider} from '@shopify/hydrogen/client';
 
 import CartUIProvider, {useCartUI} from './CartUIProvider.client';
 
+/**
+ * Creates a cart object and provides callbacks that can be accessed by any descendent component using the `useCart` hook and related hooks
+ */
 export default function CartProvider({children, numCartLines}) {
   return (
     <CartUIProvider>

--- a/packages/dev/src/components/CartToggle.client.jsx
+++ b/packages/dev/src/components/CartToggle.client.jsx
@@ -1,6 +1,9 @@
 import {useCartUI} from './CartUIProvider.client';
 import CartIconWithItems from './CartIconWithItems.client';
 
+/**
+ * Defines the behavior when a user toggles a cart
+ */
 export default function CartToggle({handleClick}) {
   const cartUI = useCartUI();
 

--- a/packages/dev/src/components/CartToggle.client.jsx
+++ b/packages/dev/src/components/CartToggle.client.jsx
@@ -2,7 +2,7 @@ import {useCartUI} from './CartUIProvider.client';
 import CartIconWithItems from './CartIconWithItems.client';
 
 /**
- * Defines the behavior when a user toggles a cart
+ * A client component that defines the behavior when a user toggles a cart
  */
 export default function CartToggle({handleClick}) {
   const cartUI = useCartUI();

--- a/packages/dev/src/components/CartUIProvider.client.jsx
+++ b/packages/dev/src/components/CartUIProvider.client.jsx
@@ -9,7 +9,7 @@ import React, {
 export const CartContext = createContext(null);
 
 /**
- * Defines the behavior that occurs when a user is interacting with a cart (for example, opening or closing it)
+ * A client component that defines the behavior that occurs when a user is interacting with a cart (for example, opening or closing it)
  */
 export default function CartUIProvider({children}) {
   const [open, setOpen] = useState(false);

--- a/packages/dev/src/components/CartUIProvider.client.jsx
+++ b/packages/dev/src/components/CartUIProvider.client.jsx
@@ -8,6 +8,9 @@ import React, {
 
 export const CartContext = createContext(null);
 
+/**
+ * Defines the behavior that occurs when a user is interacting with a cart (for example, opening or closing it)
+ */
 export default function CartUIProvider({children}) {
   const [open, setOpen] = useState(false);
 

--- a/packages/dev/src/components/CurrencySelector.client.jsx
+++ b/packages/dev/src/components/CurrencySelector.client.jsx
@@ -3,7 +3,7 @@ import {useAvailableCountries, useCountry} from '@shopify/hydrogen/client';
 import {Listbox} from '@headlessui/react';
 
 /**
- * Selects the appropriate currency to display for products on a website
+ * A client component that selects the appropriate currency to display for products on a website
  */
 export default function CurrencySelector() {
   const countries = useAvailableCountries();

--- a/packages/dev/src/components/CurrencySelector.client.jsx
+++ b/packages/dev/src/components/CurrencySelector.client.jsx
@@ -2,6 +2,9 @@ import {useCallback} from 'react';
 import {useAvailableCountries, useCountry} from '@shopify/hydrogen/client';
 import {Listbox} from '@headlessui/react';
 
+/**
+ * Selects the appropriate currency to display for products on a website
+ */
 export default function CurrencySelector() {
   const countries = useAvailableCountries();
   const [selectedCountry, setSelectedCountry] = useCountry();

--- a/packages/dev/src/components/DefaultSeo.server.jsx
+++ b/packages/dev/src/components/DefaultSeo.server.jsx
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import Seo from './Seo.client';
 
 /**
- * Fetches a `shop.name` and sets default values and templates for every page on a website
+ * A server component that fetches a `shop.name` and sets default values and templates for every page on a website
  */
 export default function SeoServer() {
   const {

--- a/packages/dev/src/components/DefaultSeo.server.jsx
+++ b/packages/dev/src/components/DefaultSeo.server.jsx
@@ -3,6 +3,9 @@ import gql from 'graphql-tag';
 
 import Seo from './Seo.client';
 
+/**
+ * Fetches a `shop.name` and sets default values and templates for every page on a website
+ */
 export default function SeoServer() {
   const {
     data: {

--- a/packages/dev/src/components/FeaturedCollection.jsx
+++ b/packages/dev/src/components/FeaturedCollection.jsx
@@ -1,7 +1,7 @@
 import {Image, Link} from '@shopify/hydrogen';
 
 /**
- * Defines a single featured collection to display on a storefront
+ * A shared component that defines a single featured collection to display on a storefront
  */
 export default function FeaturedCollection({collection}) {
   return collection ? (

--- a/packages/dev/src/components/FeaturedCollection.jsx
+++ b/packages/dev/src/components/FeaturedCollection.jsx
@@ -1,5 +1,8 @@
 import {Image, Link} from '@shopify/hydrogen';
 
+/**
+ * Defines a single featured collection to display on a storefront
+ */
 export default function FeaturedCollection({collection}) {
   return collection ? (
     <div className="shadow-xl rounded-xl grid grid-cols-1 lg:grid-cols-2 items-center bg-white overflow-hidden">

--- a/packages/dev/src/components/Footer.server.jsx
+++ b/packages/dev/src/components/Footer.server.jsx
@@ -1,7 +1,7 @@
 import {Link} from '@shopify/hydrogen';
 
 /**
- * Specifies the content of the footer on the website
+ * A server component that specifies the content of the footer on the website
  */
 export default function Footer({collection, product}) {
   return (

--- a/packages/dev/src/components/Footer.server.jsx
+++ b/packages/dev/src/components/Footer.server.jsx
@@ -1,5 +1,8 @@
 import {Link} from '@shopify/hydrogen';
 
+/**
+ * Specifies the content of the footer on the website
+ */
 export default function Footer({collection, product}) {
   return (
     <footer role="contentinfo">

--- a/packages/dev/src/components/Gallery.client.jsx
+++ b/packages/dev/src/components/Gallery.client.jsx
@@ -4,6 +4,9 @@ import {
   SelectedVariantImage,
 } from '@shopify/hydrogen/client';
 
+/**
+ * Defines a media gallery for hosting images, 3D models, and videos of products
+ */
 export default function Gallery() {
   const {media, selectedVariant} = useProduct();
 

--- a/packages/dev/src/components/Gallery.client.jsx
+++ b/packages/dev/src/components/Gallery.client.jsx
@@ -5,7 +5,7 @@ import {
 } from '@shopify/hydrogen/client';
 
 /**
- * Defines a media gallery for hosting images, 3D models, and videos of products
+ * A client component that defines a media gallery for hosting images, 3D models, and videos of products
  */
 export default function Gallery() {
   const {media, selectedVariant} = useProduct();

--- a/packages/dev/src/components/Header.client.jsx
+++ b/packages/dev/src/components/Header.client.jsx
@@ -7,7 +7,7 @@ import Navigation from './Navigation.client';
 import MobileNavigation from './MobileNavigation.client';
 
 /**
- * Specifies the content of the header on the website
+ * A client component that specifies the content of the header on the website
  */
 export default function Header({collections, storeName}) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);

--- a/packages/dev/src/components/Header.client.jsx
+++ b/packages/dev/src/components/Header.client.jsx
@@ -6,6 +6,9 @@ import CurrencySelector from './CurrencySelector.client';
 import Navigation from './Navigation.client';
 import MobileNavigation from './MobileNavigation.client';
 
+/**
+ * Specifies the content of the header on the website
+ */
 export default function Header({collections, storeName}) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 

--- a/packages/dev/src/components/Layout.server.jsx
+++ b/packages/dev/src/components/Layout.server.jsx
@@ -11,6 +11,9 @@ import Footer from './Footer.server';
 import {useCartUI} from './CartUIProvider.client';
 import Cart from './Cart.client';
 
+/**
+ * Defines a structure and organization of a page that can be used in different parts of the Hydrogen app
+ */
 export default function Layout({children, hero}) {
   const {data} = useShopQuery({
     query: QUERY,

--- a/packages/dev/src/components/Layout.server.jsx
+++ b/packages/dev/src/components/Layout.server.jsx
@@ -12,7 +12,7 @@ import {useCartUI} from './CartUIProvider.client';
 import Cart from './Cart.client';
 
 /**
- * Defines a structure and organization of a page that can be used in different parts of the Hydrogen app
+ * A server component that defines a structure and organization of a page that can be used in different parts of the Hydrogen app
  */
 export default function Layout({children, hero}) {
   const {data} = useShopQuery({

--- a/packages/dev/src/components/LoadMoreProducts.client.jsx
+++ b/packages/dev/src/components/LoadMoreProducts.client.jsx
@@ -1,7 +1,7 @@
 import {useServerState} from '@shopify/hydrogen/client';
 
 /**
- * Provides functionality to initially show a subset of products and a button to load more products
+ * A client component that provides functionality to initially show a subset of products and a button to load more products
  */
 export default function LoadMoreProducts({startingCount}) {
   const {pending, serverState, setServerState} = useServerState();

--- a/packages/dev/src/components/LoadMoreProducts.client.jsx
+++ b/packages/dev/src/components/LoadMoreProducts.client.jsx
@@ -1,5 +1,8 @@
 import {useServerState} from '@shopify/hydrogen/client';
 
+/**
+ * Provides functionality to initially show a subset of products and a button to load more products
+ */
 export default function LoadMoreProducts({startingCount}) {
   const {pending, serverState, setServerState} = useServerState();
 

--- a/packages/dev/src/components/LoadingFallback.jsx
+++ b/packages/dev/src/components/LoadingFallback.jsx
@@ -1,6 +1,9 @@
 import CartIcon from './CartIcon';
 import OpenIcon from './OpenIcon';
 
+/**
+ * A Suspense call that's used in `App.server.jsx` to let your app wait for code to load while declaring a loading state
+ */
 export default function LoadingFallback() {
   return (
     <header className="h-20 lg:h-32 max-w-screen text-gray-700">

--- a/packages/dev/src/components/LoadingFallback.jsx
+++ b/packages/dev/src/components/LoadingFallback.jsx
@@ -2,7 +2,7 @@ import CartIcon from './CartIcon';
 import OpenIcon from './OpenIcon';
 
 /**
- * A Suspense call that's used in `App.server.jsx` to let your app wait for code to load while declaring a loading state
+ * A shared component and Suspense call that's used in `App.server.jsx` to let your app wait for code to load while declaring a loading state
  */
 export default function LoadingFallback() {
   return (

--- a/packages/dev/src/components/MobileCurrencySelector.client.jsx
+++ b/packages/dev/src/components/MobileCurrencySelector.client.jsx
@@ -5,7 +5,7 @@ import {Listbox} from '@headlessui/react';
 import {ArrowIcon, CheckIcon} from './CurrencySelector.client';
 
 /**
- * Selects the appropriate currency to display for products on a mobile storefront
+ * A client component that selects the appropriate currency to display for products on a mobile storefront
  */
 export default function MobileCurrencySelector() {
   const countries = useAvailableCountries();

--- a/packages/dev/src/components/MobileCurrencySelector.client.jsx
+++ b/packages/dev/src/components/MobileCurrencySelector.client.jsx
@@ -4,6 +4,9 @@ import {Listbox} from '@headlessui/react';
 
 import {ArrowIcon, CheckIcon} from './CurrencySelector.client';
 
+/**
+ * Selects the appropriate currency to display for products on a mobile storefront
+ */
 export default function MobileCurrencySelector() {
   const countries = useAvailableCountries();
   const [selectedCountry, setSelectedCountry] = useCountry();

--- a/packages/dev/src/components/MobileNavigation.client.jsx
+++ b/packages/dev/src/components/MobileNavigation.client.jsx
@@ -6,7 +6,7 @@ import MobileCurrencySelector from './MobileCurrencySelector.client';
 import OpenIcon from './OpenIcon';
 
 /**
- * Defines the navigation for a mobile storefront
+ * A client component that defines the navigation for a mobile storefront
  */
 export default function MobileNavigation({collections, isOpen, setIsOpen}) {
   const OpenFocusTrap = isOpen ? FocusTrap : Fragment;

--- a/packages/dev/src/components/MobileNavigation.client.jsx
+++ b/packages/dev/src/components/MobileNavigation.client.jsx
@@ -5,6 +5,9 @@ import {FocusTrap} from '@headlessui/react';
 import MobileCurrencySelector from './MobileCurrencySelector.client';
 import OpenIcon from './OpenIcon';
 
+/**
+ * Defines the navigation for a mobile storefront
+ */
 export default function MobileNavigation({collections, isOpen, setIsOpen}) {
   const OpenFocusTrap = isOpen ? FocusTrap : Fragment;
 

--- a/packages/dev/src/components/MoneyCompareAtPrice.client.jsx
+++ b/packages/dev/src/components/MoneyCompareAtPrice.client.jsx
@@ -1,7 +1,7 @@
 import {Money} from '@shopify/hydrogen/client';
 
 /**
- * Renders a `Money` component for a product's compare at price
+ * A client component that renders a `Money` component for a product's compare at price
  */
 export default function MoneyCompareAtPrice({money}) {
   return (

--- a/packages/dev/src/components/MoneyCompareAtPrice.client.jsx
+++ b/packages/dev/src/components/MoneyCompareAtPrice.client.jsx
@@ -1,5 +1,8 @@
 import {Money} from '@shopify/hydrogen/client';
 
+/**
+ * Renders a `Money` component for a product's compare at price
+ */
 export default function MoneyCompareAtPrice({money}) {
   return (
     <Money money={money}>

--- a/packages/dev/src/components/MoneyPrice.client.jsx
+++ b/packages/dev/src/components/MoneyPrice.client.jsx
@@ -1,5 +1,8 @@
 import {Money} from '@shopify/hydrogen/client';
 
+/**
+ * Defines the currency code, currency symbol, and amount of a product
+ */
 export default function MoneyPrice({money}) {
   return (
     <Money className="text-black text-md" money={money}>

--- a/packages/dev/src/components/MoneyPrice.client.jsx
+++ b/packages/dev/src/components/MoneyPrice.client.jsx
@@ -1,7 +1,7 @@
 import {Money} from '@shopify/hydrogen/client';
 
 /**
- * Defines the currency code, currency symbol, and amount of a product
+ * A client component that defines the currency code, currency symbol, and amount of a product
  */
 export default function MoneyPrice({money}) {
   return (

--- a/packages/dev/src/components/Navigation.client.jsx
+++ b/packages/dev/src/components/Navigation.client.jsx
@@ -1,7 +1,7 @@
 import {Link} from '@shopify/hydrogen/client';
 
 /**
- * Defines the navigation for a web storefront
+ * A client component that defines the navigation for a web storefront
  */
 export default function Navigation({collections}) {
   return (

--- a/packages/dev/src/components/Navigation.client.jsx
+++ b/packages/dev/src/components/Navigation.client.jsx
@@ -1,5 +1,8 @@
 import {Link} from '@shopify/hydrogen/client';
 
+/**
+ * Defines the navigation for a web storefront
+ */
 export default function Navigation({collections}) {
   return (
     <nav className="hidden lg:block text-center">

--- a/packages/dev/src/components/NotFound.server.jsx
+++ b/packages/dev/src/components/NotFound.server.jsx
@@ -10,7 +10,7 @@ import Button from './Button.client';
 import ProductCard from './ProductCard';
 
 /**
- * Defines the content to display when a page isn't found (404 error)
+ * A server component that defines the content to display when a page isn't found (404 error)
  */
 function NotFoundHero() {
   return (

--- a/packages/dev/src/components/NotFound.server.jsx
+++ b/packages/dev/src/components/NotFound.server.jsx
@@ -9,6 +9,9 @@ import Layout from './Layout.server';
 import Button from './Button.client';
 import ProductCard from './ProductCard';
 
+/**
+ * Defines the content to display when a page isn't found (404 error)
+ */
 function NotFoundHero() {
   return (
     <div className="py-10 border-b border-gray-200">

--- a/packages/dev/src/components/OpenIcon.jsx
+++ b/packages/dev/src/components/OpenIcon.jsx
@@ -1,5 +1,5 @@
 /**
- * Specifies the icon to render when opened
+ * A shared component that specifies the icon to render when opened
  */
 export default function OpenIcon() {
   return (

--- a/packages/dev/src/components/OpenIcon.jsx
+++ b/packages/dev/src/components/OpenIcon.jsx
@@ -1,3 +1,6 @@
+/**
+ * Specifies the icon to render when opened
+ */
 export default function OpenIcon() {
   return (
     <svg

--- a/packages/dev/src/components/ProductCard.jsx
+++ b/packages/dev/src/components/ProductCard.jsx
@@ -4,7 +4,7 @@ import MoneyCompareAtPrice from './MoneyCompareAtPrice.client';
 import MoneyPrice from './MoneyPrice.client';
 
 /**
- * Displays a single product to allow buyers to quickly identify a particular item of interest
+ * A shared component that displays a single product to allow buyers to quickly identify a particular item of interest
  */
 export default function ProductCard({product}) {
   const selectedVariant = product.variants.edges[0].node;

--- a/packages/dev/src/components/ProductCard.jsx
+++ b/packages/dev/src/components/ProductCard.jsx
@@ -3,6 +3,9 @@ import {Image, Link} from '@shopify/hydrogen';
 import MoneyCompareAtPrice from './MoneyCompareAtPrice.client';
 import MoneyPrice from './MoneyPrice.client';
 
+/**
+ * Displays a single product to allow buyers to quickly identify a particular item of interest
+ */
 export default function ProductCard({product}) {
   const selectedVariant = product.variants.edges[0].node;
 

--- a/packages/dev/src/components/ProductDetails.client.jsx
+++ b/packages/dev/src/components/ProductDetails.client.jsx
@@ -8,6 +8,9 @@ import {
   BUTTON_SECONDARY_CLASSES,
 } from './Button.client';
 
+/**
+ * Displays detailed information about a product to allow buyers to make informed decisions
+ */
 function ProductPriceMarkup() {
   return (
     <div className="flex md:flex-col items-end font-semibold text-lg md:items-start md:mb-4">

--- a/packages/dev/src/components/ProductDetails.client.jsx
+++ b/packages/dev/src/components/ProductDetails.client.jsx
@@ -9,7 +9,7 @@ import {
 } from './Button.client';
 
 /**
- * Displays detailed information about a product to allow buyers to make informed decisions
+ * A client component that displays detailed information about a product to allow buyers to make informed decisions
  */
 function ProductPriceMarkup() {
   return (

--- a/packages/dev/src/components/ProductOptions.client.jsx
+++ b/packages/dev/src/components/ProductOptions.client.jsx
@@ -1,5 +1,8 @@
 import {useProduct} from '@shopify/hydrogen/client';
 
+/**
+ * Tracks a selected variant and/or selling plan state, as well as callbacks for modifying the state
+ */
 export default function ProductOptions() {
   const {options, setSelectedOption, selectedOptions} = useProduct();
 

--- a/packages/dev/src/components/ProductOptions.client.jsx
+++ b/packages/dev/src/components/ProductOptions.client.jsx
@@ -1,7 +1,7 @@
 import {useProduct} from '@shopify/hydrogen/client';
 
 /**
- * Tracks a selected variant and/or selling plan state, as well as callbacks for modifying the state
+ * A client component that tracks a selected variant and/or selling plan state, as well as callbacks for modifying the state
  */
 export default function ProductOptions() {
   const {options, setSelectedOption, selectedOptions} = useProduct();

--- a/packages/dev/src/components/Seo.client.jsx
+++ b/packages/dev/src/components/Seo.client.jsx
@@ -1,5 +1,8 @@
 import {useShop, Helmet} from '@shopify/hydrogen/client';
 
+/**
+ * Customizes the output of SEO-related tags in your document `head`
+ */
 export default function Seo({shopName, product}) {
   const {locale} = useShop();
   const lang = locale.split(/[-_]/)[0];

--- a/packages/dev/src/components/Seo.client.jsx
+++ b/packages/dev/src/components/Seo.client.jsx
@@ -1,7 +1,7 @@
 import {useShop, Helmet} from '@shopify/hydrogen/client';
 
 /**
- * Customizes the output of SEO-related tags in your document `head`
+ * A client component that customizes the output of SEO-related tags in your document `head`
  */
 export default function Seo({shopName, product}) {
   const {locale} = useShop();

--- a/packages/dev/src/components/Welcome.server.jsx
+++ b/packages/dev/src/components/Welcome.server.jsx
@@ -107,6 +107,9 @@ function TemplateLinks({firstProductPath, firstCollectionPath}) {
   );
 }
 
+/**
+ * Displays the content on the homepage of the Hydrogen app
+ */
 export default function Welcome() {
   const {data} = useShopQuery({query: QUERY});
   const shopName = data ? data.shop.name : '';

--- a/packages/dev/src/components/Welcome.server.jsx
+++ b/packages/dev/src/components/Welcome.server.jsx
@@ -108,7 +108,7 @@ function TemplateLinks({firstProductPath, firstCollectionPath}) {
 }
 
 /**
- * Displays the content on the homepage of the Hydrogen app
+ * A server component that displays the content on the homepage of the Hydrogen app
  */
 export default function Welcome() {
   const {data} = useShopQuery({query: QUERY});

--- a/packages/hydrogen/src/docs/components.md
+++ b/packages/hydrogen/src/docs/components.md
@@ -244,6 +244,6 @@ The [LocalizationProvider](/api/hydrogen/components/localization/localizationpro
 
 ## Next steps
 
-- [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
+- [Get started](/custom-storefronts/hydrogen/getting-started/create) with Hydrogen and begin building a custom storefront.
 - Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
 - Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/docs/hooks.md
+++ b/packages/hydrogen/src/docs/hooks.md
@@ -164,6 +164,6 @@ Hydrogen includes the following metafield hooks:
 
 ## Next steps
 
-- [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
+- [Get started](/custom-storefronts/hydrogen/getting-started/create) with Hydrogen and begin building a custom storefront.
 - Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
 - Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/docs/hydrogen-sdk.md
+++ b/packages/hydrogen/src/docs/hydrogen-sdk.md
@@ -346,6 +346,6 @@ Hydrogen includes the following utilities to help speed up your development proc
 
 ## Next steps
 
-- [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
+- [Get started](/custom-storefronts/hydrogen/getting-started/create) with Hydrogen and begin building a custom storefront.
 - Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
 - Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/docs/utilities.md
+++ b/packages/hydrogen/src/docs/utilities.md
@@ -24,6 +24,6 @@ Hydrogen includes the following utilities:
 
 ## Next steps
 
-- [Get started](/custom-storefronts/hydrogen/getting-started) with Hydrogen and begin building a custom storefront.
+- [Get started](/custom-storefronts/hydrogen/getting-started/create) with Hydrogen and begin building a custom storefront.
 - Learn about [Hydrogen's architecture and framework](/custom-storefronts/hydrogen/framework).
 - Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -18,31 +18,27 @@ Hydrogen comes with [React Router](https://reactrouter.com/), a tool that allows
 
 ## Hydrogen project structure
 
-When you [create a Hydrogen app](/custom-storefronts/hydrogen/getting-started#step-1-create-a-new-hydrogen-app), a file structure for the project is generated. Most of the files that you'll work with in the Hydrogen project are located in the `/src` directory. The `/src` directory contains the following:
+When you [create a Hydrogen app](/custom-storefronts/hydrogen/getting-started/create#step-1-create-a-new-hydrogen-app), the Hydrogen starter template initializes a basic file structure of a Hydrogen project that's integrated with a Shopify store. Most of the files that you'll work with in the Hydrogen project are located in the `/src` directory. The `/src` directory contains the following:
 
-- A set of boilerplate [components](/api/hydrogen/components) (`components`) and [pages](/custom-storefronts/hydrogen/framework/pages) (`pages`)
+- A set of boilerplate [`components`](/custom-storefronts/hydrogen/getting-started#components) and [`pages`](/custom-storefronts/hydrogen/getting-started#pages)
 - The main app component, which includes boilerplate code for the app and routing (`App.server.jsx`)
 - The Hydrogen app's two entry points, which are based on environment:
 
   - **Server**: `entry-server.jsx`
   - **Client**: `entry-client.jsx`
 
-- A shortcut icon (`favicon.svg`) that you can change to your own favicon
 - Basic styles provided by Tailwind CSS (`index.css`)
 
-{% codeblock file, filename: "Hydrogen project structure" %}
+{% codeblock file, filename: "File structure of the Hydrogen starter template" %}
 
 ```
 └── src
     ├── components
+        └── Button.client.jsx
         └── Cart.client.jsx
-        └── CartProvider.client.jsx
-        └── CartUIProvider.client.jsx
+        └── CartIcon.client.jsx
         └── ...
     ├── pages
-        └── blogs
-            └── [handle]
-            └── [handle].server.jsx
         └── collections
             └── [handle].server.jsx
         └── pages
@@ -50,12 +46,10 @@ When you [create a Hydrogen app](/custom-storefronts/hydrogen/getting-started#st
         └── products
             └── [handle].server.jsx
         └── index.server.jsx
-        └── search.server.jsx
         └── sitemap.xml.server.jsx
     ├── App.server.jsx
     ├── entry-client.jsx
     ├── entry-server.jsx
-    ├── favicon.svg
     ├── index.css
 ```
 

--- a/packages/hydrogen/src/framework/docs/pages.md
+++ b/packages/hydrogen/src/framework/docs/pages.md
@@ -2,7 +2,7 @@ The Hydrogen framework includes page server components. This guide describes how
 
 ## How pages work
 
-Hydrogen uses file-based routing, and any pages added to the `src/pages` folder will be automatically registered as routes by the app.
+Hydrogen uses file-based routing. Any pages added to the `src/pages` directory will be automatically registered as routes by the app.
 
 You might want to add a new page and have it display at `localhost:3000/test`. You can do this by adding a new file to `src/pages`. For example, if you add `test.server.jsx` to `src/pages`, then the page displays at `localhost:3000/test`.
 
@@ -16,9 +16,6 @@ The following example shows how each `*.server.jsx` file maps to a different pag
 ```
 └── src
     ├── pages
-        └── blogs
-            └── [handle]
-            └── [handle].server.jsx // localhost:3000/blogs/<handle>
         └── collections
             └── [handle].server.jsx // localhost:3000/collections/<handle>
         └── pages


### PR DESCRIPTION
## This PR: 
- Adds descriptions for each of the components in the Hydrogen starter template
- Ports over some recent updates to `/hydrogen` from `/shopify-dev` (re: [this PR](https://github.com/Shopify/shopify-dev/pull/13684))
- Relates to https://github.com/Shopify/shopify-dev/pull/13684#discussion_r763385938 and https://github.com/Shopify/shopify-dev/pull/14148