### PR TITLE
fix: warn instead of error on new or malformed page server components

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Warn instead of error when a page server component is missing valid exports
 
 ## 0.9.1 - 2022-01-20
 

--- a/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
+++ b/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
@@ -22,7 +22,7 @@ export function DefaultRoutes({
 }) {
   const {path} = useRouteMatch();
   const routes = useMemo(
-    () => createRoutesFromPages(pages, path),
+    () => createRoutesFromPages(pages, path, log),
     [pages, path]
   );
 
@@ -46,7 +46,8 @@ interface HydrogenRoute {
 
 export function createRoutesFromPages(
   pages: ImportGlobEagerOutput,
-  topLevelPath = '*'
+  topLevelPath = '*',
+  log: Logger | null = null
 ): HydrogenRoute[] {
   const topLevelPrefix = topLevelPath.replace('*', '').replace(/\/$/, '');
 
@@ -78,10 +79,11 @@ export function createRoutesFromPages(
        */
       const exact = !/\[(?:[.]{3})(\w+?)\]/.test(key);
 
-      if (!pages[key].default && !pages[key].api)
-        throw new Error(
+      if (!pages[key].default && !pages[key].api) {
+        log?.warn(
           `${key} doesn't export a default React component or an API function`
         );
+      }
 
       return {
         path: topLevelPrefix + path,

--- a/packages/hydrogen/src/foundation/Router/tests/DefaultRoutes.test.tsx
+++ b/packages/hydrogen/src/foundation/Router/tests/DefaultRoutes.test.tsx
@@ -1,5 +1,6 @@
 import {createRoutesFromPages} from '../DefaultRoutes';
 import {ImportGlobEagerOutput} from '../../../types';
+import {Logger} from '../../..';
 
 const STUB_MODULE = {default: {}, api: null};
 
@@ -244,15 +245,14 @@ it('factors in the top-level path prefix', () => {
 });
 
 it("errors routes don't have a default or api export", () => {
-  function makeError() {
-    const pages: ImportGlobEagerOutput = {
-      './pages/contact.server.jsx': {} as any,
-    };
+  const log: Logger = {...console, fatal: jest.fn(), warn: jest.fn()};
+  const pages: ImportGlobEagerOutput = {
+    './pages/contact.server.jsx': {} as any,
+  };
 
-    createRoutesFromPages(pages);
-  }
+  createRoutesFromPages(pages, '*', log);
 
-  expect(makeError).toThrowError(
+  expect(log.warn).toBeCalledWith(
     `./pages/contact.server.jsx doesn't export a default React component or an API function`
   );
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

RE: #494 

This PR warns instead of throwing an error.

Still need to find out why the old contents are cached for so long.


### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
