### PR TITLE
feat: detect bot user agents (e.g. googlebot) and change the response type accordingly

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- feat: Detect bot user agents and give bots a non-streamed response.
 - feat: Add global `Oxygen.env` for server-only environment variables.
 - fix: cart decrease button removes at zero quantity
 - feat: upgrade to latest React 18 experimental version

--- a/packages/hydrogen/src/handle-event.ts
+++ b/packages/hydrogen/src/handle-event.ts
@@ -73,7 +73,7 @@ export default async function handleEvent(
   }
 
   const userAgent = request.headers.get('user-agent');
-  const isStreamable = streamableResponse && isBotUA(url, userAgent);
+  const isStreamable = streamableResponse && !isBotUA(url, userAgent);
 
   /**
    * Stream back real-user responses, but for bots/etc,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #294 by including a static list (taken from various places) of known bot user agents, and comparing the request's user agent against that list. If the UA is a bot, then don't do a streaming response so bots get the full fat HTML in one go and don't have to execute JS. 

### Additional context

- I got rid of `isStreamableRequest` since it currently only checked to see if it was a bot. Do we want to keep it around though?
- I would love to add an (e2e probably?) test for this, but I'm not quite sure how - or if that's the right decision. Some guidance on that would be helpful!
- Are there doc updates that need to go with this?

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
