### PR TITLE
fix: add npm-run-all as a dev dependency (for run-p)

### DIFF
--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -75,7 +75,7 @@
     "postcss": "^8",
     "raw-loader": "^4.0.2",
     "rimraf": "^3.0.2",
-    "run-p": "^0.0.0"
+    "npm-run-all": "^4.1.5"
   },
   "peerDependencies": {
     "react": "0.0.0-experimental-0cc724c77-20211125",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -74,7 +74,8 @@
     "mkdirp": "^1.0.4",
     "postcss": "^8",
     "raw-loader": "^4.0.2",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "run-p": "^0.0.0"
   },
   "peerDependencies": {
     "react": "0.0.0-experimental-0cc724c77-20211125",


### PR DESCRIPTION
<!-- Thank you for contributing! -->
Development fails because run-p is not added as a dep. So this PR adds and fix this behaviour.
### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---


