### PR TITLE
Force file formatting parser in cli

### DIFF
--- a/packages/cli/src/fs/fs.ts
+++ b/packages/cli/src/fs/fs.ts
@@ -65,10 +65,12 @@ export class Fs {
       }
 
       const oldFile = this.readCache.get(path);
-      const formattedFile = formatFile(contents);
-      const diff = oldFile ? formatFile(oldFile) !== formattedFile : false;
+      const formattedFile = await formatFile(path, contents);
+      const diff = oldFile
+        ? (await formatFile(path, oldFile)) !== formattedFile
+        : false;
 
-      await writeFile(path, formatFile(formattedFile));
+      await writeFile(path, formattedFile);
       yield {path: this.relativePath(path), overwritten: exists, diff: diff};
     }
   }

--- a/packages/cli/src/utilities/format.ts
+++ b/packages/cli/src/utilities/format.ts
@@ -1,13 +1,24 @@
 import prettier from 'prettier';
+import {extname} from 'path';
 
-const PRETTIER_CONFIG = {
-  parser: 'babel',
-  ...require('@shopify/prettier-config'),
-};
+const DEFAULT_PRETTIER_CONFIG = {...require('@shopify/prettier-config')};
 
-export function formatFile(content: string) {
-  // TODO: Search for local project config with fallback to Shopify
-  const formattedContent = prettier.format(content, PRETTIER_CONFIG);
+export async function formatFile(path: string, content: string) {
+  const ext = extname(path);
+  const prettierConfig = {
+    // TODO: Search for local project config with fallback to Shopify
+    ...DEFAULT_PRETTIER_CONFIG,
+    parser: 'babel',
+  };
+
+  switch (ext) {
+    case '.html':
+    case '.css':
+      prettierConfig.parser = ext.slice(1);
+      break;
+  }
+
+  const formattedContent = await prettier.format(content, prettierConfig);
 
   return formattedContent;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The CLI was throwing errors when trying to parse different files types. This PR forces the parser from on the file's extension for css and html files only (the ones causing errors). This meant passing the path to the format file util as well.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
