### PR TITLE
chore: deprecate Sanity plugin and point to Sanity's version instead

### DIFF
--- a/packages/hydrogen-plugin-sanity/CHANGELOG.md
+++ b/packages/hydrogen-plugin-sanity/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Deprecate this plugin. Use [hydrogen-plugin-sanity](https://www.npmjs.com/package/hydrogen-plugin-sanity) instead.
 
 ## 0.8.0 - 2021-12-07
 

--- a/packages/hydrogen-plugin-sanity/README.md
+++ b/packages/hydrogen-plugin-sanity/README.md
@@ -1,5 +1,11 @@
 # Sanity plugin for Hydrogen
 
+## NOTICE: This plugin has been deprecated.
+
+**Please use [hydrogen-plugin-sanity](https://www.npmjs.com/package/hydrogen-plugin-sanity) instead.**
+
+---
+
 This is a plugin for Hydrogen with Sanity. A `useSanityQuery` React hook with a API similar to `useShopQuery` is exposed to efficiently and ergonomically fetch data from a Sanity instance.
 
 ## Getting Started
@@ -11,23 +17,24 @@ yarn add @shopify/hydrogen-plugin-sanity
 ```
 
 To fetch data from a Sanity instance:
-```javascript
-  import {useSanityQuery} from '@shopify/hydrogen-plugin-sanity';
 
-  const {data} = useSanityQuery({
-    query: gql`
-      query product($ids: String!) {
-        product: allProduct(where: { id: { in: $ids}}) {
-          id
-          vendor {
-            title
-          }
-          upc
+```javascript
+import {useSanityQuery} from '@shopify/hydrogen-plugin-sanity';
+
+const {data} = useSanityQuery({
+  query: gql`
+    query product($ids: String!) {
+      product: allProduct(where: {id: {in: $ids}}) {
+        id
+        vendor {
+          title
         }
-      } 
-    `,
-    variables: { ids: products.map((product) => product.id) },
-  });
+        upc
+      }
+    }
+  `,
+  variables: {ids: products.map((product) => product.id)},
+});
 ```
 
 The `useSanityQuery` hook knows which Sanity instance to query and authenticate against through the use of two environment variables: `VITE_SANITY_ID` and `VITE_SANITY_TOKEN`. Both of these environment variables must be set in order to fetch data with the `useSanityQuery` hook.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds a call-out to the top of the README that this plugin is being deprecated. This will be propagated to the npmjs page the next time we publish Hydrogen.

Part 1 of #291 

### Additional context

Points users to install https://www.npmjs.com/package/hydrogen-plugin-sanity instead.