### PR TITLE
feat: selected options deep link prototype

### DIFF
--- a/examples/template-hydrogen-default/src/components/ProductOptions.client.jsx
+++ b/examples/template-hydrogen-default/src/components/ProductOptions.client.jsx
@@ -1,10 +1,38 @@
+import {useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
 import {useProduct} from '@shopify/hydrogen/client';
 
 /**
  * A client component that tracks a selected variant and/or selling plan state, as well as callbacks for modifying the state
  */
 export default function ProductOptions() {
-  const {options, setSelectedOption, selectedOptions} = useProduct();
+  const {options, setSelectedOption, selectedOptions, setSelectedOptions} =
+    useProduct();
+  const history = useHistory();
+
+  useEffect(() => {
+    const params = new URLSearchParams(history.location.search);
+
+    params.forEach((value, name) => {
+      selectedOptions[name] = value;
+    });
+
+    history.replace({
+      search: params.toString(),
+    });
+
+    setSelectedOptions(selectedOptions);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(selectedOptions);
+
+    history.replace({
+      search: params.toString(),
+    });
+  }, [history, selectedOptions]);
 
   return (
     <>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Related to https://github.com/Shopify/hydrogen/issues/538

### Description

This is a quick POC for storing product state in the URL query params for product options. 

### Additional context

When the component renders (on the client) we parse the query params from the URL and call the `setSelectedOptions` function with a merged object of the existing `selectedOptions` and the ones from our URL query param state. We also need to update the url query param when the component selected options change.


### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
