### PR TITLE
docs: update production deployment

### DIFF
--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -12,10 +12,13 @@ Runs the Hydrogen dev project on the port specified as `$PORT`, defaulting to `8
 ```bash
 yarn build
 
-yarn workspace dev serve
+yarn serve
 ```
 
-Visit the project running at http://localhost:8080.
+> Note:
+> Depending on the platform you deploy to (for example, Heroku, Google Cloud Platform, or Vercel), you might need to modify the configuration of `server.js`.
+
+If you're using the default port, then the production version of your app will be running at http://localhost:8080.
 
 ### Platform: Docker
 
@@ -55,6 +58,8 @@ entry-point = "."
 upload.format = "service-worker"
 command = "yarn && yarn build"
 ```
+
+For more information about the configurable properties in the `wrangler.toml` file, refer to Cloudflare's [configuration](https://developers.cloudflare.com/workers/cli-wrangler/configuration) and [compatibility dates](https://developers.cloudflare.com/workers/platform/compatibility-dates) documentation.
 
 Install Cloudflare's KV asset handler:
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Update serve command and align docs with shopify-dev docs (#15676)

@cartogram I'm not sure how these docs are maintained but they still mentions "Hydrogen dev". Should we change that to "starter template" or similar?

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
