### PR TITLE
fix: docs util for grabbing first sentence of ts-doc comment

### DIFF
--- a/packages/generate-docs/src/utilities/shared.ts
+++ b/packages/generate-docs/src/utilities/shared.ts
@@ -295,14 +295,9 @@ export function firstSentence(content: string) {
   if (content === '') {
     return content;
   }
-  const lines = content.split(/(\n|\. )/g);
-  let firstSentence = lines.length ? lines[0] : content;
+  const lines = content.split('\n').join(' ').split('. ');
 
-  // try to split on period if first line doesn't have one
-  if (lines.length && lines[0].indexOf('.') !== 0) {
-    const sentences = content.split('.');
-    firstSentence = sentences[0];
-  }
+  let firstSentence = lines.length ? lines[0] : content;
 
   if (firstSentence[firstSentence.length - 1] !== '.') {
     firstSentence += '.';

--- a/packages/hydrogen/src/foundation/useShop/use-shop.tsx
+++ b/packages/hydrogen/src/foundation/useShop/use-shop.tsx
@@ -3,7 +3,7 @@ import {ShopifyProviderValue} from '../ShopifyProvider/types';
 import {ShopifyContext} from '../ShopifyProvider/ShopifyContext';
 
 /**
- * The `useShop` hook provides access to values within `shopify.config.js`.The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
+ * The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
  */
 export function useShop(): ShopifyProviderValue {
   const context = useContext(ShopifyContext);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/Shopify/custom-storefronts/issues/149

### Additional context

This PR changes how we grab the first sentence from a the description for docs generation.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
