### PR TITLE
feat: avoid bundling all client components in server

### DIFF
--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
@@ -9,6 +9,8 @@
 
 import {createElement} from 'react';
 
+globalThis.__COMPONENT_INDEX = {};
+
 function _defineProperty(obj, key, value) {
   if (key in obj) {
     Object.defineProperty(obj, key, {
@@ -66,6 +68,13 @@ function wrapInClientProxy(_ref) {
   rscDescriptor.$$typeof_rsc = Symbol.for('react.module.reference');
   rscDescriptor.filepath = id;
   rscDescriptor.name = named ? name : 'default';
+
+  if (!__COMPONENT_INDEX[id]) {
+    // Store a loader function to find components during SSR when consuming RSC
+    __COMPONENT_INDEX[id] = () =>
+      Promise.resolve({[rscDescriptor.name]: component});
+  }
+
   return new Proxy(componentRef, {
     get: function (target, prop) {
       return (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This removes Vite's `import.meta.glob` from the server so it won't bundle all client components there. Instead, it stores only the used components in a global store that is later used in SSR when consuming the RSC response.
This is all based on the fact that RSC always runs before SSR so we can let it "discover" client components and store a reference to them.

The starter template worker bundle is reduced by 17KB with this but it should be more noticeable in apps that don't use all the Hydrogen UI components.

Note: Client bundle still relies on `import.meta.glob` to load components lazily.

### Additional context

`import.meta.glob` finds **all** client components even if they are not used (including the ones provided by Hydrogen). This is not a big issue in the client because they are lazy loaded, meaning that there's only a reference bundled for the client but the actual component is only downloaded if needed.
However, server and worker environment always bundle all the discovered components at build time.



@jplhomer With this change, we could potentially remove the `new Proxy` we have in the plugin, but we would need to refactor our `renderToBufferedString` before to rely on RSC=>SSR instead of purely SSR.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
