### PR TITLE
[Hydrogen reference]: Specify `initialVariantId` prop as optional

### DIFF
--- a/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
@@ -19,7 +19,7 @@ export function ProductProvider({
   /** A [Product object](/api/storefront/reference/products/product). */
   product: Product;
   /** The initially selected variant. */
-  initialVariantId: string;
+  initialVariantId?: string;
 }) {
   const {
     variants,


### PR DESCRIPTION
## This PR: 
- Specifies the `initialVariantId` prop as optional in the `ProductProvider` component
- Relates to https://shopify.slack.com/archives/C02A5S8LNP9/p1642111732399700 and https://github.com/Shopify/shopify-dev/issues/10171