### PR TITLE
feat: The dir attribute of `<html>` will now change based on locale

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- The `dir` attribute of `<html>` will now change based on locale
 - Warn instead of error when a page server component is missing valid exports
 - Adopt upstream version of React Server Components. See [#498](https://github.com/Shopify/hydrogen/pull/498) for breaking changes.
 - The 'locale' option in shopify.config.js had been renamed to 'defaultLocale'

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -25,6 +25,7 @@ import {setShop} from './foundation/useShop';
 import type {ServerResponse} from 'http';
 import type {PassThrough as PassThroughType, Writable} from 'stream';
 import {getApiRouteFromURL, getApiRoutesFromPages} from './utilities/apiRoutes';
+import {getLocaleDirection, getLocaleLanguage} from './utilities/locale';
 
 // @ts-ignore
 import {renderToReadableStream as rscRenderToReadableStream} from '@shopify/hydrogen/vendor/react-server-dom-vite/writer.browser.server';
@@ -155,7 +156,13 @@ const renderHydrogen: ServerHandler = (App, {shopifyConfig, pages}) => {
     }
 
     const ReactAppSSR = (
-      <Html template={template} htmlAttrs={{lang: 'en'}}>
+      <Html
+        template={template}
+        htmlAttrs={{
+          lang: getLocaleLanguage(shopifyConfig.defaultLocale),
+          dir: getLocaleDirection(shopifyConfig.defaultLocale),
+        }}
+      >
         <RscConsumer />
       </Html>
     );

--- a/packages/hydrogen/src/utilities/locale.ts
+++ b/packages/hydrogen/src/utilities/locale.ts
@@ -1,0 +1,20 @@
+/**
+ * returns `ltr` or `rtl` based on the locale
+ */
+export const getLocaleDirection = (locale?: string): 'ltr' | 'rtl' => {
+  if (!locale) return 'ltr';
+
+  const lng = locale.split('-')[0];
+  const rtlLanguages = new Set(['ar', 'he', 'fa', 'ps', 'ur', 'yi']);
+
+  return rtlLanguages.has(lng) ? 'rtl' : 'ltr';
+};
+
+/**
+ * returns language code from locale
+ */
+export const getLocaleLanguage = (locale?: string): string => {
+  if (!locale) return 'en';
+
+  return locale.split('-')[0];
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixes #511 
I encountered the following issue while trying to use RTL with SSR,Hydration.
First I added `dir="rtl"` to the `<header>` element in `LoadingFallback` and to the Helmet component inside `Seo`.
This is the result of a full page reload:

https://user-images.githubusercontent.com/24938324/150685508-074b18b8-4c08-4439-a8af-687d8520daad.mov


If you look closely, the `LoadingFallback` renders the html with RTL correctly.
Afterwards the app switches to LTR (I guess its related to SSR)
Finally the app returns to RTL when `Seo` with the Helmet component kicks in.

Changes in this PR fixes the issue
Here is a video with the changes:

https://user-images.githubusercontent.com/24938324/150699279-d6218f8d-37e1-41d0-9caa-36b81290ebc7.mov

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
