### PR TITLE
fix: bump to latest React experimental to include SSR Context bugfix

### DIFF
--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -40,8 +40,8 @@
     "express": "^4.17.1",
     "graphql-tag": "^2.12.4",
     "path-to-regexp": "^6.2.0",
-    "react": "0.0.0-experimental-0cc724c77-20211125",
-    "react-dom": "0.0.0-experimental-0cc724c77-20211125",
+    "react": "0.0.0-experimental-529dc3ce8-20220124",
+    "react-dom": "0.0.0-experimental-529dc3ce8-20220124",
     "react-router-dom": "^5.2.0",
     "serve-static": "^1.14.1"
   }

--- a/packages/cli/src/commands/create/app/app.ts
+++ b/packages/cli/src/commands/create/app/app.ts
@@ -83,10 +83,10 @@ export async function app(env: Env<{name: string}>) {
   }
 
   workspace.install('react', {
-    version: '0.0.0-experimental-0cc724c77-20211125',
+    version: '0.0.0-experimental-529dc3ce8-20220124',
   });
   workspace.install('react-dom', {
-    version: '0.0.0-experimental-0cc724c77-20211125',
+    version: '0.0.0-experimental-529dc3ce8-20220124',
   });
   workspace.install('react-router-dom', {version: '^5.2.0'});
   workspace.install('@shopify/hydrogen');

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Warn instead of error when a page server component is missing valid exports
 - Adopt upstream version of React Server Components. See [#498](https://github.com/Shopify/hydrogen/pull/498) for breaking changes.
 - The 'locale' option in shopify.config.js had been renamed to 'defaultLocale'
+- Bump to latest version of React experimental to include [upstream context bugfix](https://github.com/facebook/react/issues/23089)
 
 ## 0.9.1 - 2022-01-20
 

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -83,8 +83,8 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "react": "0.0.0-experimental-0cc724c77-20211125",
-    "react-dom": "0.0.0-experimental-0cc724c77-20211125",
+    "react": "0.0.0-experimental-529dc3ce8-20220124",
+    "react-dom": "0.0.0-experimental-529dc3ce8-20220124",
     "react-router-dom": "^5.2.0",
     "vite": "^2.7.1"
   },

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -1,6 +1,6 @@
 import React, {Suspense, useState} from 'react';
 // @ts-ignore
-import {createRoot} from 'react-dom';
+import {hydrateRoot} from 'react-dom';
 import {BrowserRouter} from 'react-router-dom';
 import type {ClientHandler, ShopifyConfig} from './types';
 import {ErrorBoundary} from 'react-error-boundary';
@@ -24,7 +24,8 @@ const renderHydrogen: ClientHandler = async (
     return;
   }
 
-  createRoot(root, {hydrate: true}).render(
+  hydrateRoot(
+    root,
     <ErrorBoundary FallbackComponent={Error}>
       <Suspense fallback={null}>
         <Content clientWrapper={ClientWrapper} shopifyConfig={shopifyConfig} />

--- a/packages/playground/server-components-worker/package.json
+++ b/packages/playground/server-components-worker/package.json
@@ -16,8 +16,8 @@
     "@cloudflare/kv-asset-handler": "*",
     "@shopify/hydrogen": "^0.9.1",
     "miniflare": "^1.3.3",
-    "react": "0.0.0-experimental-0cc724c77-20211125",
-    "react-dom": "0.0.0-experimental-0cc724c77-20211125",
+    "react": "0.0.0-experimental-529dc3ce8-20220124",
+    "react-dom": "0.0.0-experimental-529dc3ce8-20220124",
     "react-router-dom": "^5.2.0"
   }
 }

--- a/packages/playground/server-components/package.json
+++ b/packages/playground/server-components/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@shopify/hydrogen": "^0.9.1",
-    "react": "0.0.0-experimental-0cc724c77-20211125",
-    "react-dom": "0.0.0-experimental-0cc724c77-20211125",
+    "react": "0.0.0-experimental-529dc3ce8-20220124",
+    "react-dom": "0.0.0-experimental-529dc3ce8-20220124",
     "react-router-dom": "^5.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11275,14 +11275,14 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@0.0.0-experimental-0cc724c77-20211125:
-  version "0.0.0-experimental-0cc724c77-20211125"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-0cc724c77-20211125.tgz#f48ee44d803b7ba6a888f1cd5ef4402e84f46dba"
-  integrity sha512-VAaAcGgIVGHX8nOjwQNLEFNI1ONyxsPvKgZ3ywJjEEo5leMDCuYzu+AC2kn1wyyd/4SsI0FOogbpaTcnLMgoUg==
+react-dom@0.0.0-experimental-529dc3ce8-20220124:
+  version "0.0.0-experimental-529dc3ce8-20220124"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-529dc3ce8-20220124.tgz#62408979d684b43a5bea27934fda15fa31a80f2a"
+  integrity sha512-FNqeU2sPoynTu7Sh1IY880Bxg/xX22tlsTHoh67J+PTY7aFBAYMgE5PkxZon54DpQkv2p8gWVIIzSObi4U7ZjQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.0.0-experimental-0cc724c77-20211125"
+    scheduler "0.0.0-experimental-529dc3ce8-20220124"
 
 react-error-boundary@^3.1.3:
   version "3.1.4"
@@ -11360,10 +11360,10 @@ react-router@5.2.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@0.0.0-experimental-0cc724c77-20211125:
-  version "0.0.0-experimental-0cc724c77-20211125"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-0cc724c77-20211125.tgz#ed650068fbccae10a4cb7b78981517cf7a249f22"
-  integrity sha512-8jVo1Rew40qblTTRkVm6ksk4YZ0rG30nwyXwDnnPEszQaUp+dXfEFsoxnSGElroECC2dx4Gg3a6kFsmrBYaF5Q==
+react@0.0.0-experimental-529dc3ce8-20220124:
+  version "0.0.0-experimental-529dc3ce8-20220124"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-529dc3ce8-20220124.tgz#843efb350b3034c5cb5d3d657ece78a8057b7a2b"
+  integrity sha512-EGC2hJU4tjaVgcLHE090M592h+AfO6Y88cnS1XtPMHWBgsNpO4t3rZfLFU4bMor3wRSKPEIzmEcpaPWCrJWctA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -12068,10 +12068,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.0.0-experimental-0cc724c77-20211125:
-  version "0.0.0-experimental-0cc724c77-20211125"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-0cc724c77-20211125.tgz#79c9bedbcc1942aab5ddadf12711ddd5db8ef915"
-  integrity sha512-JcvQnsZuiqkRI+uekA9cgAVOHccuBxzOdTqPs3FAInrnZO9OhufomeTKIXuFQwjwZ5DYstOSZax/QnKVXCJFbw==
+scheduler@0.0.0-experimental-529dc3ce8-20220124:
+  version "0.0.0-experimental-529dc3ce8-20220124"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-529dc3ce8-20220124.tgz#4c3da241ae995e2790688e2a775e7db2e26f9d0f"
+  integrity sha512-mp0MaDWUfFuByyQS3syKFF3pqk7m6NcIsTNFsu/7jdy0GCqk7jy3T2YgHF3S1Y0qNhV9TYCgGwLTZSNaae2uUQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

@frandiox fixed the React 18 streaming SSR context bug we'd diagnosed: https://github.com/facebook/react/issues/23089

This PR uses the latest experimental version to ensure we have this code 🎉 

**Note**: We'll need to remember to have users update the version of React experimental they're using when they make the upgrade.

Fixes #415 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
