### PR TITLE
feat: add optional trace logging for entry-server

### DIFF
--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -9,7 +9,7 @@ import {
   Logger,
   logServerResponse,
   getLoggerFromContext,
-  log,
+  log as noContextLogger,
 } from './utilities/log/log';
 import {getErrorMarkup} from './utilities/error';
 import {defer} from './utilities/defer';
@@ -128,6 +128,7 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
     {request, response, template, nonce, dev}
   ) {
     const log = getLoggerFromContext(request);
+    log.trace('start stream');
     const state = {pathname: url.pathname, search: url.search};
     let didError: Error | undefined;
 
@@ -162,13 +163,17 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
 
     const rscToScriptTagReadable = new ReadableStream({
       start(controller) {
+        log.trace('rsc start chunks');
         let init = true;
         const encoder = new TextEncoder();
         bufferReadableStream(rscReadableForFlight.getReader(), (chunk) => {
           const scriptTag = flightContainer({init, chunk, nonce});
           controller.enqueue(encoder.encode(scriptTag));
           init = false;
-        }).then(() => controller.close());
+        }).then(() => {
+          log.trace('rsc finish chunks');
+          return controller.close();
+        });
       },
     });
 
@@ -182,6 +187,8 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
       const ssrReadable: ReadableStream = renderToReadableStream(ReactAppSSR, {
         nonce,
         onCompleteShell() {
+          log.trace('worker ready to stream');
+
           Object.assign(
             responseOptions,
             getResponseOptions(componentResponse, didError)
@@ -212,6 +219,7 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
           deferredShouldReturnApp.resolve(true);
         },
         async onCompleteAll() {
+          log.trace('worker complete stream');
           if (componentResponse.canStream()) return;
 
           Object.assign(
@@ -278,11 +286,13 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
           (scriptTag) => writable.write(encoder.encode(scriptTag))
         );
 
-        Promise.all([writingSSR, writingRSC]).then(() => {
-          // Last SSR write might be pending, delay closing the writable one tick
-          setTimeout(() => writable.close(), 0);
-          logServerResponse('str', log, request, responseOptions.status);
-        });
+        Promise.all([writingSSR, writingRSC])
+          .then(() => {
+            // Last SSR write might be pending, delay closing the writable one tick
+            setTimeout(() => writable.close(), 0);
+            logServerResponse('str', log, request, responseOptions.status);
+          })
+          .catch((error) => console.log('lsjdfalkjsdlkjasdlfjkasdlkfjasdlkjf'));
       } else {
         writable.close();
         logServerResponse('str', log, request, responseOptions.status);
@@ -303,6 +313,7 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
       const {pipe} = renderToPipeableStream(ReactAppSSR, {
         nonce,
         onCompleteShell() {
+          log.trace('node ready to stream');
           /**
            * TODO: This assumes `response.cache()` has been called _before_ any
            * queries which might be caught behind Suspense. Clarify this or add
@@ -313,7 +324,7 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
             componentResponse.cacheControlHeader
           );
 
-          writeHeadToServerResponse(response, componentResponse, didError);
+          writeHeadToServerResponse(response, componentResponse, log, didError);
 
           logServerResponse('str', log, request, response.statusCode);
 
@@ -329,22 +340,21 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
             dev ? didError : undefined
           );
 
-          // Piping ends the response so let RSC go first.
-          // Generally, RSC reader should finish before SSR because
-          // the latter is also reading RSC until it finishes.
-          // However, this might not be the case in small apps that
-          // are written in SSR at once.
-          setTimeout(() => pipe(response), 0);
-          bufferReadableStream(rscToScriptTagReadable.getReader(), (chunk) =>
-            response.write(chunk)
-          );
+          bufferReadableStream(rscToScriptTagReadable.getReader(), (chunk) => {
+            log.trace('rsc chunk');
+            return response.write(chunk);
+          }).then(() => {
+            log.trace('node pipe response');
+            pipe(response);
+          });
         },
         async onCompleteAll() {
+          log.trace('node complete stream');
           clearTimeout(streamTimeout);
 
           if (componentResponse.canStream() || response.writableEnded) return;
 
-          writeHeadToServerResponse(response, componentResponse, didError);
+          writeHeadToServerResponse(response, componentResponse, log, didError);
 
           logServerResponse('str', log, request, response.statusCode);
 
@@ -455,7 +465,7 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
     stream,
     hydrate,
     getApiRoute,
-    log,
+    log: noContextLogger,
   };
 };
 
@@ -566,6 +576,7 @@ async function renderToBufferedString(
           deferred.resolve(null);
         },
         onError(error: any) {
+          console.log('hi there! b');
           log.error(error);
           deferred.reject(error);
         },
@@ -594,6 +605,7 @@ async function renderToBufferedString(
           pipe(writer);
         },
         onError(error: any) {
+          console.log('hi there! c');
           log.error(error);
           reject(error);
         },
@@ -664,9 +676,11 @@ function getResponseOptions(
 function writeHeadToServerResponse(
   response: ServerResponse,
   serverComponentResponse: ServerComponentResponse,
+  log: Logger,
   error?: Error
 ) {
   if (response.headersSent) return;
+  log.trace('writeHeadToServerResponse');
 
   const {headers, status, statusText} = getResponseOptions(
     serverComponentResponse,

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -338,12 +338,14 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
             dev ? didError : undefined
           );
 
+          setTimeout(() => {
+            log.trace('node pipe response');
+            pipe(response);
+          }, 0);
+
           bufferReadableStream(rscToScriptTagReadable.getReader(), (chunk) => {
             log.trace('rsc chunk');
             return response.write(chunk);
-          }).then(() => {
-            log.trace('node pipe response');
-            pipe(response);
           });
         },
         async onCompleteAll() {

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -286,13 +286,11 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
           (scriptTag) => writable.write(encoder.encode(scriptTag))
         );
 
-        Promise.all([writingSSR, writingRSC])
-          .then(() => {
-            // Last SSR write might be pending, delay closing the writable one tick
-            setTimeout(() => writable.close(), 0);
-            logServerResponse('str', log, request, responseOptions.status);
-          })
-          .catch((error) => console.log('lsjdfalkjsdlkjasdlfjkasdlkfjasdlkjf'));
+        Promise.all([writingSSR, writingRSC]).then(() => {
+          // Last SSR write might be pending, delay closing the writable one tick
+          setTimeout(() => writable.close(), 0);
+          logServerResponse('str', log, request, responseOptions.status);
+        });
       } else {
         writable.close();
         logServerResponse('str', log, request, responseOptions.status);
@@ -576,7 +574,6 @@ async function renderToBufferedString(
           deferred.resolve(null);
         },
         onError(error: any) {
-          console.log('hi there! b');
           log.error(error);
           deferred.reject(error);
         },
@@ -605,7 +602,6 @@ async function renderToBufferedString(
           pipe(writer);
         },
         onError(error: any) {
-          console.log('hi there! c');
           log.error(error);
           reject(error);
         },

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -17,7 +17,8 @@ export interface Logger {
 
 const defaultLogger = {
   trace(context: {[key: string]: any}, ...args: Array<any>) {
-    console.log(...args);
+    // Re-enable following line to show trace debugging information
+    // console.log(context.id, ...args);
   },
   debug(context: {[key: string]: any}, ...args: Array<any>) {
     console.log(...args);


### PR DESCRIPTION
1. Add optional trace logging to entry-server. Enable it by uncommenting the trace log line in log.ts
2. Wait to pipe response until `bufferReadableStream` completes