### PR TITLE
feat: update stackblitz action to use new examples

### DIFF
--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Rename gitignore
         run: |
-          mv packages/dev/_gitignore packages/dev/.gitignore
+          mv packages/template-hydrogen-default/_gitignore packages/template-hydrogen-default/.gitignore
       - name: Push to stackblitz branch
         run: |
           git show-ref


### PR DESCRIPTION
Related discussion: https://github.com/Shopify/hydrogen/discussions/404
Successor to: https://github.com/Shopify/hydrogen/pull/422

### Description

This PR updates the github action responsible for publishing our stackblitz branch to reference the new top-level default example.

### Additional context

A complimentary PR has been created to redirect the `hydrogen.new` but I will not link it here in the interest of keeping that aspect internal-only.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
