### PR TITLE
dx: rename graphqlApiVersion to storefrontApiVersion

### DIFF
--- a/examples/template-hydrogen-default/shopify.config.js
+++ b/examples/template-hydrogen-default/shopify.config.js
@@ -1,4 +1,5 @@
 export default {
   storeDomain: 'hydrogen-preview.myshopify.com',
   storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
+  storefrontApiVersion: 'unstable',
 };

--- a/packages/cli/src/commands/add/shopifyConfig/templates/shopify-config-js.ts
+++ b/packages/cli/src/commands/add/shopifyConfig/templates/shopify-config-js.ts
@@ -5,6 +5,7 @@ export default function ({storeDomain, storefrontToken}: TemplateOptions) {
 module.exports = {
   storeDomain: '${storeDomain}',
   storefrontToken: '${storefrontToken}',
+  storefrontApiVersion: 'unstable',
 };
 `;
 }

--- a/packages/cli/src/commands/add/shopifyProvider/templates/shopify-config-js.ts
+++ b/packages/cli/src/commands/add/shopifyProvider/templates/shopify-config-js.ts
@@ -5,6 +5,7 @@ export default function ({storeDomain, storefrontToken}: TemplateOptions) {
 module.exports = {
   storeDomain: '${storeDomain}',
   storefrontToken: '${storefrontToken}',
+  storefrontApiVersion: 'unstable',
 };
 `;
 }

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Warn instead of error when a page server component is missing valid exports
 - Adopt upstream version of React Server Components. See [#498](https://github.com/Shopify/hydrogen/pull/498) for breaking changes.
 - The 'locale' option in shopify.config.js had been renamed to 'defaultLocale'
+- dx: rename `graphqlApiVersion` to `storefrontApiVersion` in `shopify.config.js`
 
 ## 0.9.1 - 2022-01-20
 

--- a/packages/hydrogen/src/components/CartProvider/hooks.tsx
+++ b/packages/hydrogen/src/components/CartProvider/hooks.tsx
@@ -10,7 +10,7 @@ import {
 import {Cart} from './types';
 
 export function useCartFetch() {
-  const {storeDomain, graphqlApiVersion, storefrontToken} = useShop();
+  const {storeDomain, storefrontApiVersion, storefrontToken} = useShop();
 
   return React.useCallback(
     <T, K>({
@@ -21,7 +21,7 @@ export function useCartFetch() {
       variables: T;
     }): Promise<{data: K | undefined; error: any}> => {
       return fetch(
-        `https://${storeDomain}/api/${graphqlApiVersion}/graphql.json`,
+        `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
         {
           method: 'POST',
           headers: {
@@ -42,7 +42,7 @@ export function useCartFetch() {
           };
         });
     },
-    [storeDomain, graphqlApiVersion, storefrontToken]
+    [storeDomain, storefrontApiVersion, storefrontToken]
   );
 }
 

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyContext.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyContext.tsx
@@ -1,5 +1,5 @@
 import {createContext} from 'react';
-import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../constants';
+import {DEFAULT_LOCALE} from '../constants';
 import type {ShopifyContextValue} from './types';
 import type {ShopifyConfig} from '../../types';
 
@@ -13,7 +13,6 @@ export function makeShopifyContext(
     locale: shopifyConfig.defaultLocale ?? DEFAULT_LOCALE,
     storeDomain: shopifyConfig?.storeDomain?.replace(/^https?:\/\//, ''),
     storefrontToken: shopifyConfig.storefrontToken,
-    storefrontApiVersion:
-      shopifyConfig.storefrontApiVersion ?? DEFAULT_API_VERSION,
+    storefrontApiVersion: shopifyConfig.storefrontApiVersion,
   };
 }

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyContext.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyContext.tsx
@@ -13,6 +13,7 @@ export function makeShopifyContext(
     locale: shopifyConfig.defaultLocale ?? DEFAULT_LOCALE,
     storeDomain: shopifyConfig?.storeDomain?.replace(/^https?:\/\//, ''),
     storefrontToken: shopifyConfig.storefrontToken,
-    graphqlApiVersion: shopifyConfig.graphqlApiVersion ?? DEFAULT_API_VERSION,
+    storefrontApiVersion:
+      shopifyConfig.storefrontApiVersion ?? DEFAULT_API_VERSION,
   };
 }

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -72,13 +72,13 @@ describe('<ShopifyProvider />', () => {
       });
     });
 
-    it('contains graphqlApiVersion from shopifyConfig', () => {
+    it('contains storefrontApiVersion from shopifyConfig', () => {
       const provider = mount(
         <ShopifyProvider
           shopifyConfig={{
             storeDomain: 'hydrogen-preview.myshopify.com',
             storefrontToken: '1234',
-            graphqlApiVersion: '2022-04',
+            storefrontApiVersion: '2022-04',
           }}
         >
           <Children />
@@ -87,12 +87,12 @@ describe('<ShopifyProvider />', () => {
 
       expect(provider).toContainReactComponent(ShopifyContext.Provider, {
         value: expect.objectContaining({
-          graphqlApiVersion: '2022-04',
+          storefrontApiVersion: '2022-04',
         }),
       });
     });
 
-    it('contains DEFAULT_API_VERSION as graphqlApiVersion when it is not specify in shopifyConfig', () => {
+    it('contains DEFAULT_API_VERSION as storefrontApiVersion when it is not specify in shopifyConfig', () => {
       const provider = mount(
         <ShopifyProvider
           shopifyConfig={{
@@ -106,7 +106,7 @@ describe('<ShopifyProvider />', () => {
 
       expect(provider).toContainReactComponent(ShopifyContext.Provider, {
         value: expect.objectContaining({
-          graphqlApiVersion: DEFAULT_API_VERSION,
+          storefrontApiVersion: DEFAULT_API_VERSION,
         }),
       });
     });

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -91,25 +91,6 @@ describe('<ShopifyProvider />', () => {
         }),
       });
     });
-
-    it('contains DEFAULT_API_VERSION as storefrontApiVersion when it is not specify in shopifyConfig', () => {
-      const provider = mount(
-        <ShopifyProvider
-          shopifyConfig={{
-            storeDomain: 'hydrogen-preview.myshopify.com',
-            storefrontToken: '1234',
-          }}
-        >
-          <Children />
-        </ShopifyProvider>
-      );
-
-      expect(provider).toContainReactComponent(ShopifyContext.Provider, {
-        value: expect.objectContaining({
-          storefrontApiVersion: DEFAULT_API_VERSION,
-        }),
-      });
-    });
   });
 });
 

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {ShopifyProvider} from '../ShopifyProvider';
 import {ShopifyContext} from '../ShopifyContext';
-import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../../constants';
+import {DEFAULT_LOCALE} from '../../constants';
 import {SHOPIFY_CONFIG} from './fixtures';
 
 describe('<ShopifyProvider />', () => {
@@ -25,6 +25,7 @@ describe('<ShopifyProvider />', () => {
             defaultLocale: 'zh-TW',
             storeDomain: 'hydrogen-preview.myshopify.com',
             storefrontToken: '1234',
+            storefrontApiVersion: 'unstable',
           }}
         >
           <Children />
@@ -42,6 +43,7 @@ describe('<ShopifyProvider />', () => {
           shopifyConfig={{
             storeDomain: 'hydrogen-preview.myshopify.com',
             storefrontToken: '1234',
+            storefrontApiVersion: 'unstable',
           }}
         >
           <Children />
@@ -59,6 +61,7 @@ describe('<ShopifyProvider />', () => {
           shopifyConfig={{
             storeDomain: 'https://hydrogen-preview.myshopify.com',
             storefrontToken: '1234',
+            storefrontApiVersion: 'unstable',
           }}
         >
           <Children />

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/fixtures.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/fixtures.ts
@@ -1,8 +1,8 @@
-import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../../constants';
+import {DEFAULT_LOCALE} from '../../constants';
 
 export const SHOPIFY_CONFIG = {
   locale: DEFAULT_LOCALE,
   storeDomain: 'notashop.myshopify.io',
   storefrontToken: 'abc123',
-  apiVersion: DEFAULT_API_VERSION,
+  storefrontApiVersion: 'unstable',
 };

--- a/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
@@ -4,7 +4,7 @@ export type ShopifyContextValue = {
   locale: string;
   storeDomain: ShopifyConfig['storeDomain'];
   storefrontToken: ShopifyConfig['storefrontToken'];
-  graphqlApiVersion: string;
+  storefrontApiVersion: string;
 };
 
 export type ShopifyProviderProps = {

--- a/packages/hydrogen/src/foundation/constants.ts
+++ b/packages/hydrogen/src/foundation/constants.ts
@@ -1,4 +1,3 @@
 // Note: do not mix this export with other app-only logic
 // to avoid importing unnecessary code in the plugins.
-export const DEFAULT_API_VERSION = 'unstable';
 export const DEFAULT_LOCALE = 'en-us';

--- a/packages/hydrogen/src/foundation/useShop/README.md
+++ b/packages/hydrogen/src/foundation/useShop/README.md
@@ -18,12 +18,12 @@ export default function MyPage() {
 
 The `useShop` hook returns an object with the following keys:
 
-| Key                 | Description                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| `locale`            | The application locale. Default to `defaultLocale` in `shopify.config.js` then `en-us`. |
-| `storeDomain`       | The store domain set in `shopify.config.js`.                                            |
-| `storefrontToken`   | The Storefront API token set in `shopify.config.js`.                                    |
-| `graphqlApiVersion` | The GraphQL API version set in `shopify.config.js`. Default to `unstable`.              |
+| Key                    | Description                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `locale`               | The application locale. Default to `defaultLocale` in `shopify.config.js` then `en-us`. |
+| `storeDomain`          | The store domain set in `shopify.config.js`.                                            |
+| `storefrontToken`      | The Storefront API token set in `shopify.config.js`.                                    |
+| `storefrontApiVersion` | The Storefront GraphQL API version set in `shopify.config.js`. Default to `unstable`.   |
 
 ## Related components
 

--- a/packages/hydrogen/src/foundation/useShop/README.md
+++ b/packages/hydrogen/src/foundation/useShop/README.md
@@ -23,7 +23,7 @@ The `useShop` hook returns an object with the following keys:
 | `locale`               | The application locale. Default to `defaultLocale` in `shopify.config.js` then `en-us`. |
 | `storeDomain`          | The store domain set in `shopify.config.js`.                                            |
 | `storefrontToken`      | The Storefront API token set in `shopify.config.js`.                                    |
-| `storefrontApiVersion` | The Storefront GraphQL API version set in `shopify.config.js`. Default to `unstable`.   |
+| `storefrontApiVersion` | The Storefront GraphQL API version set in `shopify.config.js`. |
 
 ## Related components
 

--- a/packages/hydrogen/src/foundation/useShop/README.md
+++ b/packages/hydrogen/src/foundation/useShop/README.md
@@ -23,7 +23,7 @@ The `useShop` hook returns an object with the following keys:
 | `locale`               | The application locale. Default to `defaultLocale` in `shopify.config.js` then `en-us`. |
 | `storeDomain`          | The store domain set in `shopify.config.js`.                                            |
 | `storefrontToken`      | The Storefront API token set in `shopify.config.js`.                                    |
-| `storefrontApiVersion` | The Storefront GraphQL API version set in `shopify.config.js`.                          |
+| `storefrontApiVersion` | The GraphQL Storefront API version set in `shopify.config.js`.                          |
 
 ## Related components
 

--- a/packages/hydrogen/src/foundation/useShop/README.md
+++ b/packages/hydrogen/src/foundation/useShop/README.md
@@ -23,7 +23,7 @@ The `useShop` hook returns an object with the following keys:
 | `locale`               | The application locale. Default to `defaultLocale` in `shopify.config.js` then `en-us`. |
 | `storeDomain`          | The store domain set in `shopify.config.js`.                                            |
 | `storefrontToken`      | The Storefront API token set in `shopify.config.js`.                                    |
-| `storefrontApiVersion` | The Storefront GraphQL API version set in `shopify.config.js`. |
+| `storefrontApiVersion` | The Storefront GraphQL API version set in `shopify.config.js`.                          |
 
 ## Related components
 

--- a/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
+++ b/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
@@ -2,9 +2,9 @@
 
 The `useShop` hook returns an object with the following keys:
 
-| Key                    | Description                                                                   |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| `locale`               | The locale set in `shopify.config.js`.                                        |
-| `storeDomain`          | The store domain set in `shopify.config.js`.                                  |
-| `storefrontToken`      | The Storefront API token set in `shopify.config.js`.                          |
-| `storefrontApiVersion` | The Storefront API version set in `shopify.config.js`. Defaults to `unstable` |
+| Key                    | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| `locale`               | The locale set in `shopify.config.js`.                 |
+| `storeDomain`          | The store domain set in `shopify.config.js`.           |
+| `storefrontToken`      | The Storefront API token set in `shopify.config.js`.   |
+| `storefrontApiVersion` | The Storefront API version set in `shopify.config.js`. |

--- a/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
+++ b/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
@@ -2,9 +2,9 @@
 
 The `useShop` hook returns an object with the following keys:
 
-| Key                 | Description                                          |
-| ------------------- | ---------------------------------------------------- |
-| `locale`            | The locale set in `shopify.config.js`.               |
-| `storeDomain`       | The store domain set in `shopify.config.js`.         |
-| `storefrontToken`   | The Storefront API token set in `shopify.config.js`. |
-| `graphqlApiVersion` | The GraphQL API version set in `shopify.config.js`.  |
+| Key                    | Description                                          |
+| ---------------------- | ---------------------------------------------------- |
+| `locale`               | The locale set in `shopify.config.js`.               |
+| `storeDomain`          | The store domain set in `shopify.config.js`.         |
+| `storefrontToken`      | The Storefront API token set in `shopify.config.js`. |
+| `storefrontApiVersion` | The GraphQL API version set in `shopify.config.js`.  |

--- a/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
+++ b/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
@@ -2,9 +2,9 @@
 
 The `useShop` hook returns an object with the following keys:
 
-| Key                    | Description                                            |
-| ---------------------- | ------------------------------------------------------ |
-| `locale`               | The locale set in `shopify.config.js`.                 |
-| `storeDomain`          | The store domain set in `shopify.config.js`.           |
-| `storefrontToken`      | The Storefront API token set in `shopify.config.js`.   |
-| `storefrontApiVersion` | The Storefront API version set in `shopify.config.js`. |
+| Key                    | Description                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `locale`               | The locale set in `shopify.config.js`.                                        |
+| `storeDomain`          | The store domain set in `shopify.config.js`.                                  |
+| `storefrontToken`      | The Storefront API token set in `shopify.config.js`.                          |
+| `storefrontApiVersion` | The Storefront API version set in `shopify.config.js`. Defaults to `unstable` |

--- a/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
+++ b/packages/hydrogen/src/foundation/useShop/docs/1-return-value.md
@@ -2,9 +2,9 @@
 
 The `useShop` hook returns an object with the following keys:
 
-| Key                    | Description                                          |
-| ---------------------- | ---------------------------------------------------- |
-| `locale`               | The locale set in `shopify.config.js`.               |
-| `storeDomain`          | The store domain set in `shopify.config.js`.         |
-| `storefrontToken`      | The Storefront API token set in `shopify.config.js`. |
-| `storefrontApiVersion` | The GraphQL API version set in `shopify.config.js`.  |
+| Key                    | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| `locale`               | The locale set in `shopify.config.js`.                 |
+| `storeDomain`          | The store domain set in `shopify.config.js`.           |
+| `storefrontToken`      | The Storefront API token set in `shopify.config.js`.   |
+| `storefrontApiVersion` | The Storefront API version set in `shopify.config.js`. |

--- a/packages/hydrogen/src/framework/graphiql.ts
+++ b/packages/hydrogen/src/framework/graphiql.ts
@@ -1,9 +1,7 @@
-import {DEFAULT_API_VERSION} from '../foundation/constants';
-
 export function graphiqlHtml(
   shop: string,
   token: string,
-  apiVersion = DEFAULT_API_VERSION
+  apiVersion = 'unstable'
 ) {
   return `<html>
   <head>

--- a/packages/hydrogen/src/framework/graphiql.ts
+++ b/packages/hydrogen/src/framework/graphiql.ts
@@ -1,8 +1,4 @@
-export function graphiqlHtml(
-  shop: string,
-  token: string,
-  apiVersion = 'unstable'
-) {
+export function graphiqlHtml(shop: string, token: string, apiVersion: string) {
   return `<html>
   <head>
     <title>Shopify Storefront API</title>

--- a/packages/hydrogen/src/framework/middleware.ts
+++ b/packages/hydrogen/src/framework/middleware.ts
@@ -175,14 +175,14 @@ async function respondWithGraphiql(
     );
   }
 
-  const {storeDomain, storefrontToken, graphqlApiVersion} = shopifyConfig;
+  const {storeDomain, storefrontToken, storefrontApiVersion} = shopifyConfig;
 
   response.setHeader('Content-Type', 'text/html');
   response.end(
     graphiqlHtml(
       storeDomain?.replace(/^https?:\/\//, ''),
       storefrontToken,
-      graphqlApiVersion
+      storefrontApiVersion
     )
   );
 }

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -96,11 +96,11 @@ function createShopRequest(body: string, locale?: string) {
   const {
     storeDomain,
     storefrontToken,
-    graphqlApiVersion,
+    storefrontApiVersion,
     locale: defaultLocale,
   } = useShop();
 
-  const url = `https://${storeDomain}/api/${graphqlApiVersion}/graphql.json`;
+  const url = `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`;
 
   return {
     request: new Request(url, {
@@ -112,6 +112,6 @@ function createShopRequest(body: string, locale?: string) {
       },
       body,
     }),
-    key: [storeDomain, graphqlApiVersion, body, locale],
+    key: [storeDomain, storefrontApiVersion, body, locale],
   };
 }

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -47,7 +47,7 @@ export type ShopifyConfig = {
   defaultLocale?: string;
   storeDomain: string;
   storefrontToken: string;
-  graphqlApiVersion?: string;
+  storefrontApiVersion?: string;
 };
 
 export type Hook = (

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -47,7 +47,7 @@ export type ShopifyConfig = {
   defaultLocale?: string;
   storeDomain: string;
   storefrontToken: string;
-  storefrontApiVersion?: string;
+  storefrontApiVersion: string;
 };
 
 export type Hook = (

--- a/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
+++ b/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {createMount} from '@shopify/react-testing';
-import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../../foundation/constants';
+import {DEFAULT_LOCALE} from '../../foundation/constants';
 
 import {ShopifyConfig} from '../../types';
 import {ShopifyProvider} from '../../foundation/ShopifyProvider';
@@ -30,6 +30,6 @@ export function getShopifyConfig(config: Partial<ShopifyConfig> = {}) {
     locale: config.defaultLocale ?? DEFAULT_LOCALE,
     storeDomain: config.storeDomain ?? 'notashop.myshopify.io',
     storefrontToken: config.storefrontToken ?? 'abc123',
-    storefrontApiVersion: config.storefrontApiVersion ?? DEFAULT_API_VERSION,
+    storefrontApiVersion: config.storefrontApiVersion ?? 'unstable',
   };
 }

--- a/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
+++ b/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
@@ -30,6 +30,6 @@ export function getShopifyConfig(config: Partial<ShopifyConfig> = {}) {
     locale: config.defaultLocale ?? DEFAULT_LOCALE,
     storeDomain: config.storeDomain ?? 'notashop.myshopify.io',
     storefrontToken: config.storefrontToken ?? 'abc123',
-    graphqlApiVersion: config.graphqlApiVersion ?? DEFAULT_API_VERSION,
+    storefrontApiVersion: config.storefrontApiVersion ?? DEFAULT_API_VERSION,
   };
 }

--- a/packages/playground/server-components-worker/shopify.config.js
+++ b/packages/playground/server-components-worker/shopify.config.js
@@ -2,5 +2,5 @@ export default {
   locale: 'en-us',
   storeDomain: 'hydrogen-preview.myshopify.com',
   storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
-  graphqlApiVersion: 'unstable',
+  storefrontApiVersion: 'unstable',
 };

--- a/packages/playground/server-components/shopify.config.js
+++ b/packages/playground/server-components/shopify.config.js
@@ -2,5 +2,5 @@ export default {
   locale: 'en-us',
   storeDomain: 'hydrogen-preview.myshopify.com',
   storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
-  graphqlApiVersion: 'unstable',
+  storefrontApiVersion: 'unstable',
 };


### PR DESCRIPTION
BREAKING CHANGE: In `shopify.config.js`, rename the `graphqlApiVersion` property to `storefrontApiVersion`

Close #462

<!-- Thank you for contributing! -->

### Description

It was requested to rename `graphqlApiVersion` to have a more clear name, and I created #462 in response. 

This is a breaking change, but hopefully simple to fix. 

If we feel uncomfortable about merging this in at this moment, I think it would be fairly safe to wait until we merge in some other bigger breaking changes, and add this one at that time too. But preferably before v1. 

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
