### PR TITLE
Load logger only once

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
   "lerna": "4.0.0",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "0.8.1",
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix: load logger only once.
 
 ## 0.8.1 - 2022-01-04
 

--- a/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
+++ b/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
@@ -1,6 +1,6 @@
 import React, {ReactElement, useMemo} from 'react';
 import {Route, Switch, useRouteMatch} from 'react-router-dom';
-import {Logger} from '../../utilities/log/log';
+import type {Logger} from '../../utilities/log/log';
 
 export type ImportGlobEagerOutput = Record<string, Record<'default', any>>;
 

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -1,5 +1,5 @@
 import type {CacheOptions, QueryKey} from '../../types';
-import {log} from '../../utilities';
+import {log} from '../../utilities/log';
 import {
   deleteItemFromCache,
   getItemFromCache,

--- a/packages/hydrogen/src/handle-event.ts
+++ b/packages/hydrogen/src/handle-event.ts
@@ -4,7 +4,6 @@ import type {ServerComponentRequest} from './framework/Hydration/ServerComponent
 import {getCacheControlHeader} from './framework/cache';
 import {setContext, setCache, RuntimeContext} from './framework/runtime';
 import {setConfig} from './framework/config';
-import {getLoggerFromContext, logServerResponse} from './utilities/log';
 
 interface HydrogenFetchEvent {
   /**
@@ -76,8 +75,6 @@ export default async function handleEvent(
   const userAgent = request.headers.get('user-agent');
   const isStreamable = streamableResponse && !isBotUA(url, userAgent);
 
-  const logger = getLoggerFromContext(request);
-
   /**
    * Stream back real-user responses, but for bots/etc,
    * use `render` instead. This is because we need to inject <head>
@@ -90,7 +87,6 @@ export default async function handleEvent(
         request,
         response: streamableResponse,
         dev,
-        log: logger,
       });
     } else {
       stream(url, {
@@ -99,7 +95,6 @@ export default async function handleEvent(
         response: streamableResponse,
         template,
         dev,
-        log: logger,
       });
     }
     return;
@@ -111,7 +106,6 @@ export default async function handleEvent(
       context: {},
       isReactHydrationRequest,
       dev,
-      log: logger,
     });
 
   const headers = componentResponse.headers;
@@ -162,8 +156,6 @@ export default async function handleEvent(
       headers,
     });
   }
-
-  logServerResponse('ssr', logger, request, response.status);
 
   return response;
 }

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -1,5 +1,5 @@
 import {useShop} from '../../foundation/useShop';
-import {log} from '../../utilities';
+import {log} from '../../utilities/log';
 import {ASTNode} from 'graphql';
 import {useQuery} from '../../foundation/useQuery';
 import type {CacheOptions} from '../../types';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -8,11 +8,10 @@ export {
   graphqlRequestBody,
   decodeShopifyId,
   isClient,
-  log,
-  setLogger,
   getTime,
-  Logger,
 } from './utilities';
+
+export {log, setLogger, Logger} from './utilities/log';
 
 export {Helmet} from 'react-helmet-async';
 

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -1,5 +1,4 @@
 import {ServerResponse} from 'http';
-import type {Logger} from './utilities/log/log';
 import type {ServerComponentResponse} from './framework/Hydration/ServerComponentResponse.server';
 import type {ServerComponentRequest} from './framework/Hydration/ServerComponentRequest.server';
 import type {Metafield, Image, MediaContentType} from './graphql/types/types';
@@ -11,7 +10,6 @@ export type Renderer = (
     context?: Record<string, any>;
     isReactHydrationRequest?: boolean;
     dev?: boolean;
-    log: Logger;
   }
 ) => Promise<
   {
@@ -27,7 +25,6 @@ export type Streamer = (
     request: ServerComponentRequest;
     response: ServerResponse;
     template: string;
-    log: Logger;
     dev?: boolean;
   }
 ) => void;
@@ -38,7 +35,6 @@ export type Hydrator = (
     context: any;
     request: ServerComponentRequest;
     response: ServerResponse;
-    log: Logger;
     dev?: boolean;
   }
 ) => void;

--- a/packages/hydrogen/src/utilities/index.ts
+++ b/packages/hydrogen/src/utilities/index.ts
@@ -17,14 +17,6 @@ export {wrapPromise} from './suspense';
 export {flattenConnection} from './flattenConnection';
 export {isClient} from './isClient';
 export {isServer} from './isServer';
-export {
-  log,
-  setLogger,
-  Logger,
-  logServerResponse,
-  getLoggerFromContext,
-  resetLogger,
-} from './log';
 export {getMeasurementAsParts, getMeasurementAsString} from './measurement';
 export {parseMetafieldValue} from './parseMetafieldValue';
 export {fetchBuilder, graphqlRequestBody, decodeShopifyId} from './fetch';

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -7,11 +7,6 @@ import {getTime} from '../timing';
  * component. Using the latter is ideal, because it will ty your log to the current request in progress.
  */
 
-declare global {
-  // eslint-disable-next-line no-var
-  var __hlogger: Logger;
-}
-
 export interface Logger {
   trace: (...args: Array<any>) => void;
   debug: (...args: Array<any>) => void;
@@ -20,19 +15,7 @@ export interface Logger {
   fatal: (...args: Array<any>) => void;
 }
 
-export function getLoggerFromContext(context: any): Logger {
-  return {
-    trace: (...args) => globalThis.__hlogger.trace(context, ...args),
-    debug: (...args) => globalThis.__hlogger.debug(context, ...args),
-    warn: (...args) => globalThis.__hlogger.warn(context, ...args),
-    error: (...args) => globalThis.__hlogger.error(context, ...args),
-    fatal: (...args) => globalThis.__hlogger.fatal(context, ...args),
-  };
-}
-
-// @todo - multiple instances of log.ts are loaded, we utilitze the
-// global in order to make sure that the logger is a singleton
-const defaultLogger = (globalThis.__hlogger = {
+const defaultLogger = {
   trace(context: {[key: string]: any}, ...args: Array<any>) {
     console.log(...args);
   },
@@ -48,31 +31,43 @@ const defaultLogger = (globalThis.__hlogger = {
   fatal(context: {[key: string]: any}, ...args: Array<any>) {
     console.error(red('FATAL: '), ...args);
   },
-});
+};
 
-export function setLogger(_logger: Logger) {
-  globalThis.__hlogger = _logger;
+let logger = defaultLogger as Logger;
+
+export function getLoggerFromContext(context: any): Logger {
+  return {
+    trace: (...args) => logger.trace(context, ...args),
+    debug: (...args) => logger.debug(context, ...args),
+    warn: (...args) => logger.warn(context, ...args),
+    error: (...args) => logger.error(context, ...args),
+    fatal: (...args) => logger.fatal(context, ...args),
+  };
+}
+
+export function setLogger(newLogger: Logger) {
+  logger = newLogger;
 }
 
 export function resetLogger() {
-  globalThis.__hlogger = defaultLogger;
+  logger = defaultLogger;
 }
 
 export const log: Logger = {
   trace(...args) {
-    return globalThis.__hlogger.trace({}, ...args);
+    return logger.trace({}, ...args);
   },
   debug(...args) {
-    return globalThis.__hlogger.debug({}, ...args);
+    return logger.debug({}, ...args);
   },
   warn(...args) {
-    return globalThis.__hlogger.warn({}, ...args);
+    return logger.warn({}, ...args);
   },
   error(...args) {
-    return globalThis.__hlogger.error({}, ...args);
+    return logger.error({}, ...args);
   },
   fatal(...args) {
-    return globalThis.__hlogger.fatal({}, ...args);
+    return logger.fatal({}, ...args);
   },
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #386 

The logger was imported in two different contexts in the server. More info in #386.

This is basically moving the creation of the logger and `logServerResponse` to `entry-server` to be consistent and keep the logger running always in the "ssr environment" that Vite loads via `ssrLoadModule`.

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
