### PR TITLE
[Hydrogen reference]: React Server Components docs revised

### DIFF
--- a/packages/hydrogen/src/framework/docs/react-server-components.md
+++ b/packages/hydrogen/src/framework/docs/react-server-components.md
@@ -17,15 +17,15 @@ For example, the following React element tree is [composed of React components](
 
 React Server Components include the following component types:
 
-| Type   | Description                                                                                                                                                                                                                                                 | Filename convention                         |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| Server | Components that fetch data and render content on the server. Their dependencies aren't in the client bundle. Server components don't include any client-side interactivity. Only server components can make calls to the [Storefront API](/api/storefront). | End in `.client.jsx`                        |
-| Client | Components that render on the client. These components include client-side stateful interactivity.                                                                                                                                                          | End in `.server.jsx`                        |
-| Shared | Components that render on both the server and the client.                                                                                                                                                                                                   | Don't end in `.client.jsx` or `.server.jsx` |
+| Type   | Description                                                                                                                                                                                                                                                 | Filename convention                                                   |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Server | Components that fetch data and render content on the server. Their dependencies aren't in the client bundle. Server components don't include any client-side interactivity. Only server components can make calls to the [Storefront API](/api/storefront). | Server components end in `.server.jsx`.                               |
+| Client | Components that render on the client. Client components include client-side stateful interactivity.                                                                                                                                                         | Client components end in `.client.jsx`.                               |
+| Shared | Components that render on both the server and the client.                                                                                                                                                                                                   | Shared components don't end in either `.client.jsx` or `.server.jsx`. |
 
 ## Benefits
 
-React Server Components separate the concerns between client and server logic. This separation provides the following benefits to Hydrogen apps:
+React Server Components separate client and server logic. This separation provides the following benefits to Hydrogen apps:
 
 - Server-only code that has no impact on bundle size and reduces bundle sizes
 - Server-side access to custom and private server-side data sources
@@ -44,7 +44,7 @@ React Server Components have the following constraints on server and client comp
 - Client components can’t access server-only features, like the filesystem, and can only import other client components.
 - Server components can’t access client-only features, like state.
 
-Due to these constraints, there are [specific rules](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#capabilities--constraints-of-server-and-client-components) you need to follow when building your Hydrogen app:
+Due to these constraints, there are [specific rules](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#capabilities--constraints-of-server-and-client-components) that you need to follow when building your Hydrogen app:
 
 ![A diagram that illustrates the rules that apply to server and client components](/assets/custom-storefronts/hydrogen/server-client-component-rules.png)
 
@@ -83,7 +83,7 @@ export default function MyServerComponent() {
 
 ```js
 // `MyOuterServerComponent` can instantiate both the client and server
-// components. You can pass in a `<MyServerComponent/>` as
+// components. You can pass in `<MyServerComponent/>` as
 // the `children` prop to `MyClientComponent`.
 import MyClientComponent from './MyClientComponent.client';
 import MyServerComponent from './MyServerComponent.server';
@@ -128,11 +128,11 @@ The following prop wouldn't send successfully:
 
 ### Sharing code between server and client
 
-In addition to server-specific and client-specific components, you can also create components that work on both the server and the client. This allows logic to be shared across environments, as long as the components meet all the [constraints of both the server and client components](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#sharing-code-between-server-and-client).
+In addition to server-specific and client-specific components, you can create components that work on both the server and the client. This allows logic to be shared across environments, as long as the components meet all the [constraints of both the server and client components](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#sharing-code-between-server-and-client).
 
 ![A diagram that illustrates server-specific and client-specific components, and shared components between the client and server](/assets/custom-storefronts/hydrogen/hydrogen-shared-components.png)
 
-Although shared components have the most restrictions, many components already obey these rules and can be used across the server and client without modification. For example, many components transform some props based on certain conditions, without using state or loading additional data. This is why shared components are the default and don’t have a special file extension.
+Although shared components have the most constraints, many components already obey these rules and can be used across the server and client without modification. For example, many components transform some props based on certain conditions, without using state or loading additional data. This is why shared components are the default and [don’t have a dedicated file extension](#component-types).
 
 ## Next steps
 

--- a/packages/hydrogen/src/framework/docs/react-server-components.md
+++ b/packages/hydrogen/src/framework/docs/react-server-components.md
@@ -1,88 +1,104 @@
-Hydrogen is modelled after [React Server Components](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html), an approach that offers an opinionated data-fetching and rendering workflow for React apps. React Server Components are rendered in the server-side to improve the performance of React apps by decreasing bundle size and performing queries on the server.
+Hydrogen is modelled after [React Server Components](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html), an approach that offers an opinionated data-fetching and rendering workflow for React apps.
 
-This guide provides information about rules for server and client components and known limitations.
+This guide provides information about how React Server Components work in the context of Hydrogen.
 
 > Note:
 > React Server Components are currently in Alpha. However, Hydrogen includes a built-in layer of abstraction that provides stability, regardless of the state of React Server Components.
 
-## Component types
+## How React Server Components work
+
+React Server Components allow the server and the client to work together to render your Hydrogen app.
+
+For example, the following React element tree is [composed of React components](#composition) that render other React components. React Server Components allow some components to render on the server, some to render on the client, and others to render on both the server and the client:
+
+![A diagram that illustrates a React element tree composed of server, client, and shared components](/assets/custom-storefronts/hydrogen/react-element-tree.png)
+
+### Component types
 
 React Server Components include the following component types:
 
-| Type   | Description                                                                                                                                                       |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Server | Components that render on the server. Server components don't include any client-side interactivity. Only server components can make calls to the Storefront API. |
-| Client | Components that render on the client. These components include client-side interactivity.                                                                         |
-| Shared | Components that render on both the server and the client.                                                                                                         |
+| Type   | Description | Filename convention                                                                                    
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| Server | Components that fetch data and render content on the server. Their dependencies aren't in the client bundle. Server components don't include any client-side interactivity. Only server components can make calls to the [Storefront API](/api/storefront). | End in `.client.jsx` |
+| Client | Components that render on the client. These components include client-side stateful interactivity. | End in `.server.jsx` |
+| Shared | Components that render on both the server and the client. | Don't end in `.client.jsx` or `.server.jsx` |
 
-## Rules for server and client components
+## Benefits
 
-React Server Components have the following constraints on server and client components:
+React Server Components separate the concerns between client and server logic. This separation provides the following benefits to Hydrogen apps:
 
-- Component filenames ending with `.client.jsx` render on the client.
-- Component filenames ending with `.server.jsx` render on the server, and their dependencies aren't in the client bundle.
-- Component filenames not ending in `.client.jsx` or `.server.jsx` render on both the server and the client.
-- Client components can’t access server-only features, like the filesystem, and can only import other client components.
-- Server components can’t access client-only features, like state.
+- Server-only code that has no impact on bundle size and reduces bundle sizes
+- Server-side access to custom and private server-side data sources
+- Seamless integration and a well-defined protocol for server and client components
+- Streaming rendering and progressive hydration
+- Subtree and component-level updates that preserve client state
+- [Server and client code sharing](#sharing-code-between-server-and-client), where appropriate
 
-Due to these constraints, there are [specific rules](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#capabilities--constraints-of-server-and-client-components) you need to follow when building your Hydrogen app.
+## Constraints
 
 > Tip:
 > You don't need to memorize the rules referenced in this section to use React Server Components. Hydrogen has lint rules and error messages to help enforce the constraints on `.server.jsx` and `.client.jsx` files during the rendering process.
 
+React Server Components have the following constraints on server and client components:
+
+- Client components can’t access server-only features, like the filesystem, and can only import other client components.
+- Server components can’t access client-only features, like state.
+
+Due to these constraints, there are [specific rules](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#capabilities--constraints-of-server-and-client-components) you need to follow when building your Hydrogen app:
+
 ![A diagram that illustrates the rules that apply to server and client components](/assets/custom-storefronts/hydrogen/server-client-component-rules.png)
 
-### Example
+### Composition
 
-The following example shows a server component (`Product.server.jsx`) that uses the [`useShopQuery`](/api/hydrogen/hooks/global/useshopquery) hook to fetch data. The data is passed to a client component (`WishListButton.client.jsx`) that uses state:
+One of the key constraints of React Server Components is that you can't import and render server components from client components. However, you can compose React Server Components to take in props.
 
-{% codeblock file, filename: 'Product.server.jsx' %}
+The following example shows how to pass a server component as a `children` prop to a client component. The `OuterServerComponent` can then instantiate both the client and server components. This is how you can have server components under client components in your [React element tree](#how-react-server-components-work).
+
+{% codeblock file, filename: 'MyClientComponent.client.jsx' %}
 
 ```js
-import {useShopQuery} from '@shopify/hydrogen';
-import WishListButton from './WishListButton.client';
-
-export default function Product() {
-  const {data} = useShopQuery({query: QUERY});
-
+export default function MyClientComponent({ children }) {
   return (
-    <section>
-      <h1>{data.product.title}</h1>
-      <WishListButton product={data.product} />
-    </section>
-  );
+    <div>
+      <h1>This code is rendered on the client</h1>
+      {children}
+    </div>
+  )
 }
 ```
 
 {% endcodeblock %}
 
-{% codeblock file, filename: 'WishListButton.client.jsx' %}
+{% codeblock file, filename: 'MyServerComponent.server.jsx' %}
 
 ```js
-import {useState} from 'react';
-
-export default function WishListButton({product}) {
-  const [added, setAddToWishList] = useState(false);
-
-  return (
-    <button onClick={() => setAddToWishList(!added)} type="button">
-      {added ? 'Added' : 'Add'} {product.title} to Wish List
-    </button>
-  );
+export default function MyServerComponent() {
+  return <span>This code is rendered on the server</span>
 }
 ```
 
 {% endcodeblock %}
 
-## Sharing code between server and client
+{% codeblock file, filename: 'MyOuterServerComponent.server.jsx' %}
 
-In addition to server-specific and client-specific components, you can also create components, hooks, and utilities that work on both the server and the client. This allows logic to be shared across environments, as long as the components, hooks, and utilities meet all the [constraints of both the server and client components](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#sharing-code-between-server-and-client).
+```js
+// `MyOuterServerComponent` can instantiate both the client and server
+// components. You can pass in a `<MyServerComponent/>` as
+// the `children` prop to `MyClientComponent`.
+import MyClientComponent from './MyClientComponent.client'
+import MyServerComponent from './MyServerComponent.server'
+export default function MyOuterServerComponent() {
+  return (
+    <MyClientComponent>
+      <MyServerComponent />
+    </MyClientComponent>
+  )
+}
+```
 
-![A diagram that illustrates server-specific and client-specific components and hooks, and shared components and hooks between the client and server](/assets/custom-storefronts/hydrogen/hydrogen-shared-components.png)
+{% endcodeblock %}
 
-Although shared components have the most restrictions, many components already obey these rules and can be used across the server and client without modification. For example, many components transform some props based on certain conditions, without using state or loading additional data. This is why shared components are the default and don’t have a special file extension.
-
-## Known limitations
+### Sending props
 
 When you send props to client components from a server component, make sure that the props are JSON-serializable. For example, functions or callbacks can't be passed as props.
 
@@ -109,6 +125,14 @@ The following prop wouldn't send successfully:
 ```
 
 {% endcodeblock %}
+
+### Sharing code between server and client
+
+In addition to server-specific and client-specific components, you can also create components that work on both the server and the client. This allows logic to be shared across environments, as long as the components meet all the [constraints of both the server and client components](https://github.com/josephsavona/rfcs/blob/server-components/text/0000-server-components.md#sharing-code-between-server-and-client).
+
+![A diagram that illustrates server-specific and client-specific components, and shared components between the client and server](/assets/custom-storefronts/hydrogen/hydrogen-shared-components.png)
+
+Although shared components have the most restrictions, many components already obey these rules and can be used across the server and client without modification. For example, many components transform some props based on certain conditions, without using state or loading additional data. This is why shared components are the default and don’t have a special file extension.
 
 ## Next steps
 

--- a/packages/hydrogen/src/framework/docs/react-server-components.md
+++ b/packages/hydrogen/src/framework/docs/react-server-components.md
@@ -17,11 +17,11 @@ For example, the following React element tree is [composed of React components](
 
 React Server Components include the following component types:
 
-| Type   | Description | Filename convention                                                                                    
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| Server | Components that fetch data and render content on the server. Their dependencies aren't in the client bundle. Server components don't include any client-side interactivity. Only server components can make calls to the [Storefront API](/api/storefront). | End in `.client.jsx` |
-| Client | Components that render on the client. These components include client-side stateful interactivity. | End in `.server.jsx` |
-| Shared | Components that render on both the server and the client. | Don't end in `.client.jsx` or `.server.jsx` |
+| Type   | Description                                                                                                                                                                                                                                                 | Filename convention                         |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| Server | Components that fetch data and render content on the server. Their dependencies aren't in the client bundle. Server components don't include any client-side interactivity. Only server components can make calls to the [Storefront API](/api/storefront). | End in `.client.jsx`                        |
+| Client | Components that render on the client. These components include client-side stateful interactivity.                                                                                                                                                          | End in `.server.jsx`                        |
+| Shared | Components that render on both the server and the client.                                                                                                                                                                                                   | Don't end in `.client.jsx` or `.server.jsx` |
 
 ## Benefits
 
@@ -57,13 +57,13 @@ The following example shows how to pass a server component as a `children` prop 
 {% codeblock file, filename: 'MyClientComponent.client.jsx' %}
 
 ```js
-export default function MyClientComponent({ children }) {
+export default function MyClientComponent({children}) {
   return (
     <div>
       <h1>This code is rendered on the client</h1>
       {children}
     </div>
-  )
+  );
 }
 ```
 
@@ -73,7 +73,7 @@ export default function MyClientComponent({ children }) {
 
 ```js
 export default function MyServerComponent() {
-  return <span>This code is rendered on the server</span>
+  return <span>This code is rendered on the server</span>;
 }
 ```
 
@@ -85,14 +85,14 @@ export default function MyServerComponent() {
 // `MyOuterServerComponent` can instantiate both the client and server
 // components. You can pass in a `<MyServerComponent/>` as
 // the `children` prop to `MyClientComponent`.
-import MyClientComponent from './MyClientComponent.client'
-import MyServerComponent from './MyServerComponent.server'
+import MyClientComponent from './MyClientComponent.client';
+import MyServerComponent from './MyServerComponent.server';
 export default function MyOuterServerComponent() {
   return (
     <MyClientComponent>
       <MyServerComponent />
     </MyClientComponent>
-  )
+  );
 }
 ```
 

--- a/packages/hydrogen/src/framework/docs/third-party-dependencies.md
+++ b/packages/hydrogen/src/framework/docs/third-party-dependencies.md
@@ -20,7 +20,7 @@ npm install <dependency>
 
 Consider the following:
 
-- If the dependency interacts with `useState` or browser APIs, then place it inside a `*.client.jsx` component. Follow the [rules of server and client components](/custom-storefronts/hydrogen/framework/react-server-components#rules-for-server-and-client-components).
+- If the dependency interacts with `useState` or browser APIs, then place it inside a `*.client.jsx` component. Follow the [rules of server and client components](/custom-storefronts/hydrogen/framework/react-server-components#constraints).
 - If the dependency is purely client-based, and you don't need to interact with it in individual components, then you can insert it in `src/entry-client.jsx`.
 - If the dependency includes a style import from a CSS file, then you can import that in `src/entry-client.jsx`.
 

--- a/packages/hydrogen/src/framework/docs/work-with-rsc.md
+++ b/packages/hydrogen/src/framework/docs/work-with-rsc.md
@@ -85,15 +85,15 @@ Sharing state information between the client and server is important for common 
 
 1. `App.server.jsx` relies on the `page` state to choose the correct route to render. To change routes, the client updates the `page` state:
 
-    {% codeblock file, filename: 'ProductDetails.client.jsx' %}
+   {% codeblock file, filename: 'ProductDetails.client.jsx' %}
 
-    ```js
-    useEffect(() => {
-      setServerState('page', location.pathname);
-    }, [location.pathname, setServerState]);
-    ```
+   ```js
+   useEffect(() => {
+     setServerState('page', location.pathname);
+   }, [location.pathname, setServerState]);
+   ```
 
-    {% endcodeblock %}
+   {% endcodeblock %}
 
 2. The `page` state is sent to the server. This happens through a `useServerResponse` fetch call. It's a special server endpoint called `/react` which accepts `state` as a query parameter.
 3. The `/react` endpoint returns the wire representation for the new state.

--- a/packages/hydrogen/src/framework/docs/work-with-rsc.md
+++ b/packages/hydrogen/src/framework/docs/work-with-rsc.md
@@ -1,4 +1,4 @@
-This guide provides information about working with React Server Components in your Hydrogen app.
+This guide provides information about working with React Server Components in your Hydrogen app. To learn how React Server Components work in the context of Hydrogen, refer to [React Server Components overview](/custom-storefronts/hydrogen/framework/react-server-components).
 
 > Note:
 > React Server Components are currently in Alpha. However, Hydrogen includes a built-in layer of abstraction that provides stability, regardless of the state of React Server Components.
@@ -12,11 +12,65 @@ Hydrogen provides the following ways to fetch data from server components:
 - [`useShopQuery`](/api/hydrogen/hooks/global/useshopquery): A hook that allows you to make server-only GraphQL queries to the Storefront API.
 - [`useQuery`](/api/hydrogen/hooks/global/usequery): A simple wrapper around `fetch` that supports [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html). You can use this function to call any third-party APIs.
 
+### Example
+
+The following example shows a server component (`Product.server.jsx`) that uses the `useShopQuery` hook to fetch data. The data is passed to a client component (`WishListButton.client.jsx`) that uses state:
+
+{% codeblock file, filename: 'Product.server.jsx' %}
+
+```js
+import {useShopQuery} from '@shopify/hydrogen';
+import WishListButton from './WishListButton.client';
+
+export default function Product() {
+  const {data} = useShopQuery({query: QUERY});
+
+  return (
+    <section>
+      <h1>{data.product.title}</h1>
+      <WishListButton product={data.product} />
+    </section>
+  );
+}
+```
+
+{% endcodeblock %}
+
+{% codeblock file, filename: 'WishListButton.client.jsx' %}
+
+```js
+import {useState} from 'react';
+
+export default function WishListButton({product}) {
+  const [added, setAddToWishList] = useState(false);
+
+  return (
+    <button onClick={() => setAddToWishList(!added)} type="button">
+      {added ? 'Added' : 'Add'} {product.title} to Wish List
+    </button>
+  );
+}
+```
+
+{% endcodeblock %}
+
 ## Accessing Hydrogen components from client components
 
 Because of the way tree-shaking works in Vite, avoid importing server components when referencing Hydrogen client components in one of your client components.
 
 Hydrogen provides a special `@shopify/hydrogen/client` module to reference components that are safe to use within client components. You should use this import path when writing your client components.
+
+### Example
+
+The following example shows how to use the `@shopify/hydrogen/client` import path in a client component:
+
+{% codeblock file, filename: 'ProductSelector.client.jsx' %}
+
+```jsx
+import {useServerState} from '@shopify/hydrogen/client';
+```
+
+{% endcodeblock %}
 
 ## Sharing `state` between client and server
 
@@ -31,15 +85,15 @@ Sharing state information between the client and server is important for common 
 
 1. `App.server.jsx` relies on the `page` state to choose the correct route to render. To change routes, the client updates the `page` state:
 
-   {% codeblock file, filename: 'ProductDetails.client.jsx' %}
+    {% codeblock file, filename: 'ProductDetails.client.jsx' %}
 
-   ```js
-   useEffect(() => {
-     setServerState('page', location.pathname);
-   }, [location.pathname, setServerState]);
-   ```
+    ```js
+    useEffect(() => {
+      setServerState('page', location.pathname);
+    }, [location.pathname, setServerState]);
+    ```
 
-   {% endcodeblock %}
+    {% endcodeblock %}
 
 2. The `page` state is sent to the server. This happens through a `useServerResponse` fetch call. It's a special server endpoint called `/react` which accepts `state` as a query parameter.
 3. The `/react` endpoint returns the wire representation for the new state.


### PR DESCRIPTION
## This PR:
- Illustrates how React Server Components are made up of client, server, and shared components (React element tree)
- Makes some sign-posting and organizational improvements
- Relates to https://github.com/Shopify/shopify-dev/issues/10171 and https://github.com/Shopify/shopify-dev/pull/14939