### PR TITLE
fix: warn instead of error when the app takes longer than 3s #408

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - fix: load logger only once.
+- fix: warn when requests take longer than 3000ms instead of erroring
 - feat: `useQuery` returns an error if the query's fetch was unsuccessful
 - feat: `useShopQuery` will give error hints to look at `shopify.config.js` when the Storefront API responds with a 403
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -119,7 +119,7 @@ const renderHydrogen: ServerHandler = (App, hook) => {
 
     const head = template.match(/<head>(.+?)<\/head>/s)![1];
 
-    const {pipe, abort} = renderToPipeableStream(
+    const {pipe} = renderToPipeableStream(
       <Html head={head}>
         <ReactApp {...state} />
       </Html>,
@@ -202,13 +202,7 @@ const renderHydrogen: ServerHandler = (App, hook) => {
 
     const streamTimeout = setTimeout(() => {
       const errorMessage = `The app failed to stream after ${STREAM_ABORT_TIMEOUT_MS} ms`;
-      log.error(errorMessage);
-
-      if (dev && response.headersSent) {
-        response.write(getErrorMarkup(new Error(errorMessage)));
-      }
-
-      abort();
+      log.warn(errorMessage);
     }, STREAM_ABORT_TIMEOUT_MS);
   };
 
@@ -239,7 +233,7 @@ const renderHydrogen: ServerHandler = (App, hook) => {
 
     const writer = new HydrationWriter();
 
-    const {pipe, abort} = renderToPipeableStream(
+    const {pipe} = renderToPipeableStream(
       <HydrationContext.Provider value={true}>
         <ReactApp {...state} />
       </HydrationContext.Provider>,
@@ -272,10 +266,9 @@ const renderHydrogen: ServerHandler = (App, hook) => {
     );
 
     const renderTimeout = setTimeout(() => {
-      const errorMessage = `The app failed to render RSC after ${STREAM_ABORT_TIMEOUT_MS} ms`;
-      didError = new Error(errorMessage);
-      log.error(errorMessage);
-      abort();
+      log.error(
+        `The app failed to render RSC after ${STREAM_ABORT_TIMEOUT_MS} ms`
+      );
     }, STREAM_ABORT_TIMEOUT_MS);
   };
 
@@ -387,9 +380,7 @@ function renderAppFromBufferedStream(
 ) {
   return new Promise<string>((resolve, reject) => {
     const errorTimeout = setTimeout(() => {
-      reject(
-        new Error(`The app failed to SSR after ${STREAM_ABORT_TIMEOUT_MS} ms`)
-      );
+      log.warn(`The app failed to SSR after ${STREAM_ABORT_TIMEOUT_MS} ms`);
     }, STREAM_ABORT_TIMEOUT_MS);
 
     if (isWorker) {


### PR DESCRIPTION
### Description
fix: warn instead of error when the app takes longer than 3s 

### Additional context
Usually for suspense streaming, react recommends you abort after a specified timeout. On abort, the client (browser) takes over rendering. For RSC this isn't possible, because the rendering must happen on the server. So we can't really abort. Instead we throw an error. This is not desirable because there are many things that could make the overall request take longer than the default 3000ms timeout. Also that 3000ms timeout is not configurable by the merchant. Instead, we should just warn the merchant that a long request is in progress, and hope that it resolves. (maybe there could be a separate timeout that errors after some excruciating long time? 30s)

---

### Before submitting the PR, please make sure you do the following:

- [X] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository for your change, if needed
