### PR TITLE
feat: add mini-oxygen preview script

### DIFF
--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -13,10 +13,14 @@
     "build:client": "vite build --outDir dist/client --manifest",
     "build:server": "vite build --outDir dist/server --ssr src/entry-server.jsx",
     "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr worker.js",
-    "serve": "node --enable-source-maps server"
+    "serve": "node --enable-source-maps server",
+    "preview": "node ./scripts/preview.mjs"
   },
   "prettier": "@shopify/prettier-config",
   "devDependencies": {
+    "@miniflare/core": "2.2.0",
+    "@miniflare/http-server": "2.2.0",
+    "@miniflare/runner-vm": "2.2.0",
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/stylelint-plugin": "^10.0.1",
     "@tailwindcss/typography": "^0.5.0",
@@ -29,7 +33,9 @@
     "prettier": "^2.3.2",
     "stylelint": "^13.13.0",
     "tailwindcss": "^3.0.0",
-    "vite": "^2.7.0"
+    "vite": "^2.7.0",
+    "connect": "^3.7.0",
+    "mime": "^3.0.0"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.1",

--- a/examples/template-hydrogen-default/scripts/mini-oxygen/core.mjs
+++ b/examples/template-hydrogen-default/scripts/mini-oxygen/core.mjs
@@ -1,0 +1,35 @@
+import {CorePlugin, MiniflareCore} from '@miniflare/core';
+import {VMScriptRunner} from '@miniflare/runner-vm';
+import {Log, LogLevel} from '@miniflare/shared';
+
+import {createServer} from './server.mjs';
+import {StorageFactory} from './storage.mjs';
+
+export class MiniOxygen extends MiniflareCore {
+  constructor(options) {
+    const storageFactory = new StorageFactory();
+    super(
+      PLUGINS,
+      {
+        log: new Log(LogLevel.VERBOSE),
+        storageFactory,
+        scriptRunner: new VMScriptRunner(),
+      },
+      {
+        ...options,
+      },
+    );
+  }
+
+  async dispose() {
+    await super.dispose();
+  }
+
+  createServer() {
+    return createServer(this);
+  }
+}
+
+const PLUGINS = {
+  CorePlugin,
+};

--- a/examples/template-hydrogen-default/scripts/mini-oxygen/server.mjs
+++ b/examples/template-hydrogen-default/scripts/mini-oxygen/server.mjs
@@ -1,0 +1,75 @@
+import path from 'path';
+import http from 'http';
+import fs from 'fs';
+import mime from 'mime';
+import {URL} from 'url';
+import {Request} from '@miniflare/core';
+import connect from 'connect';
+
+function createAssetMiddleware() {
+  return (req, res, next) => {
+    if (req.url.includes('/assets')) {
+      const filePath = path.join(process.cwd(), './dist/client', req.url);
+      const rs = fs.createReadStream(filePath);
+      const {size} = fs.statSync(filePath);
+
+      res.setHeader('Content-Type', mime.getType(filePath));
+      res.setHeader('Content-Length', size);
+
+      return rs.pipe(res);
+    }
+
+    next();
+  };
+}
+
+function createRequestMiddleware(mf) {
+  return async (req, res) => {
+    let response;
+    let status = 500;
+    let headers = {};
+
+    const request = new Request(urlFromRequest(req), {
+      ...req,
+    });
+
+    try {
+      response = await mf.dispatchFetch(request);
+      status = response.status;
+      headers = response.headers;
+      res.writeHead(status, headers);
+
+      if (response.body) {
+        for await (const chunk of response.body) {
+          if (chunk) res.write(chunk);
+        }
+      }
+
+      res.end();
+    } catch (e) {
+      res.writeHead(500, {'Content-Type': 'text/plain; charset=UTF-8'});
+      res.end(e.stack, 'utf8');
+    }
+
+    return response;
+  };
+}
+
+export async function createServer(mf) {
+  const app = connect();
+
+  app.use(createAssetMiddleware());
+  app.use(createRequestMiddleware(mf));
+
+  const server = http.createServer(app);
+
+  return server;
+}
+
+function urlFromRequest(req) {
+  const protocol = req.socket.encrypted ? 'https' : 'http';
+  const origin = `${protocol}://${req.headers.host ?? 'localhost'}`;
+  const url = new URL(req.url ?? '', origin);
+
+  return url;
+}

--- a/examples/template-hydrogen-default/scripts/mini-oxygen/storage.mjs
+++ b/examples/template-hydrogen-default/scripts/mini-oxygen/storage.mjs
@@ -1,0 +1,12 @@
+export class StorageFactory {
+  constructor() {
+    this.storages = new Map();
+  }
+
+  storage(namespace) {
+    let storage = this.storages.get(namespace);
+    if (storage) return storage;
+    this.storages.set(namespace, (storage = new Map()));
+    return storage;
+  }
+}

--- a/examples/template-hydrogen-default/scripts/preview.mjs
+++ b/examples/template-hydrogen-default/scripts/preview.mjs
@@ -1,0 +1,20 @@
+// @ts-check
+import path from 'path';
+import {MiniOxygen} from './mini-oxygen/core.mjs';
+
+start();
+
+async function start({root = process.cwd(), port = 3000} = {}) {
+  const mf = new MiniOxygen({
+    buildCommand: 'yarn build',
+    globals: {Oxygen: {}},
+    scriptPath: path.resolve(root, 'dist/worker/worker.js'),
+    sitePath: path.resolve(root, 'dist/client'),
+  });
+
+  const app = await mf.createServer();
+
+  app.listen(port, () => {
+    console.log(`Started miniOxygen server on port ${port}`);
+  });
+}

--- a/examples/template-hydrogen-default/worker.js
+++ b/examples/template-hydrogen-default/worker.js
@@ -9,7 +9,6 @@ addEventListener('fetch', (event) => {
       handleEvent(event, {
         entrypoint,
         indexTemplate: indexHtml,
-        cache: caches.default,
         context: event,
       }),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,6 +2252,66 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz#30728e34ebc90351dd3aff4e18d038eed2c3e098"
   integrity sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==
 
+"@miniflare/core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/core/-/core-2.2.0.tgz#ec45606ca2864612a455b91df74d57c2a279f866"
+  integrity sha512-CJwYhyXQ7si0ALZ4wB/vFAo0sHcyaMR7A8oQb6HaZ8XKhaKkzA8BmPutMvYVikiW+oRJP3YRcJGuVKibL3TSgA==
+  dependencies:
+    "@iarna/toml" "^2.2.5"
+    "@miniflare/shared" "2.2.0"
+    "@miniflare/watcher" "2.2.0"
+    busboy "^0.3.1"
+    dotenv "^10.0.0"
+    kleur "^4.1.4"
+    set-cookie-parser "^2.4.8"
+    undici "4.12.1"
+
+"@miniflare/http-server@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/http-server/-/http-server-2.2.0.tgz#a6d899532a4c6ae0cd36e5ceac0da7635be44558"
+  integrity sha512-nx7xEXKYvPyUpu2HFigD+UEgclipMQzGdTKtm4t6JzsOGYys7Lj7kGjryYaQVtbbJvPKIxqSaViFQDk/QSdosg==
+  dependencies:
+    "@miniflare/core" "2.2.0"
+    "@miniflare/shared" "2.2.0"
+    "@miniflare/web-sockets" "2.2.0"
+    kleur "^4.1.4"
+    selfsigned "^2.0.0"
+    undici "4.12.1"
+    ws "^8.2.2"
+    youch "^2.2.2"
+
+"@miniflare/runner-vm@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/runner-vm/-/runner-vm-2.2.0.tgz#897042f6e08f2112ae054d9a9f1b07e34c87d721"
+  integrity sha512-x58BxIsAB6LcYgqTNVfxTsKFCu4G3Xiuj1k+3ZQ4b8v8TZjuZ3iOJcsrYU0PlbW5JpnRA8IH/mkiFRb/MrLtaQ==
+  dependencies:
+    "@miniflare/shared" "2.2.0"
+
+"@miniflare/shared@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/shared/-/shared-2.2.0.tgz#a4c79b0919a54c9c3da64c65f05ae813e56988ce"
+  integrity sha512-ikz3nkBexVQ16Ioi6naAzK6Spj5O7lUcqIihMLCQKTAAdC252EL0QrBRxHV9MlvkypVNj6MqkoL4E6HcyuCo6g==
+  dependencies:
+    ignore "^5.1.8"
+    kleur "^4.1.4"
+
+"@miniflare/watcher@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/watcher/-/watcher-2.2.0.tgz#adfa5d93aa0df86ed8b83e44f71ebb1cbce4bb13"
+  integrity sha512-Myaztj1QaL1IaB04uBLKY8hE1kFtvB65cnKdJPOgjFxIgFzNyqybjlBjxx01Q6vymboFTPrl1Q5+g7fsW3lmfQ==
+  dependencies:
+    "@miniflare/shared" "2.2.0"
+
+"@miniflare/web-sockets@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@miniflare/web-sockets/-/web-sockets-2.2.0.tgz#77c3c3a5c86dcbeee8b5ad8a31904a80dc737531"
+  integrity sha512-/GHYuTq6m28udequw4E8IpcFmcEheAcVQ3oZyAvY0ub0by8v4WzYuougiizqYylyQZ0KXyLg8SmPeBNChe82Zw==
+  dependencies:
+    "@miniflare/core" "2.2.0"
+    "@miniflare/shared" "2.2.0"
+    undici "4.12.1"
+    ws "^8.2.2"
+
 "@mrbbot/node-fetch@^4.6.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@mrbbot/node-fetch/-/node-fetch-4.6.0.tgz#82c273b8e6b5d7846dfec0ed331007801ac49fff"
@@ -5267,6 +5327,11 @@ dot-prop@^6.0.1:
   integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
     is-obj "^2.0.0"
+
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotenv@^8.2.0:
   version "8.6.0"
@@ -9830,6 +9895,11 @@ node-forge@^0.10.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
+node-forge@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
+
 node-gyp@^5.0.2:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.1.1.tgz#eb915f7b631c937d282e33aed44cb7a025f62a3e"
@@ -12094,6 +12164,13 @@ selfsigned@^1.10.11:
   dependencies:
     node-forge "^0.10.0"
 
+selfsigned@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.0.tgz#e927cd5377cbb0a1075302cff8df1042cc2bce5b"
+  integrity sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==
+  dependencies:
+    node-forge "^1.2.0"
+
 semiver@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/semiver/-/semiver-1.1.0.tgz#9c97fb02c21c7ce4fcf1b73e2c7a24324bdddd5f"
@@ -12170,6 +12247,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.8:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -13568,6 +13650,11 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
+undici@4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-4.12.1.tgz#3a7b5fb12f835a96a65397dd94578464b08d1c27"
+  integrity sha512-MSfap7YiQJqTPP12C11PFRs9raZuVicDbwsZHTjB0a8+SsCqt7KdUis54f373yf7ZFhJzAkGJLaKm0202OIxHg==
+
 undici@^4.12.2:
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/undici/-/undici-4.12.2.tgz#f2fc50ca77a774ed8c0e7067c9361ee18a2f422b"
@@ -14272,6 +14359,11 @@ ws@7.4.5:
   version "7.5.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.6.tgz#e59fc509fb15ddfb65487ee9765c5a51dec5fe7b"
   integrity sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==
+
+ws@^8.2.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
+  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a miniflare plugin to emulate the Oxygen runtime environment and a script in the `default-template-hydrogen` example to run it. Essentially this is a very stripped down version of Miniflare that we can now build up to support the Oxygen APIs beyond what I've add in this initial version.

More information on this approach can be [found in this document](https://docs.google.com/document/d/1sYBmk84lUKuYQU-2i7Qq-uEWqli9IoTM0qdHsf7y9Vc/edit#) (Shopifolk only).

### Additional context

In this first PR I am adding the initial scaffolding for how this library could work. Some notable details and questions:
- The miniflare `http-server` package was proving difficult to work with because I could not find a good way to add middleware for serving assets in a unique way while also preventing the server from attempting to continue to write headers to the response object. For this reason, you will find a stripped down the server without all the Cloudflare bits.
- The code for the above is in `server.mjs`. I think we could potentially bring back the miniflare `http-server` library (either by contributing upstream to provide middleware support or by some other solution), but felt like having our own oxygen server emulation was probably our ideal future state anyways (and it unblocked the asset serving aspect for this PR). Would love additional thoughts on this.
- The storage plugin does very little. It creates an in memory storage Map, but would love to know what is actually required here. (cc @maxshirshin)
- To run the preview script, you would run `yarn preview` in the example project of our monorepo. This will also be ready to use for folks creating a new project via the CLI. This is fine for now as a first version, but we need to carve a path forward for how to release and maintain this.
- Related to the above point, what team owns this functionality (hydrogen or oxygen?). I'd like this to be in the Hydrogen CLI via `hydrogen preview`, whether that means it lives in our monorepo as a separate stand-alone package, directly within the CLI package, or as a separate repo entirely is up for discussion. Would love opinions on what people would like to see here. (cc @vlucas)
- The `hydrate` method in the example is not yet working as intended (cc @frandiox), I will be looking more into why this is, but in the meantime you can view a working example in a [simpler hydrogen site here](https://github.com/Shopify/mini-oxygen-demo). Video Demo will be posted shortly. 

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
