### PR TITLE
fix: flakey check test

### DIFF
--- a/packages/cli/src/commands/check/tests/check.test.ts
+++ b/packages/cli/src/commands/check/tests/check.test.ts
@@ -1,5 +1,10 @@
 import {withCli} from '../../../testing';
 
+// Some tests in this file are finishing before
+// the stream is closed. This is a known issue.
+// We should investigate and remove this increase.
+jest.setTimeout(30000);
+
 describe('check', () => {
   describe('eslint', () => {
     it('fails in an empty project', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixing some flakey CLI tests by increasing the jest timeout.

### Additional context

Some of the CLI tests require additional time. This is because:
- they accept mock user inputs, which need to be passed in by our test framework.
- they write and read files from a sandbox environment and this I/O takes time

I'm not crazy about increasing the timeout, but this might simply be the unavoidable nature of having tests that rely on the above 2 points. I'd be interested in what others think, but for now we should merge this so that the flakey tests do not disrupt development further.

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
