### PR TITLE
Update Node 14 -> 16

### DIFF
--- a/examples/template-hydrogen-default/.devcontainer/devcontainer.json
+++ b/examples/template-hydrogen-default/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Shopify Hydrogen",
-  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14",
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-16",
   "settings": {},
   "extensions": [
     "graphql.vscode-graphql",

--- a/packages/create-hydrogen-app/CHANGELOG.md
+++ b/packages/create-hydrogen-app/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- fix: Update Node 14 to Node 16 in DevContainer
 
 ## 0.9.1 - 2022-01-20
 


### PR DESCRIPTION
### Description

Updating VSCode Container as Hydrogen v0.9 requires Node 16.
https://github.com/Shopify/hydrogen/releases/tag/v0.9.0

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
