### PR TITLE
ci: prettier ignore lerna.json to stop breaking CI after publishing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
+# built files
 **/dist/**
+# Lerna creates its own commit when publishing, and doesn't format things like prettier wants. For now, just ignore it and let Lerna format that file as it wants
+lerna.json


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I think Lerna changes `lerna.json` on every publish, and doesn’t give prettier a chance to format the file correctly before it commits and pushes. This is causing new PRs after a publish to fail the github CI/CD pipelines due to formatting issues.

It seems that we could potentially add a Lerna `version` lifecycle script that runs `yarn format`  so that the file is formatted before the Lerna commit happens, or we could add `lerna.json` to prettier-ignore so that we just let lerna format how it wishes?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Either this, or adding a lifecycle to run prettier during Lerna publish. I'm good either way on this one. Thoughts?
