### PR TITLE
Add experimental publish pipeline

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -203,6 +203,14 @@ Next, visit the Shipit page for Hydrogen and click **Deploy**.
 
 After Shipit has released your version, visit the [releases page on GitHub](https://github.com/Shopify/hydrogen/releases), click on the version number you just released, and select "Create release from tag." Then, select "Auto-generate release notes." At this point, edit the release notes as you see fit (e.g. call out any breaking changes or upgrade guides). Finally, click "Publish release."
 
+## Releasing experimental versions
+
+To release an experimental version, follow the instructions above for releasing new versions, only use the `experimental` branch instead.
+
+When you run `yarn bump-version`, be sure to select a pre-release that meets expectations (or enter a custom version).
+
+After running the script, go to Shipit and find "Hydrogen Experimental." Run a deploy, and this should release your new version with the `experimental` tag on NPM.
+
 ## Testing changes in another project
 
 From the root of the repo, run:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -205,11 +205,13 @@ After Shipit has released your version, visit the [releases page on GitHub](http
 
 ## Releasing experimental versions
 
-To release an experimental version, follow the instructions above for releasing new versions, only use the `experimental` branch instead.
+Releasing an experimental version of Hydrogen to GitHub can be useful if you want to test the new version in existing apps.
 
-When you run `yarn bump-version`, be sure to select a pre-release that meets expectations (or enter a custom version).
+To release an experimental version, merge your changes into the `experimental` branch.
 
-After running the script, go to Shipit and find "Hydrogen Experimental." Run a deploy, and this should release your new version with the `experimental` tag on NPM.
+Then, run `yarn bump-version` locally while in the branch. Be sure to select a pre-release that contains `v.X.X-experimental.N` or enter a custom version.
+
+After running the script, go to Shipit and find "Hydrogen Experimental." Run a deploy against the commit containing your new version, and this should release your experimental version on NPM with the `experimental` tag.
 
 ## Testing changes in another project
 

--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -9,7 +9,7 @@
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx src",
     "lint:css": "stylelint ./src/**/*.{css,sass,scss}",
-    "build": "yarn build:client && yarn build:server",
+    "build": "yarn build:client && yarn build:server && yarn build:worker",
     "build:client": "vite build --outDir dist/client --manifest",
     "build:server": "vite build --outDir dist/server --ssr src/entry-server.jsx",
     "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr worker.js",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -14,6 +14,7 @@
   "types": "dist/esnext/index.d.ts",
   "files": [
     "dist",
+    "vendor",
     "plugin.js",
     "plugin.d.ts",
     "entry-server.js",

--- a/shipit.experimental.yml
+++ b/shipit.experimental.yml
@@ -1,0 +1,10 @@
+deploy:
+  override:
+    - >-
+      yarn workspace @shopify/hydrogen build &&
+      git diff &&
+      node_modules/.bin/lerna publish from-package
+      --no-git-tag-version
+      --dist-tag experimental
+      --no-push
+      --yes


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We can release things on `experimental` on NPM now!

Also, this fixes an issue with our new `vendor` folder in Hydrogen, since it wasn't included in the list of files for NPM publish.