### PR TITLE
Fix API Routes hot reloading and improvements to API route responses

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -12,6 +12,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - The 'locale' option in shopify.config.js had been renamed to 'defaultLocale'
 - dx: rename `graphqlApiVersion` to `storefrontApiVersion` in `shopify.config.js`
 - Bump to latest version of React experimental to include [upstream context bugfix](https://github.com/facebook/react/issues/23089)
+- feature: improve API routes by allowing [strings and JS objects](https://github.com/Shopify/hydrogen/issues/476) to be returned.
+- fix: make sure that API routes [hot reload properly](https://github.com/Shopify/hydrogen/issues/497)
 
 ## 0.9.1 - 2022-01-20
 

--- a/packages/playground/server-components-worker/src/pages/json.server.jsx
+++ b/packages/playground/server-components-worker/src/pages/json.server.jsx
@@ -1,0 +1,3 @@
+export function api() {
+  return {some: 'json'};
+}

--- a/packages/playground/server-components-worker/src/pages/string.server.jsx
+++ b/packages/playground/server-components-worker/src/pages/string.server.jsx
@@ -1,0 +1,3 @@
+export function api() {
+  return 'some string';
+}

--- a/packages/playground/server-components-worker/tests/worker-e2e.test.ts
+++ b/packages/playground/server-components-worker/tests/worker-e2e.test.ts
@@ -152,6 +152,22 @@ it('should return 404 on unknown method', async () => {
   expect(text).toBe('Comment method not found');
 });
 
+it('should support simple strings returned from API routes', async () => {
+  const response = await page.request.get(url + '/string');
+  const text = await response.text();
+
+  expect(response.status()).toBe(200);
+  expect(text).toBe('some string');
+});
+
+it('should support objects as json returned from API routes', async () => {
+  const response = await page.request.get(url + '/json');
+  const json = await response.json();
+
+  expect(response.status()).toBe(200);
+  expect(json).toEqual({some: 'json'});
+});
+
 it('supports form request on API routes', async () => {
   await page.goto(url + '/form');
   await page.type('#fname', 'sometext');

--- a/packages/playground/server-components/src/pages/json.server.jsx
+++ b/packages/playground/server-components/src/pages/json.server.jsx
@@ -1,0 +1,3 @@
+export function api() {
+  return {some: 'json'};
+}

--- a/packages/playground/server-components/src/pages/string.server.jsx
+++ b/packages/playground/server-components/src/pages/string.server.jsx
@@ -1,0 +1,3 @@
+export function api() {
+  return 'some string';
+}

--- a/packages/playground/server-components/tests/node-e2e.test.ts
+++ b/packages/playground/server-components/tests/node-e2e.test.ts
@@ -139,6 +139,22 @@ it('should return 404 on unknown method', async () => {
   expect(text).toBe('Comment method not found');
 });
 
+it('should support simple strings returned from API routes', async () => {
+  const response = await page.request.get(viteTestUrl + '/string');
+  const text = await response.text();
+
+  expect(response.status()).toBe(200);
+  expect(text).toBe('some string');
+});
+
+it('should support objects as json returned from API routes', async () => {
+  const response = await page.request.get(viteTestUrl + '/json');
+  const json = await response.json();
+
+  expect(response.status()).toBe(200);
+  expect(json).toEqual({some: 'json'});
+});
+
 it.skip('supports form request on API routes', async () => {
   await page.goto(viteTestUrl + '/form');
   await page.type('#fname', 'sometext');


### PR DESCRIPTION
### Description

1. Make sure that API routes hot reload properly - #497
2. Support automatically creating Responses from strings and primitive JS objects - #476

### Additional context

Example usage of API routes:

```js
export function api() {
  return "some string";
}

export function api() {
  return { some: "json" };
}
```

### Before submitting the PR, please make sure you do the following:

- [X] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository for your change, if needed
