### PR TITLE
feat: add `dev` command to CLI

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Adds `dev` command for running Hydrogen apps locally with vite
 - Adds `preview` command for running Hydrogen apps in a local Worker runtime
 - Prevent CLI commands from unintentionally mutating the app code
 - Adds cache support for `preview` command

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,0 +1,21 @@
+import childProcess from 'child_process';
+import {join} from 'path';
+import {Env} from '../../types';
+import {MissingDependencyError} from '../../utilities/error';
+
+export async function dev(env: Env) {
+  const {ui, workspace, fs} = env;
+
+  const binPath = join(workspace.root(), `/node_modules/.bin/vite`);
+
+  if (!(await fs.exists(binPath))) {
+    throw new MissingDependencyError('vite');
+  }
+
+  ui.say('Starting Hydrogen server in dev...');
+
+  childProcess.spawn('node', [binPath], {
+    cwd: workspace.root(),
+    stdio: 'inherit',
+  });
+}

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -1,0 +1,1 @@
+export {dev as default} from './dev';

--- a/packages/cli/src/commands/dev/tests/dev.test.ts
+++ b/packages/cli/src/commands/dev/tests/dev.test.ts
@@ -1,0 +1,29 @@
+import {withCli} from '../../../testing';
+
+describe('dev', () => {
+  it('provides a helpful message when vite is not found', async () => {
+    await withCli(async ({run}) => {
+      const {output} = await run('dev');
+
+      expect(output.stdout.join('')).toContain('Missing the `vite` dependency');
+    });
+  });
+
+  it('runs the local vite binary', async () => {
+    await withCli(
+      async ({run, fs}) => {
+        await fs.write(
+          'node_modules/.bin/vite',
+          'console.log("hello from vite");'
+        );
+
+        const result = await run('dev');
+        const output = result.output.stdout.join('');
+
+        expect(output).toContain('Starting Hydrogen server in dev..');
+        expect(output).toContain('hello from vite');
+      },
+      {debug: true}
+    );
+  });
+});

--- a/packages/cli/src/testing/testing.ts
+++ b/packages/cli/src/testing/testing.ts
@@ -29,7 +29,8 @@ export type Command =
   | 'create component'
   | 'create page'
   | 'check'
-  | 'preview';
+  | 'preview'
+  | 'dev';
 type Input = Record<string, string | boolean | null>;
 
 interface App {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -41,3 +41,5 @@ export interface CheckResult {
   /** optional function to correct the problems in the current project **/
   fix?: (env: Env) => void;
 }
+
+export type Loggable = (env: Env) => string;

--- a/packages/cli/src/ui/ui.ts
+++ b/packages/cli/src/ui/ui.ts
@@ -31,6 +31,8 @@ interface ConstructorOptions {
 
 interface SayOptions {
   error?: boolean;
+  breakAfter?: boolean;
+  strong?: boolean;
 }
 
 export interface Ui {
@@ -99,19 +101,17 @@ export class Cli implements Ui {
       return;
     }
 
-    const styledMessage = options.error ? chalk.redBright`${message}` : message;
-    const type = options.error ? chalk.black.bgRedBright` error ` : '';
+    const styledText = options.error ? chalk.redBright`${message}` : message;
+    const type = options.error
+      ? `${chalk.black.bgRedBright` error `}${this.indent}`
+      : '';
+    const combinedMessage = [type, styledText].join('');
 
-    console.log(
-      [
-        this.indent,
-        this.prefix,
-        this.indent,
-        type,
-        this.indent,
-        styledMessage,
-      ].join('')
-    );
+    console.log(options.strong ? chalk.bold(combinedMessage) : combinedMessage);
+
+    if (options.breakAfter) {
+      console.log('');
+    }
   }
 
   printFile({path, overwritten, diff}: FileResult) {

--- a/packages/cli/src/utilities/error.ts
+++ b/packages/cli/src/utilities/error.ts
@@ -33,8 +33,8 @@ export class MissingDependencyError extends HelpfulError {
       content: () => `\`${dep}\` is required to use this command.`,
       suggestion: () =>
         [
-          `- Run \`yarn add ${dep}\` to install the missing dependency.`,
           `- Run \`yarn\` to install all dependencies listed in the package.json.`,
+          `- Run \`yarn add ${dep}\` to install the missing dependency.`,
         ].join(`\n`),
     });
   }

--- a/packages/cli/src/utilities/error.ts
+++ b/packages/cli/src/utilities/error.ts
@@ -1,4 +1,80 @@
-// TODO: Make these more meaningful and logging behavior
+import {Loggable, Env} from '../types';
+
+interface ErrorOptions {
+  title?: string;
+  content?: Loggable;
+  suggestion?: Loggable;
+}
+
+const ID = Symbol.for('HydrogenCLI::HelpfulError');
+
+export function isHelpfulError(value: unknown) {
+  return Boolean((value as any)?.[ID]);
+}
+
+export class HelpfulError extends Error {
+  readonly [ID] = true;
+  readonly suggestion: ErrorOptions['suggestion'];
+  readonly title: ErrorOptions['title'];
+  readonly content: ErrorOptions['content'];
+
+  constructor({title, content, suggestion}: ErrorOptions) {
+    super(title);
+    this.title = title;
+    this.content = content;
+    this.suggestion = suggestion;
+  }
+}
+
+export class MissingDependencyError extends HelpfulError {
+  constructor(dep: string) {
+    super({
+      title: `Missing the \`${dep}\` dependency`,
+      content: () => `\`${dep}\` is required to use this command.`,
+      suggestion: () =>
+        [
+          `- Run \`yarn add ${dep}\` to install the missing dependency.`,
+          `- Run \`yarn\` to install all dependencies listed in the package.json.`,
+        ].join(`\n`),
+    });
+  }
+}
+
+export function logError(error: any, env: Env) {
+  env.ui.say(error.title ?? 'An unexpected error occurred', {
+    error: true,
+    breakAfter: true,
+  });
+
+  if (isHelpfulError(error)) {
+    if (error.content) {
+      env.ui.say('What happened?', {strong: true});
+      env.ui.say(error.content(env), {breakAfter: true});
+    }
+
+    if (error.suggestion) {
+      env.ui.say('What do I do next?', {strong: true});
+      env.ui.say(error.suggestion(env), {breakAfter: true});
+    }
+
+    env.ui.say('Still experiencing issues?', {strong: true});
+  }
+  env.ui.say(
+    'Help us make Hydrogen better by reporting this error so we can improve this message and/or fix the error.'
+  );
+  env.ui.say('- Report on Discord: https://discord.com/invite/ppSbThrFaS');
+  env.ui.say(
+    '- Create an issue in GitHub: https://github.com/Shopify/hydrogen/issues/new'
+  );
+  env.ui.say(
+    '- Fill out our feedback form: https://www.surveymonkey.com/r/HydrogenFeedback',
+    {breakAfter: true}
+  );
+  env.ui.say('Error stack:', {strong: true});
+  env.ui.say(error.stack);
+}
+
+// TODO: Make these more meaningful and add logging behavior
 export class BaseError extends Error {}
 export class NotImplementedError extends BaseError {}
 export class InputError extends BaseError {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR runs the vite binary from our CLI package and defines a better pattern to handle user errors.

### Additional context

- Next step will be to run the `createServer` method from the vite node API instead.
- You can Tophat using the tophat script to copy the cli to a local hydrogen app or by running the CLI from the root of the monorepo but setting the root to another hydrogen app on your machine. For example:

```
yarn h2 dev --root=../path/to/app
```

**Example error output**

<img width="761" alt="Screen Shot 2022-01-25 at 09 02 34" src="https://user-images.githubusercontent.com/462077/150937378-3fca78a8-c17e-40bf-8315-ab4729d2e15b.png">


### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
