### PR TITLE
fix: index routes #562

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Fix index routes. See [#562](https://github.com/Shopify/hydrogen/issues/562)
 - dx: Correct Typescript issue where `as` was a default prop for all components when it should not be
 - New React hook `useScriptLoader` is available to more easily load external scripts
 

--- a/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
+++ b/packages/hydrogen/src/foundation/Router/DefaultRoutes.tsx
@@ -61,7 +61,7 @@ export function createRoutesFromPages(
 
   const routes = Object.keys(pages)
     .map((key) => {
-      const path = key
+      let path = key
         .replace('./pages', '')
         .replace(/\.server\.(t|j)sx?$/, '')
         /**
@@ -80,6 +80,9 @@ export function createRoutesFromPages(
           /\[(?:[.]{3})?(\w+?)\]/g,
           (_match, param: string) => `:${param}`
         );
+
+      if (path.endsWith('/') && path !== '/')
+        path = path.substring(0, path.length - 1);
 
       /**
        * Catch-all routes [...handle].jsx don't need an exact match

--- a/packages/hydrogen/src/foundation/Router/tests/DefaultRoutes.test.tsx
+++ b/packages/hydrogen/src/foundation/Router/tests/DefaultRoutes.test.tsx
@@ -44,13 +44,22 @@ it('handles index pages', () => {
 
 it('handles nested index pages', () => {
   const pages: ImportGlobEagerOutput = {
+    './pages/products/index.server.jsx': STUB_MODULE,
+    './pages/products/[handle].server.jsx': STUB_MODULE,
     './pages/blogs/index.server.jsx': STUB_MODULE,
     './pages/products/snowboards/fastones/index.server.jsx': STUB_MODULE,
+    './pages/articles/index.server.jsx': STUB_MODULE,
+    './pages/articles/[...handle].server.jsx': STUB_MODULE,
   };
 
   const routes = createRoutesFromPages(pages);
 
   expect(routes).toEqual([
+    {
+      path: '/products',
+      component: STUB_MODULE.default,
+      exact: true,
+    },
     {
       path: '/blogs',
       component: STUB_MODULE.default,
@@ -60,6 +69,21 @@ it('handles nested index pages', () => {
       path: '/products/snowboards/fastones',
       component: STUB_MODULE.default,
       exact: true,
+    },
+    {
+      path: '/articles',
+      component: STUB_MODULE.default,
+      exact: true,
+    },
+    {
+      path: '/products/:handle',
+      component: STUB_MODULE.default,
+      exact: true,
+    },
+    {
+      path: '/articles/:handle',
+      component: STUB_MODULE.default,
+      exact: false,
     },
   ]);
 });

--- a/packages/hydrogen/src/foundation/Router/tests/DefaultRoutes.test.tsx
+++ b/packages/hydrogen/src/foundation/Router/tests/DefaultRoutes.test.tsx
@@ -42,6 +42,28 @@ it('handles index pages', () => {
   ]);
 });
 
+it('handles nested index pages', () => {
+  const pages: ImportGlobEagerOutput = {
+    './pages/blogs/index.server.jsx': STUB_MODULE,
+    './pages/products/snowboards/fastones/index.server.jsx': STUB_MODULE,
+  };
+
+  const routes = createRoutesFromPages(pages);
+
+  expect(routes).toEqual([
+    {
+      path: '/blogs',
+      component: STUB_MODULE.default,
+      exact: true,
+    },
+    {
+      path: '/products/snowboards/fastones',
+      component: STUB_MODULE.default,
+      exact: true,
+    },
+  ]);
+});
+
 it('handles dynamic paths', () => {
   const pages: ImportGlobEagerOutput = {
     './pages/contact.server.jsx': STUB_MODULE,


### PR DESCRIPTION
### Description

fix: index routes #562

### Additional context

Something was different in React Router where they'd auto handle paths that end in `/`.

### Before submitting the PR, please make sure you do the following:

- [X] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository for your change, if needed
