### PR TITLE
[Hydrogen reference]: Clarify required usage of `initialVariantId` prop 

### DIFF
--- a/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
@@ -19,7 +19,9 @@ export function ProductProvider({
   /** A [Product object](/api/storefront/reference/products/product). */
   product: Product;
   /** The initially selected variant. This is required only if you're using a `SelectedVariantX` hook in the `ProductProvider` component.*/
-  initialVariantId?: string;
+  initialVariantId?: Parameters<
+    typeof useProductOptions
+  >['0']['initialVariantId'];
 }) {
   const {
     variants,

--- a/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
@@ -18,7 +18,7 @@ export function ProductProvider({
   children: ReactNode;
   /** A [Product object](/api/storefront/reference/products/product). */
   product: Product;
-  /** The initially selected variant. */
+  /** The initially selected variant. This is required only if you're using a `SelectedVariantX` hook in the `ProductProvider` component.*/
   initialVariantId?: string;
 }) {
   const {


### PR DESCRIPTION
## This PR: 
- Clarifies that the `initialVariantId` prop is required if you're using a `SelectedVariantX` hook in the `ProductProvider` component.
- Relates to https://shopify.slack.com/archives/C02A5S8LNP9/p164211173239970, https://github.com/Shopify/shopify-dev/issues/10171, https://github.com/Shopify/shopify-dev/pull/14954, and https://github.com/Shopify/shopify-dev/pull/15006