### PR TITLE
docs: product provider tweaks

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - feat: upgrade to latest React 18 experimental version
+- docs: product provider tweaks
 
 ## 0.8.0 - 2021-12-07
 

--- a/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
@@ -67,7 +67,8 @@ The `ProductProviderFragment` includes variables that you will need to provide v
 | `$numProductVariantMetafields`             | The number of `Metafield` objects to query for in a variant's `MetafieldConnection`.                  |
 | `$numProductVariantSellingPlanAllocations` | The number of `SellingPlanAllocations` to query for in a variant's `SellingPlanAllocationConnection`. |
 | `$numProductSellingPlanGroups`             | The number of `SellingPlanGroups` objects to query for in a `SellingPlanGroupConnection`.             |
-| `$$numProductSellingPlans`                 | The number of `SellingPlan` objects to query for in a `SellingPlanConnection`.                        |
+| `$numProductSellingPlans`                  | The number of `SellingPlan` objects to query for in a `SellingPlanConnection`.                        |
+| `$includeReferenceMetafieldDetails`        | A boolean indicating if the reference metafield details should be queried.                            |
 
 ### Example query
 
@@ -86,6 +87,7 @@ export default function Product() {
       numProductVariantSellingPlanAllocations: 10,
       numProductSellingPlanGroups: 10,
       numProductSellingPlans: 10,
+      includeReferenceMetafieldDetails: false,
     },
   });
 

--- a/packages/hydrogen/src/components/ProductProvider/examples/product-provider.example.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/examples/product-provider.example.tsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 const QUERY = gql`
   query product($handle: String!) {
-    product: productByHandle(handle: $handle) {
+    product: product(handle: $handle) {
       ...ProductProviderFragment
     }
   }
@@ -11,13 +11,10 @@ const QUERY = gql`
   ${ProductProviderFragment}
 `;
 
-
 export function Product() {
-  const {data} = useShopQuery({query: QUERY})
+  const {data} = useShopQuery({query: QUERY});
 
   return (
-    <ProductProvider value={data.product.product}>
-      {/* Your JSX */}
-    </ProductProvider>
-  )
+    <ProductProvider product={data.product}>{/* Your JSX */}</ProductProvider>
+  );
 }


### PR DESCRIPTION
### Description

This PR modifies the ProductProvider docs:
- `$$numProductSellingPlans` -> `$numProductSellingPlans`
- Example code: use `product(handle: $handle)` instead of `productByHandle`
- Example code: Add required `$includeReferenceMetafieldDetails`
- Example code: Prop is `product` not `value`

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
