### PR TITLE
[Hydrogen docs]: Remove references to React Router

### DIFF
--- a/packages/hydrogen/src/foundation/ShopifyProvider/README.md
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/README.md
@@ -20,6 +20,13 @@ export default function App() {
 }
 ```
 
+## Props
+
+| Props           | Description                              |
+| --------------- | ---------------------------------------- |
+| `shopifyConfig` | The content of `shopify.config.js` file. |
+| `children`      | The rest of the application.             |
+
 ## Component type
 
 The `ShopifyProvider` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -12,8 +12,6 @@ Hydrogen includes a framework that offers a set of best practices and scaffoldin
 Hydrogen is the approach you use to build a custom storefront. It includes a [Vite](https://vitejs.dev/) plugin that offers server-side rendering (SSR) and hydration middleware, as well as server and client component code transformations.
 The SSR and hydration middleware is similar to existing [Vite SSR](https://vitejs.dev/guide/ssr.html) implementations.
 
-Hydrogen comes with [React Router](https://reactrouter.com/), a tool that allows you to handle routes in your app using dynamic routing.
-
 ![A diagram that illustrates Vite's offering of server-side rendering (SSR) and hydration middleware, and server and client component code transformations](/assets/custom-storefronts/hydrogen/hydrogen-framework-overview.png)
 
 ## Hydrogen project structure

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -43,26 +43,29 @@ The following example shows how to include a catch-all SEO component (`<DefaultS
 {% codeblock file, filename: 'App.server.jsx' %}
 
 ```jsx
-import {ShopifyServerProvider, DefaultRoutes} from '@shopify/hydrogen';
+import {DefaultRoutes} from '@shopify/hydrogen';
 import {Suspense} from 'react';
-import shopifyConfig from '../shopify.config';
+
 import DefaultSeo from './components/DefaultSeo.server';
 import NotFound from './components/NotFound.server';
+import AppClient from './App.client';
+import LoadingFallback from './components/LoadingFallback';
 
-export default function App({pages, ...serverState}) {
+export default function App({log, ...serverState}) {
+  const pages = import.meta.globEager('./pages/**/*.server.[jt]sx');
+
   return (
-    <ShopifyServerProvider shopifyConfig={shopifyConfig} {...serverState}>
-      <Suspense fallback="Loading...">
+    <Suspense fallback={<LoadingFallback />}>
+      <AppClient helmetContext={serverState.helmetContext}>
         <DefaultSeo />
-        <Switch>
-          <DefaultRoutes
-            pages={pages}
-            serverState={serverState}
-            fallback={<NotFound />}
-          />
-        </Switch>
-      </Suspense>
-    </ShopifyServerProvider>
+        <DefaultRoutes
+          pages={pages}
+          serverState={serverState}
+          log={log}
+          fallback={<NotFound />}
+        />
+      </AppClient>
+    </Suspense>
   );
 }
 ```

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -44,7 +44,6 @@ The following example shows how to include a catch-all SEO component (`<DefaultS
 
 ```jsx
 import {ShopifyServerProvider, DefaultRoutes} from '@shopify/hydrogen';
-import {Switch} from 'react-router-dom';
 import {Suspense} from 'react';
 import shopifyConfig from '../shopify.config';
 import DefaultSeo from './components/DefaultSeo.server';


### PR DESCRIPTION
## This PR:
- Removes references to React Router, as that will no longer be an offering as part of Hydrogen
- Relates to https://github.com/Shopify/shopify-dev/issues/10171, https://github.com/Shopify/shopify-dev/pull/15215, and https://github.com/Shopify/hydrogen/pull/525