### PR TITLE
Add discountCodes `applicable` to `useCart()`

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.graphql
+++ b/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.graphql
@@ -73,5 +73,6 @@ fragment CartFragment on Cart {
   }
   discountCodes {
     code
+    applicable
   }
 }

--- a/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.ts
+++ b/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.ts
@@ -70,6 +70,6 @@ export type CartFragmentFragment = {__typename?: 'Cart'} & Pick<
       {__typename?: 'Attribute'} & Pick<Types.Attribute, 'key' | 'value'>
     >;
     discountCodes: Array<
-      {__typename?: 'CartDiscountCode'} & Pick<Types.CartDiscountCode, 'code'>
+      {__typename?: 'CartDiscountCode'} & Pick<Types.CartDiscountCode, 'code' | 'applicable'>
     >;
   };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes #347 by making sure we retrieve the `applicable` field under `discountCodes` when retrieving the cart, that way we can show on the front-end whether or not a discount code is applicable to the current cart context.

```
const { discountCodes } = useCart();

console.log(discountCodes);
// [{"code":"TEST","applicable":false}]
```

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
