### PR TITLE
fix: do not add CLI as a dep in the starter due to Node 16 requirements

### DIFF
--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -14,11 +14,10 @@
     "build:server": "vite build --outDir dist/server --ssr src/entry-server.jsx",
     "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr worker.js",
     "serve": "node --enable-source-maps server",
-    "preview": "hydrogen preview"
+    "preview": "npx @shopify/hydrogen-cli@latest preview"
   },
   "prettier": "@shopify/prettier-config",
   "devDependencies": {
-    "@shopify/hydrogen-cli": "^0.9.0",
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/stylelint-plugin": "^10.0.1",
     "@tailwindcss/typography": "^0.5.0",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We added a `yarn preview` script which invokes `hydrogen preview`. 

This command comes from `@shopify/hydrogen-cli`, which is installed as a dep in the starter template.

Unfortunately, a dep of the CLI and the preview command is `miniflare@v2` which requires Node >v16.

We learned recently that we can't bump Node to that dependency because StackBlitz does not yet support it, and releasing the starter template with a dep on the CLI would break new Hydrogen sandboxes on StackBlitz. 

See #492 