### PR TITLE
feat: Support local commands in CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "debug": "^4.3.2",
     "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
+    "glob-promise": "^4.2.2",
     "inquirer": "^8.1.2",
     "minimist": "^1.2.5",
     "prettier": "^2.4.1"

--- a/packages/cli/src/Command.ts
+++ b/packages/cli/src/Command.ts
@@ -1,0 +1,73 @@
+import {resolve, basename, extname} from 'path';
+import debug from 'debug';
+
+import {InputError, tree} from './utilities';
+import {CONFIG_DIRECTORY} from './config';
+import {Env} from './types';
+
+interface ModuleType {
+  default: (env: Env) => Promise<void>;
+}
+
+export class Command {
+  private logger: debug.Debugger;
+  private module: ModuleType | null = null;
+  private modulePath: string | null = null;
+
+  constructor(public command: string) {
+    this.logger = debug(`hydrogen/${command}`);
+  }
+
+  async run(env: Env) {
+    this.logger(`Running ${this.command}`);
+
+    if (!this.modulePath) {
+      return;
+    }
+
+    try {
+      this.module = await import(this.modulePath);
+
+      if (!this.module) {
+        return;
+      }
+
+      await this.module.default({
+        ...env,
+        logger: this.logger,
+      });
+    } catch (error) {
+      this.logger(error);
+      console.error(error);
+      env.ui.say(`Command module not found at ${this.modulePath} ${error}`, {
+        error: true,
+      });
+
+      throw new InputError();
+    }
+
+    this.logger(`Finished ${this.command}`);
+  }
+
+  async load() {
+    this.logger(`Loading ${this.command}`);
+
+    const localCommands = await tree(resolve(CONFIG_DIRECTORY, 'commands'));
+
+    this.modulePath =
+      [...localCommands.files, ...localCommands.directories].find(
+        matchCommand(this.command)
+      ) || `./commands/${this.command}`;
+
+    this.logger(`Loaded ${this.modulePath}`);
+  }
+}
+
+function commandNameFromPath(path?: string) {
+  return path ? basename(path, extname(path)) : '';
+}
+
+function matchCommand(inputCommand: string) {
+  return (command: string) =>
+    inputCommand.split('/').includes(commandNameFromPath(command));
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -35,3 +35,5 @@ export async function loadConfig(
     logger(error);
   }
 }
+
+export const CONFIG_DIRECTORY = '.hydrogen';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,62 +1,38 @@
 import debug from 'debug';
-import {parseCliArguments, InputError, UnknownError} from './utilities';
+
+import {parseCliArguments, InputError} from './utilities';
 import {Cli} from './ui';
 import {Workspace} from './workspace';
 import {Fs} from './fs';
 import {loadConfig} from './config';
-import {Env} from './types';
+import {Command} from './Command';
 
 const logger = debug('hydrogen');
 
-interface ModuleType {
-  default: (env: Env) => Promise<void>;
-}
-
 (async () => {
   const rawInputs = process.argv.slice(2);
-  const {command, root} = parseCliArguments(rawInputs);
+  const {root, ...inputs} = parseCliArguments(rawInputs);
   const ui = new Cli();
-
   const config = (await loadConfig('hydrogen', {root})) || {};
   const workspace = new Workspace({root, ...config});
   const fs = new Fs(root);
 
-  if (!command) {
+  if (!inputs.command) {
     ui.say(`Missing command input`, {error: true});
 
     throw new InputError();
   }
 
-  async function runModule(module: ModuleType) {
-    logger('Run start');
+  const command = new Command(inputs.command);
 
-    await module.default({
-      ui,
-      fs,
-      workspace,
-      logger: debug(`hydrogen/${command}`),
-    });
-
-    logger('Run end');
-  }
-
-  try {
-    const module = await import(`./commands/${command}`);
-
-    await runModule(module);
-  } catch (error) {
-    logger(error);
-
-    throw new UnknownError();
-  }
+  await command.load();
+  await command.run({ui, fs, workspace, logger});
 
   for await (const file of fs.commit()) {
     ui.printFile(file);
   }
 
-  if (command === 'init') {
-    await workspace.commit();
-  }
+  await workspace.commit();
 })().catch((error) => {
   logger(error);
   process.exitCode = 1;

--- a/packages/cli/src/testing/testing.ts
+++ b/packages/cli/src/testing/testing.ts
@@ -24,7 +24,7 @@ import getPort from 'get-port';
 const INPUT_TIMEOUT = 500;
 const execPromise = promisify(exec);
 
-type Command = 'create' | 'create component' | 'create page' | 'check';
+export type Command = 'create' | 'create component' | 'create page' | 'check';
 type Input = Record<string, string | boolean | null>;
 
 interface App {

--- a/packages/cli/src/tests/cli.test.ts
+++ b/packages/cli/src/tests/cli.test.ts
@@ -1,0 +1,35 @@
+import {Command, withCli} from '../testing';
+
+describe('CLI', () => {
+  it('runs local commands from .hydrogen directory', async () => {
+    await withCli(async ({run, fs}) => {
+      await fs.write(
+        '.hydrogen/commands/foo.js',
+        `module.exports = function foo({ui}) {
+            ui.say('hello from local foo command');
+          };
+          `
+      );
+
+      const result = await run('foo' as Command);
+
+      expect(result.output.stdout).toStrictEqual(
+        expect.arrayContaining([
+          expect.stringMatching('hello from local foo command'),
+        ])
+      );
+    });
+  });
+
+  it('throws when command doesn’t exist', async () => {
+    await withCli(async ({run, fs}) => {
+      const result = await run('foo' as Command);
+
+      expect(result.output.stdout).toStrictEqual(
+        expect.arrayContaining([
+          expect.stringMatching('Command module not found'),
+        ])
+      );
+    });
+  });
+});

--- a/packages/cli/src/utilities/index.ts
+++ b/packages/cli/src/utilities/index.ts
@@ -7,6 +7,7 @@ export * from './feature';
 export {merge} from './merge';
 export {componentName, validComponentName} from './react';
 export {formatFile} from './format';
+export {tree, uniq} from './tree';
 
 const DEFAULT_SUBCOMMANDS = {
   create: 'app',
@@ -25,6 +26,6 @@ export function parseCliArguments(rawInputs?: string[]) {
   return {
     root: resolve(root),
     mode: debug ? 'debug' : 'default',
-    command: [command, subcommand].join('/'),
+    command: subcommand ? [command, subcommand].join('/') : command,
   };
 }

--- a/packages/cli/src/utilities/tree.ts
+++ b/packages/cli/src/utilities/tree.ts
@@ -1,0 +1,57 @@
+import {join} from 'path';
+
+import {statSync, existsSync, mkdirpSync} from 'fs-extra';
+import * as glob from 'glob-promise';
+
+interface Options {
+  recursive?: boolean;
+}
+
+export async function tree(path: string, options: Options = {}) {
+  if (!existsSync(path)) {
+    mkdirpSync(path);
+  }
+
+  const result = await walk(path, options.recursive);
+
+  return result;
+}
+
+async function walk(
+  path: string,
+  recursive = false
+): Promise<{files: string[]; directories: string[]}> {
+  if (!existsSync(path)) {
+    return {files: [], directories: []};
+  }
+
+  const pattern = recursive ? '*/**' : '*';
+  const items = await glob.promise(pattern, {
+    cwd: path,
+    root: path,
+    dot: false,
+    ignore: '**/*.d.ts',
+  });
+
+  if (items.length <= 0) {
+    return {files: [], directories: []};
+  }
+
+  const files: string[] = [];
+  const directories: string[] = [];
+
+  for (const item of items) {
+    const fullPath = join(path, item);
+    if ((await statSync(fullPath)).isDirectory()) {
+      directories.push(fullPath);
+    } else {
+      files.push(fullPath);
+    }
+  }
+
+  return {files: uniq(files), directories: uniq(directories)};
+}
+
+export function uniq<T>(array: T[]) {
+  return [...new Set(array)];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,7 +2506,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@^7.1.1":
+"@types/glob@^7.1.1", "@types/glob@^7.1.3":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
   integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
@@ -6353,6 +6353,13 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob-promise@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-4.2.2.tgz#15f44bcba0e14219cd93af36da6bb905ff007877"
+  integrity sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==
+  dependencies:
+    "@types/glob" "^7.1.3"
 
 glob-to-regexp@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR enables in-project commands to extend the hydrogen CLI.

### Additional context

When the CLI attempts to load a command it will first check the local `.hydrogen/commands` folder. If a command is found there, then it will run and these take priority over "official" commands.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
