### PR TITLE
Renamed 'locale' to 'defaultLocale' in shopify.config.js

### DIFF
--- a/examples/template-hydrogen-default/shopify.config.js
+++ b/examples/template-hydrogen-default/shopify.config.js
@@ -1,6 +1,4 @@
 export default {
-  locale: 'en-us',
   storeDomain: 'hydrogen-preview.myshopify.com',
   storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
-  graphqlApiVersion: 'unstable',
 };

--- a/packages/cli/src/commands/add/shopifyConfig/templates/shopify-config-js.ts
+++ b/packages/cli/src/commands/add/shopifyConfig/templates/shopify-config-js.ts
@@ -3,10 +3,8 @@ import {TemplateOptions} from 'types';
 export default function ({storeDomain, storefrontToken}: TemplateOptions) {
   return `
 module.exports = {
-  locale: 'en-us',
   storeDomain: '${storeDomain}',
   storefrontToken: '${storefrontToken}',
-  graphqlApiVersion: 'unstable',
 };
 `;
 }

--- a/packages/cli/src/commands/add/shopifyProvider/templates/shopify-config-js.ts
+++ b/packages/cli/src/commands/add/shopifyProvider/templates/shopify-config-js.ts
@@ -3,10 +3,8 @@ import {TemplateOptions} from 'types';
 export default function ({storeDomain, storefrontToken}: TemplateOptions) {
   return `
 module.exports = {
-  locale: 'en-us',
   storeDomain: '${storeDomain}',
   storefrontToken: '${storefrontToken}',
-  graphqlApiVersion: 'unstable',
 };
 `;
 }

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Warn instead of error when a page server component is missing valid exports
 - Adopt upstream version of React Server Components. See [#498](https://github.com/Shopify/hydrogen/pull/498) for breaking changes.
+- The 'locale' option in shopify.config.js had been renamed to 'defaultLocale'
 
 ## 0.9.1 - 2022-01-20
 

--- a/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
@@ -35,7 +35,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -51,7 +51,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} as="p" />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -115,7 +115,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -131,7 +131,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} as="p" />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -195,7 +195,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -214,7 +214,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} as="p" />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -277,7 +277,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -296,7 +296,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} as="p" />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -359,7 +359,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -378,7 +378,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} as="p" />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );
@@ -441,7 +441,7 @@ describe('<Metafield />', () => {
         <Metafield metafield={metafield} />,
         {
           shopifyConfig: {
-            locale: 'en-us',
+            defaultLocale: 'en-us',
           },
         }
       );

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -21,7 +21,7 @@ import {ServerComponentResponse} from './framework/Hydration/ServerComponentResp
 import {ServerComponentRequest} from './framework/Hydration/ServerComponentRequest.server';
 import {getCacheControlHeader} from './framework/cache';
 import {ServerRequestProvider} from './foundation/ServerRequestProvider';
-import {setShopifyConfig} from './foundation/useShop';
+import {setShop} from './foundation/useShop';
 import type {ServerResponse} from 'http';
 import type {PassThrough as PassThroughType, Writable} from 'stream';
 import {getApiRouteFromURL, getApiRoutesFromPages} from './utilities/apiRoutes';
@@ -46,7 +46,7 @@ declare global {
 const STREAM_ABORT_TIMEOUT_MS = 3000;
 
 const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
-  setShopifyConfig(shopifyConfig);
+  setShop(shopifyConfig);
 
   /**
    * The render function is responsible for turning the provided `App` into an HTML string,

--- a/packages/hydrogen/src/foundation/ShopifyProvider/README.md
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/README.md
@@ -21,3 +21,12 @@ export default function App() {
 ## Component type
 
 The `ShopifyProvider` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components).
+
+## Props
+
+`ShopifyProvider` accepts the following Props
+
+| Props           | Description                              |
+| --------------- | ---------------------------------------- |
+| `shopifyConfig` | The content of `shopify.config.js` file. |
+| `children`      | The rest of the application.             |

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyContext.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyContext.tsx
@@ -1,4 +1,18 @@
 import {createContext} from 'react';
-import {ShopifyProviderValue} from './types';
+import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../constants';
+import type {ShopifyContextValue} from './types';
+import type {ShopifyConfig} from '../../types';
 
-export const ShopifyContext = createContext<ShopifyProviderValue | null>(null);
+export const ShopifyContext = createContext<ShopifyContextValue | null>(null);
+
+/* this can be move into ShopifyProvider once ShopifyContext can be use in RSC again */
+export function makeShopifyContext(
+  shopifyConfig: ShopifyConfig
+): ShopifyContextValue {
+  return {
+    locale: shopifyConfig.defaultLocale ?? DEFAULT_LOCALE,
+    storeDomain: shopifyConfig?.storeDomain?.replace(/^https?:\/\//, ''),
+    storefrontToken: shopifyConfig.storefrontToken,
+    graphqlApiVersion: shopifyConfig.graphqlApiVersion ?? DEFAULT_API_VERSION,
+  };
+}

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.tsx
@@ -1,7 +1,6 @@
 import React, {useMemo} from 'react';
-import {ShopifyContext} from './ShopifyContext';
-import {ShopifyProviderProps} from './types';
-import {DEFAULT_API_VERSION} from '../constants';
+import {ShopifyContext, makeShopifyContext} from './ShopifyContext';
+import type {ShopifyProviderProps} from './types';
 
 /**
  * The `ShopifyProvider` component wraps your entire app and provides support for hooks.
@@ -14,12 +13,7 @@ export function ShopifyProvider({
   children,
 }: ShopifyProviderProps) {
   const shopifyProviderValue = useMemo(
-    () => ({
-      locale: 'en-us',
-      graphqlApiVersion: DEFAULT_API_VERSION,
-      ...shopifyConfig,
-      storeDomain: shopifyConfig?.storeDomain?.replace(/^https?:\/\//, ''),
-    }),
+    () => makeShopifyContext(shopifyConfig),
     [shopifyConfig]
   );
 

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -2,24 +2,114 @@ import React from 'react';
 // eslint-disable-next-line node/no-extraneous-import
 import {mount} from '@shopify/react-testing';
 import {ShopifyProvider} from '../ShopifyProvider';
-import {DEFAULT_API_VERSION} from '../../constants';
-
-const CONFIG = {
-  locale: 'en-us',
-  storeDomain: 'hydrogen-preview.myshopify.com',
-  storefrontToken: '1234',
-  graphqlApiVersion: DEFAULT_API_VERSION,
-};
+import {ShopifyContext} from '../ShopifyContext';
+import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../../constants';
+import {SHOPIFY_CONFIG} from './fixtures';
 
 describe('<ShopifyProvider />', () => {
   it('renders its children', () => {
     const provider = mount(
-      <ShopifyProvider shopifyConfig={CONFIG}>
+      <ShopifyProvider shopifyConfig={SHOPIFY_CONFIG}>
         <Children />
       </ShopifyProvider>
     );
 
     expect(provider).toContainReactComponent(Children);
+  });
+
+  describe('renders ShopifyContext.Provider', () => {
+    it('contains defaultLocale from shopifyConfig as locale', () => {
+      const provider = mount(
+        <ShopifyProvider
+          shopifyConfig={{
+            defaultLocale: 'zh-TW',
+            storeDomain: 'hydrogen-preview.myshopify.com',
+            storefrontToken: '1234',
+          }}
+        >
+          <Children />
+        </ShopifyProvider>
+      );
+
+      expect(provider).toContainReactComponent(ShopifyContext.Provider, {
+        value: expect.objectContaining({locale: 'zh-TW'}),
+      });
+    });
+
+    it('contains DEFAULT_LOCALE as local when locale is not specify in locale prop or shopifyConfig', () => {
+      const provider = mount(
+        <ShopifyProvider
+          shopifyConfig={{
+            storeDomain: 'hydrogen-preview.myshopify.com',
+            storefrontToken: '1234',
+          }}
+        >
+          <Children />
+        </ShopifyProvider>
+      );
+
+      expect(provider).toContainReactComponent(ShopifyContext.Provider, {
+        value: expect.objectContaining({locale: DEFAULT_LOCALE}),
+      });
+    });
+
+    it('contains storeDomain without https prefix', () => {
+      const provider = mount(
+        <ShopifyProvider
+          shopifyConfig={{
+            storeDomain: 'https://hydrogen-preview.myshopify.com',
+            storefrontToken: '1234',
+          }}
+        >
+          <Children />
+        </ShopifyProvider>
+      );
+
+      expect(provider).toContainReactComponent(ShopifyContext.Provider, {
+        value: expect.objectContaining({
+          storeDomain: 'hydrogen-preview.myshopify.com',
+        }),
+      });
+    });
+
+    it('contains graphqlApiVersion from shopifyConfig', () => {
+      const provider = mount(
+        <ShopifyProvider
+          shopifyConfig={{
+            storeDomain: 'hydrogen-preview.myshopify.com',
+            storefrontToken: '1234',
+            graphqlApiVersion: '2022-04',
+          }}
+        >
+          <Children />
+        </ShopifyProvider>
+      );
+
+      expect(provider).toContainReactComponent(ShopifyContext.Provider, {
+        value: expect.objectContaining({
+          graphqlApiVersion: '2022-04',
+        }),
+      });
+    });
+
+    it('contains DEFAULT_API_VERSION as graphqlApiVersion when it is not specify in shopifyConfig', () => {
+      const provider = mount(
+        <ShopifyProvider
+          shopifyConfig={{
+            storeDomain: 'hydrogen-preview.myshopify.com',
+            storefrontToken: '1234',
+          }}
+        >
+          <Children />
+        </ShopifyProvider>
+      );
+
+      expect(provider).toContainReactComponent(ShopifyContext.Provider, {
+        value: expect.objectContaining({
+          graphqlApiVersion: DEFAULT_API_VERSION,
+        }),
+      });
+    });
   });
 });
 

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/fixtures.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/fixtures.ts
@@ -1,6 +1,7 @@
-import {DEFAULT_API_VERSION} from '../ShopifyProvider';
+import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../../constants';
 
 export const SHOPIFY_CONFIG = {
+  locale: DEFAULT_LOCALE,
   storeDomain: 'notashop.myshopify.io',
   storefrontToken: 'abc123',
   apiVersion: DEFAULT_API_VERSION,

--- a/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
@@ -1,6 +1,11 @@
 import {ShopifyConfig} from '../../types';
 
-export type ShopifyProviderValue = ShopifyConfig;
+export type ShopifyContextValue = {
+  locale: string;
+  storeDomain: ShopifyConfig['storeDomain'];
+  storefrontToken: ShopifyConfig['storefrontToken'];
+  graphqlApiVersion: string;
+};
 
 export type ShopifyProviderProps = {
   /** The contents of the `shopify.config.js` file. */

--- a/packages/hydrogen/src/foundation/constants.ts
+++ b/packages/hydrogen/src/foundation/constants.ts
@@ -1,3 +1,4 @@
 // Note: do not mix this export with other app-only logic
 // to avoid importing unnecessary code in the plugins.
 export const DEFAULT_API_VERSION = 'unstable';
+export const DEFAULT_LOCALE = 'en-us';

--- a/packages/hydrogen/src/foundation/index.tsx
+++ b/packages/hydrogen/src/foundation/index.tsx
@@ -1,4 +1,4 @@
 export * from './ServerStateProvider';
-export {useShop, setShopifyConfig} from './useShop';
+export {useShop, setShop} from './useShop';
 export {DefaultRoutes} from './Router';
 export {useServerRequest} from './ServerRequestProvider';

--- a/packages/hydrogen/src/foundation/useShop/README.md
+++ b/packages/hydrogen/src/foundation/useShop/README.md
@@ -18,12 +18,12 @@ export default function MyPage() {
 
 The `useShop` hook returns an object with the following keys:
 
-| Key                 | Description                                          |
-| ------------------- | ---------------------------------------------------- |
-| `locale`            | The locale set in `shopify.config.js`.               |
-| `storeDomain`       | The store domain set in `shopify.config.js`.         |
-| `storefrontToken`   | The Storefront API token set in `shopify.config.js`. |
-| `graphqlApiVersion` | The GraphQL API version set in `shopify.config.js`.  |
+| Key                 | Description                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| `locale`            | The application locale. Default to `defaultLocale` in `shopify.config.js` then `en-us`. |
+| `storeDomain`       | The store domain set in `shopify.config.js`.                                            |
+| `storefrontToken`   | The Storefront API token set in `shopify.config.js`.                                    |
+| `graphqlApiVersion` | The GraphQL API version set in `shopify.config.js`. Default to `unstable`.              |
 
 ## Related components
 

--- a/packages/hydrogen/src/foundation/useShop/index.ts
+++ b/packages/hydrogen/src/foundation/useShop/index.ts
@@ -1,1 +1,1 @@
-export {useShop, setShopifyConfig} from './use-shop';
+export {useShop, setShop} from './use-shop';

--- a/packages/hydrogen/src/foundation/useShop/use-shop.tsx
+++ b/packages/hydrogen/src/foundation/useShop/use-shop.tsx
@@ -1,24 +1,34 @@
 import {useContext} from 'react';
+import {
+  ShopifyContext,
+  makeShopifyContext,
+} from '../ShopifyProvider/ShopifyContext';
+import type {ShopifyContextValue} from '../ShopifyProvider/types';
 import type {ShopifyConfig} from '../../types';
-import {ShopifyContext} from '../ShopifyProvider/ShopifyContext';
 
-let config: ShopifyConfig | null = null;
+let contextValue: ShopifyContextValue | null = null;
 
 /**
  * The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
  */
-export function useShop(): ShopifyConfig {
+export function useShop(): ShopifyContextValue {
   /**
-   * During RSC, context is not (yet) allowed, so we should be calling `setShopifyConfig`
-   * and returning the object here.
+   * During RSC, context is not (yet) allowed on Server Component, so we should be calling `setShop`
+   * in server and returning the object here.
    */
-  if (config) {
-    return config as ShopifyConfig;
+  if (contextValue) {
+    return contextValue;
   }
 
-  return useContext(ShopifyContext) as ShopifyConfig;
+  const context = useContext(ShopifyContext);
+
+  if (!context) {
+    throw new Error('No Shopify Context found');
+  }
+
+  return context;
 }
 
-export function setShopifyConfig(newConfig: ShopifyConfig) {
-  config = newConfig;
+export function setShop(shopifyConfig: ShopifyConfig) {
+  contextValue = makeShopifyContext(shopifyConfig);
 }

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -44,7 +44,7 @@ export type EntryServerHandler = {
 };
 
 export type ShopifyConfig = {
-  locale?: string;
+  defaultLocale?: string;
   storeDomain: string;
   storefrontToken: string;
   graphqlApiVersion?: string;

--- a/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
+++ b/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {createMount} from '@shopify/react-testing';
-import {DEFAULT_API_VERSION} from '../../foundation/constants';
+import {DEFAULT_API_VERSION, DEFAULT_LOCALE} from '../../foundation/constants';
+
 import {ShopifyConfig} from '../../types';
 import {ShopifyProvider} from '../../foundation/ShopifyProvider';
 
@@ -26,6 +27,7 @@ export const mountWithProviders = createMount<
 
 export function getShopifyConfig(config: Partial<ShopifyConfig> = {}) {
   return {
+    locale: config.defaultLocale ?? DEFAULT_LOCALE,
     storeDomain: config.storeDomain ?? 'notashop.myshopify.io',
     storefrontToken: config.storefrontToken ?? 'abc123',
     graphqlApiVersion: config.graphqlApiVersion ?? DEFAULT_API_VERSION,


### PR DESCRIPTION
feat(dev): Renamed 'locale' to 'defaultLocale' in shopify.config.js

BREAKING CHANGE: The 'locale' in shopify.config.js had been renamed to 'defaultLocale'

<!-- Thank you for contributing! -->

### Description

Rename `locale` in shopify.config.js to `defaultLocale` to make it more clear that this value should be use as the application's default locale but not necessarily the current locale.

(p.s. I try doing this to main first but the experimental branch has a lot of ShopifyProvider changes so it make more sense for it to go here)

The following refactor were also done along side of this change:
- Make utility method `makeShopifyContext` that take `shopify.config.js` value and apply default values & transformation
- Add test to `ShopifyProvider` that test for these default values & transoformation.
- Rename `setShopifyConfig`(the method use to set up ShopifyConext within the useShop hook)  to `setShop`
- Use `makeShopifyContext` in both `ShopifyProvider` & `setShop`
- Remove `locale` and `graphqlApiVersion` from any templating value since there are default
- Separate type `ShopifyConfig` (optional defaultLocale & optional graphqlApiVersion) from `ShopifyContextValue` (always has locale & graphqlApiVersion after default had been applied) 
- Update `useShop` & `ShopifyProvider` documentations

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
