### PR TITLE
fix: do not attempt to decode Product IDs.

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - fix: load logger only once.
 - feat: `useQuery` returns an error if the query's fetch was unsuccessful
 - feat: `useShopQuery` will give error hints to look at `shopify.config.js` when the Storefront API responds with a 403
+- fix: do not attempt to decode product IDs, as they are no longer base64-encoded in `unstable`
 
 ## 0.8.1 - 2022-01-04
 

--- a/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
+++ b/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
@@ -34,7 +34,7 @@ export function ShopPayButton({variantIds, className}: ShopPayButtonProps) {
 
   useEffect(() => {
     const ids = variantIds.reduce<string[]>((accumulator, gid) => {
-      const id = atob(gid).split('/').pop();
+      const id = gid.split('/').pop();
       if (id) {
         accumulator.push(id);
       }

--- a/packages/hydrogen/src/utilities/fetch.ts
+++ b/packages/hydrogen/src/utilities/fetch.ts
@@ -70,12 +70,6 @@ export function graphqlRequestBody(
 
 export function decodeShopifyId(id: string) {
   if (!id.startsWith('gid://')) {
-    id =
-      typeof btoa !== 'undefined'
-        ? btoa(id)
-        : Buffer.from(id, 'base64').toString('ascii');
-  }
-  if (!id.startsWith('gid://')) {
     throw new Error('invalid Shopify ID');
   }
   return id;


### PR DESCRIPTION
### Description

As of this morning, Product Ids are no longer encoded in `unstable` in the Storefront API

### Additional context

Currently, the cart crashes when it attempts to 

Since Hydrogen is built against `unstable` during dev preview, we no longer need to do any base64 decoding of Product IDs.

People using existing Hydrogen apps should upgrade to this version of Hydrogen.

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
