### PR TITLE
fix: yarn scripts cli path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,8 +20,8 @@
     "dev": "yarn build -w",
     "build": "tsc -p . ",
     "prepack": "yarn build && node scripts/copy-templates.js",
-    "hydrogen": "./packages/cli/bin/hydrogen",
-    "h2": "./packages/cli/bin/hydrogen"
+    "hydrogen": "./bin/hydrogen",
+    "h2": "./bin/hydrogen"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes the path to the hydrogen binary when running the cli locally from within the `packages/cli` folder.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
