### PR TITLE
[Hydrogen docs]: Hooks overview tables

### DIFF
--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -11,7 +11,7 @@ import gql from 'graphql-tag';
 
 const QUERY = gql`
   query product($handle: String!) {
-    product: productByHandle(handle: $handle) {
+    product: product(handle: $handle) {
       ...ProductProviderFragment
     }
   }
@@ -23,9 +23,7 @@ export function Product() {
   const {data} = useShopQuery({query: QUERY});
 
   return (
-    <ProductProvider value={data.product.product}>
-      {/* Your JSX */}
-    </ProductProvider>
+    <ProductProvider product={data.product}>{/* Your JSX */}</ProductProvider>
   );
 }
 ```
@@ -107,7 +105,8 @@ The `ProductProviderFragment` includes variables that you will need to provide v
 | `$numProductVariantMetafields`             | The number of `Metafield` objects to query for in a variant's `MetafieldConnection`.                  |
 | `$numProductVariantSellingPlanAllocations` | The number of `SellingPlanAllocations` to query for in a variant's `SellingPlanAllocationConnection`. |
 | `$numProductSellingPlanGroups`             | The number of `SellingPlanGroups` objects to query for in a `SellingPlanGroupConnection`.             |
-| `$$numProductSellingPlans`                 | The number of `SellingPlan` objects to query for in a `SellingPlanConnection`.                        |
+| `$numProductSellingPlans`                  | The number of `SellingPlan` objects to query for in a `SellingPlanConnection`.                        |
+| `$includeReferenceMetafieldDetails`        | A boolean indicating if the reference metafield details should be queried.                            |
 
 ### Example query
 
@@ -126,6 +125,7 @@ export default function Product() {
       numProductVariantSellingPlanAllocations: 10,
       numProductSellingPlanGroups: 10,
       numProductSellingPlans: 10,
+      includeReferenceMetafieldDetails: false,
     },
   });
 

--- a/packages/hydrogen/src/foundation/useShop/README.md
+++ b/packages/hydrogen/src/foundation/useShop/README.md
@@ -1,6 +1,6 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/foundation/useShop and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/master/content/internal/operations/hydrogen-reference-docs.md. -->
 
-The `useShop` hook provides access to values within `shopify.config.js`.The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
+The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
 
 ## Example code
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -209,6 +209,15 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'foundation/useQuery',
         'hooks/useShopQuery',
       ],
+      intro:
+        'Global hooks are React hooks that relate to your entire app. You use global hooks to fetch data from server components.',
+      tables: [
+        await generator.table({
+          title: 'Reference',
+          description: 'Hydrogen includes the following global hooks:',
+          columns: ['Hook name', Column.Description],
+        }),
+      ],
     }),
 
     // Primitive
@@ -234,6 +243,15 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'Get familiar with the Hydrogen product and variant hooks included in Hydrogen.',
       url: '/api/hydrogen/hooks/product-variant/index.md',
       entry: ['hooks/useProduct', 'hooks/useProductOptions'],
+      intro:
+        'Products are the goods, digital downloads, services, and gift cards that a merchant sells. If a product has options, like size or color, then merchants can add a variant for each combination of options. Each combination of option values for a product can be a variant for that product. For example, a t-shirt might be available for purchase in blue and green. The blue t-shirt and the green t-shirt are variants.',
+      tables: [
+        await generator.table({
+          title: 'Reference',
+          description: 'Hydrogen includes the following product and variant hooks:',
+          columns: ['Hook name', Column.Description],
+        }),
+      ],
     }),
     // Metafield
     generator.section({
@@ -242,6 +260,15 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'Get familiar with the Hydrogen metafield hooks included in Hydrogen.',
       url: '/api/hydrogen/hooks/metafield/index.md',
       entry: ['hooks/useParsedMetafields'],
+      intro:
+        'Metafields allow you to attach specialized information to Shopify resources, such as part numbers or release dates. Merchants and other apps can retrieve and edit the data that is stored in metafields from the Shopify admin.',
+      tables: [
+        await generator.table({
+          title: 'Reference',
+          description: 'Hydrogen includes the following metafield hooks:',
+          columns: ['Hook name', Column.Description],
+        }),
+      ],
     }),
     // Cart
     generator.section({
@@ -263,6 +290,15 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'hooks/useCartLinesUpdateCallback',
         'hooks/useCartNoteUpdateCallback',
       ],
+      intro:
+        'A cart contains the merchandise that a customer intends to purchase and the estimated cost associated with the cart. When a customer is ready to purchase their items, they can proceed to checkout.',
+      tables: [
+        await generator.table({
+          title: 'Reference',
+          description: 'Hydrogen includes the following cart hooks:',
+          columns: ['Hook name', Column.Description],
+        }),
+      ],
     }),
     // Localization
     generator.section({
@@ -271,6 +307,15 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
         'Get familiar with the Hydrogen localization hooks included in Hydrogen.',
       url: '/api/hydrogen/hooks/localization/index.md',
       entry: ['hooks/useAvailableCountries', 'hooks/useCountry'],
+      intro:
+        'Localization can help merchants expand their business to a global audience by creating shopping experiences in local languages and currencies.',
+      tables: [
+        await generator.table({
+          title: 'Reference',
+          description: 'Hydrogen includes the following localization hooks:',
+          columns: ['Hook name', Column.Description],
+        }),
+      ],
     }),
     // Utilities
     generator.section({


### PR DESCRIPTION
## This PR: 
- Defines and passes in the remaining hooks tables to the docs generator script
- Relates to https://github.com/Shopify/shopify-dev/pull/14213