### PR TITLE
Fix HMR for new page files

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix: hot reload for newly added page files
 
 ## 0.10.0 - 2022-01-25
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -46,7 +46,7 @@ export default (
             shopifyConfig,
             indexTemplate: getIndexTemplate,
             getServerEntrypoint: async () =>
-              await server.ssrLoadModule(resolve('./src/entry-server')),
+              await server.ssrLoadModule('/src/entry-server'),
             devServer: server,
             cache: pluginOptions?.devCache
               ? (new InMemoryCache() as unknown as Cache)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Reported by @scottdixon and @blittle 

New files added to `src/pages/` are not reloaded properly. The visible issue is just a warning that says `./pages/name.server.jsx doesn't export a default React component or an API function` because the file is normally created empty, but this is not solved when updating the file with proper content until the server is restarted.

The reason is that Vite is creating two different modules for `src/entry-server.jsx`, which is the file that imports all the new page files via `import.meta.glob`. Having two modules for the same file is likely a bug in Vite. I'll make a PR or talk with the Vite team later to clarify.

In the meantime, this change ensures we end up with only 1 module for `src/entry-server.jsx` that tracks all the existing and new pages.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
