### PR TITLE
Update Dockerfile from the example

### DIFF
--- a/examples/template-hydrogen-default/Dockerfile
+++ b/examples/template-hydrogen-default/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:14 AS build-env
+FROM node:16 AS build-env
 ADD . /app
 
 WORKDIR /app
-RUN npm install
-RUN npm run build
+RUN yarn
+RUN yarn build
 
-FROM gcr.io/distroless/nodejs:14 AS run-env
+FROM gcr.io/distroless/nodejs:16 AS run-env
 ENV NODE_ENV production
 COPY --from=build-env /app /app
 
-EXPOSE 8080
+EXPOSE ${PORT:-8080}
 
 WORKDIR /app
 CMD ["server.js"]


### PR DESCRIPTION
This makes sure we use Node 16 for build and run, as it is now the minimum required version with the API routes PR.  
We're also using yarn which is faster than npm in that case.
The exposed port has been changed to accept a PORT env variable, with a default fallback to 8080.