### PR TITLE
fix: cli init create missing directory

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -32,6 +32,8 @@ export async function init(env: Env) {
     if (overwrite) {
       await fs.empty(workspace.root());
     }
+  } else {
+    await fs.makeDir(workspace.root());
   }
 
   const template = await ui.ask<Template>(

--- a/packages/cli/src/fs/fs.ts
+++ b/packages/cli/src/fs/fs.ts
@@ -52,8 +52,8 @@ export class Fs {
     }
   }
 
-  async exists(path: string) {
-    return await pathExists(this.fullPath(path));
+  exists(path: string) {
+    return pathExists(this.fullPath(path));
   }
 
   async *commit(): AsyncIterableIterator<FileResult> {
@@ -75,6 +75,10 @@ export class Fs {
 
   write(path: string, contents: string) {
     this.files.set(this.fullPath(path), contents);
+  }
+
+  makeDir(dir: string) {
+    return mkdirp(dir);
   }
 
   fullPath(path: string) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Creates a directory if one does not exist in the CLI init command.



### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
