### PR TITLE
feat: Provide shopifyConfig in client automatically

### DIFF
--- a/examples/template-hydrogen-default/src/App.client.jsx
+++ b/examples/template-hydrogen-default/src/App.client.jsx
@@ -1,16 +1,13 @@
 import {HelmetProvider} from '@shopify/hydrogen/client';
 import CartProvider from './components/CartProvider.client';
-import {ShopifyProvider} from '@shopify/hydrogen/client';
 
 /**
  *  Setup client context, though the children are most likely server components
  */
 export default function ClientApp({helmetContext, children, shopifyConfig}) {
   return (
-    <ShopifyProvider shopifyConfig={shopifyConfig}>
-      <HelmetProvider context={helmetContext}>
-        <CartProvider>{children}</CartProvider>
-      </HelmetProvider>
-    </ShopifyProvider>
+    <HelmetProvider context={helmetContext}>
+      <CartProvider>{children}</CartProvider>
+    </HelmetProvider>
   );
 }

--- a/examples/template-hydrogen-default/src/App.server.jsx
+++ b/examples/template-hydrogen-default/src/App.server.jsx
@@ -12,10 +12,7 @@ export default function App({log, pages, ...serverState}) {
   return (
     <Suspense fallback={<LoadingFallback />}>
       <ShopifyProvider shopifyConfig={shopifyConfig}>
-        <AppClient
-          helmetContext={serverState.helmetContext}
-          shopifyConfig={shopifyConfig}
-        >
+        <AppClient helmetContext={serverState.helmetContext}>
           <DefaultSeo />
           <DefaultRoutes
             pages={pages}

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -36,3 +36,8 @@ jest.mock('@shopify/react-testing/build/cjs/compat.js', () => {
     },
   };
 });
+
+// TODO Remove when Jest supports import.meta
+jest.mock('./packages/hydrogen/src/utilities/meta-env-ssr', () => ({
+  META_ENV_SSR: false,
+}));

--- a/packages/hydrogen/src/client.ts
+++ b/packages/hydrogen/src/client.ts
@@ -2,7 +2,6 @@ export * from './components';
 export * from './hooks';
 export * from './foundation/useServerState';
 export * from './foundation/useShop';
-export * from './foundation/ShopifyProvider';
 export {Boomerang} from './foundation/Boomerang/Boomerang.client';
 export * from './foundation/ServerStateProvider';
 export {ServerStateRouter} from './foundation/Router/ServerStateRouter.client';

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -154,7 +154,9 @@ const renderHydrogen: ServerHandler = (App, {pages}) => {
 
     const ReactAppSSR = (
       <Html template={template} htmlAttrs={{lang: 'en'}}>
-        <RscConsumer />
+        <ServerRequestProvider request={request} isRSC={false}>
+          <RscConsumer />
+        </ServerRequestProvider>
       </Html>
     );
 

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -59,6 +59,13 @@ export function useServerRequest() {
   }
 
   if (!request) {
+    // @ts-ignore
+    if (__DEV__ && typeof jest !== 'undefined') {
+      // Unit tests are not wrapped in ServerRequestProvider.
+      // This mocks it, instead of providing it in every test.
+      return {ctx: {}} as ServerComponentRequest;
+    }
+
     throw new Error('No ServerRequest Context found');
   }
 

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -59,13 +59,11 @@ export function useServerRequest() {
   }
 
   if (!request) {
-    throw new NoServerRequestContext('No ServerRequest Context found');
+    throw new Error('No ServerRequest Context found');
   }
 
   return request;
 }
-
-export class NoServerRequestContext extends Error {}
 
 type RequestCacheResult<T> =
   | {data: T; error?: never} // success

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.client.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.client.tsx
@@ -1,0 +1,18 @@
+import type {ShopifyContextValue} from './types';
+import React, {createContext, ReactNode} from 'react';
+
+export const ShopifyContext = createContext<ShopifyContextValue | null>(null);
+
+export function ShopifyProviderClient({
+  children,
+  shopifyConfig,
+}: {
+  children: ReactNode;
+  shopifyConfig: ShopifyContextValue;
+}): JSX.Element {
+  return (
+    <ShopifyContext.Provider value={shopifyConfig}>
+      {children}
+    </ShopifyContext.Provider>
+  );
+}

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.server.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.server.tsx
@@ -1,14 +1,11 @@
 import React, {useMemo} from 'react';
-// import {ShopifyContext, makeShopifyContext} from './ShopifyContext';
+import {ShopifyProviderClient} from './ShopifyProvider.client';
 import type {ShopifyProviderProps} from './types';
 
-import {createContext} from 'react';
 import {DEFAULT_LOCALE} from '../constants';
 import type {ShopifyContextValue} from './types';
 import type {ShopifyConfig} from '../../types';
 import {useServerRequest} from '../ServerRequestProvider';
-
-export const ShopifyContext = createContext<ShopifyContextValue | null>(null);
 
 function makeShopifyContext(shopifyConfig: ShopifyConfig): ShopifyContextValue {
   return {
@@ -36,15 +33,12 @@ export function ShopifyProvider({
     [shopifyConfig]
   );
 
-  if (import.meta.env.SSR) {
-    const request = useServerRequest();
-    request.ctx.shopifyConfig = shopifyProviderValue;
-    return <>{children}</>;
-  }
+  const request = useServerRequest();
+  request.ctx.shopifyConfig = shopifyProviderValue;
 
   return (
-    <ShopifyContext.Provider value={shopifyProviderValue}>
+    <ShopifyProviderClient shopifyConfig={shopifyProviderValue}>
       {children}
-    </ShopifyContext.Provider>
+    </ShopifyProviderClient>
   );
 }

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.tsx
@@ -6,10 +6,7 @@ import {createContext} from 'react';
 import {DEFAULT_LOCALE} from '../constants';
 import type {ShopifyContextValue} from './types';
 import type {ShopifyConfig} from '../../types';
-import {
-  NoServerRequestContext,
-  useServerRequest,
-} from '../ServerRequestProvider';
+import {useServerRequest} from '../ServerRequestProvider';
 
 export const ShopifyContext = createContext<ShopifyContextValue | null>(null);
 
@@ -39,17 +36,10 @@ export function ShopifyProvider({
     [shopifyConfig]
   );
 
-  try {
+  if (import.meta.env.SSR) {
     const request = useServerRequest();
-
-    if (request) {
-      request.ctx.shopifyConfig = shopifyProviderValue;
-      return <>{children}</>;
-    }
-  } catch (e) {
-    if (!(e instanceof NoServerRequestContext)) {
-      throw e;
-    }
+    request.ctx.shopifyConfig = shopifyProviderValue;
+    return <>{children}</>;
   }
 
   return (

--- a/packages/hydrogen/src/foundation/ShopifyProvider/index.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/index.ts
@@ -1,1 +1,2 @@
-export {ShopifyProvider, ShopifyContext} from './ShopifyProvider';
+export {ShopifyProvider} from './ShopifyProvider.server';
+export {ShopifyContext} from './ShopifyProvider.client';

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {ShopifyProvider, ShopifyContext} from '../ShopifyProvider';
+import {ShopifyProvider, ShopifyContext} from '..';
 import {DEFAULT_LOCALE} from '../../constants';
 import {SHOPIFY_CONFIG} from './fixtures';
-import {useServerRequest} from '../../ServerRequestProvider';
 
 describe('<ShopifyProvider />', () => {
   it('renders its children', () => {

--- a/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
@@ -1,4 +1,5 @@
-import {ShopifyConfig} from '../../types';
+import type {ReactNode} from 'react';
+import type {ShopifyConfig} from '../../types';
 
 export type ShopifyContextValue = {
   locale: string;
@@ -11,6 +12,6 @@ export type ShopifyProviderProps = {
   /** The contents of the `shopify.config.js` file. */
   shopifyConfig: ShopifyConfig;
   /** Any `ReactNode` elements. */
-  children?: React.ReactNode;
+  children?: ReactNode;
   manager?: any;
 };

--- a/packages/hydrogen/src/foundation/useShop/use-shop.tsx
+++ b/packages/hydrogen/src/foundation/useShop/use-shop.tsx
@@ -1,31 +1,16 @@
 import {useContext} from 'react';
 import {ShopifyContext} from '../ShopifyProvider';
-import type {ShopifyContextValue} from '../ShopifyProvider/types';
-import {
-  NoServerRequestContext,
-  useServerRequest,
-} from '../ServerRequestProvider';
+import {useServerRequest} from '../ServerRequestProvider';
 
 // let contextValue: ShopifyContextValue | null = null;
 
 /**
  * The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
  */
-export function useShop(): ShopifyContextValue {
-  let config: ShopifyContextValue | null = null;
-
-  try {
-    const request = useServerRequest();
-    config = request?.ctx?.shopifyConfig;
-  } catch (e) {
-    if (!(e instanceof NoServerRequestContext)) {
-      throw e;
-    }
-  }
-
-  if (!config) {
-    config = useContext(ShopifyContext);
-  }
+export function useShop() {
+  const config = import.meta.env.SSR
+    ? useServerRequest().ctx.shopifyConfig
+    : useContext(ShopifyContext);
 
   if (!config) {
     throw new Error('No Shopify Context found');

--- a/packages/hydrogen/src/foundation/useShop/use-shop.tsx
+++ b/packages/hydrogen/src/foundation/useShop/use-shop.tsx
@@ -1,6 +1,8 @@
 import {useContext} from 'react';
 import {ShopifyContext} from '../ShopifyProvider';
 import {useServerRequest} from '../ServerRequestProvider';
+// @ts-ignore
+import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
 
 // let contextValue: ShopifyContextValue | null = null;
 
@@ -8,7 +10,7 @@ import {useServerRequest} from '../ServerRequestProvider';
  * The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
  */
 export function useShop() {
-  const config = import.meta.env.SSR
+  const config = META_ENV_SSR
     ? useServerRequest().ctx.shopifyConfig
     : useContext(ShopifyContext);
 

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
@@ -1,3 +1,4 @@
+import type {ShopifyContextValue} from '../../foundation/ShopifyProvider/types';
 import {getTime} from '../../utilities/timing';
 
 let reqCounter = 0; // For debugging
@@ -21,7 +22,11 @@ export class ServerComponentRequest extends Request {
   public id: string;
   public time: number;
   // CFW Request has a reserved 'context' property, use 'ctx' instead.
-  public ctx: {cache: Map<string, any>; [key: string]: any};
+  public ctx: {
+    cache: Map<string, any>;
+    shopifyConfig?: ShopifyContextValue;
+    [key: string]: any;
+  };
 
   constructor(input: any);
   constructor(input: RequestInfo, init?: RequestInit);

--- a/packages/hydrogen/src/utilities/meta-env-ssr.ts
+++ b/packages/hydrogen/src/utilities/meta-env-ssr.ts
@@ -1,0 +1,3 @@
+// This is mocked in Jest
+// @ts-ignore
+export const META_ENV_SSR = import.meta.env.SSR;

--- a/packages/playground/server-components-worker/src/components/Config.client.jsx
+++ b/packages/playground/server-components-worker/src/components/Config.client.jsx
@@ -1,7 +1,0 @@
-import {ShopifyProvider} from '@shopify/hydrogen/client';
-
-export default function ClientConfig({shopifyConfig, children}) {
-  return (
-    <ShopifyProvider shopifyConfig={shopifyConfig}>{children}</ShopifyProvider>
-  );
-}

--- a/packages/playground/server-components-worker/src/pages/config/[handle].server.jsx
+++ b/packages/playground/server-components-worker/src/pages/config/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {ShopifyProvider, useShop} from '@shopify/hydrogen';
-import ClientConfig from '../../components/Config.client';
 
 export default function Config({params}) {
   const {handle} = params;
@@ -10,9 +9,7 @@ export default function Config({params}) {
   };
   return (
     <ShopifyProvider shopifyConfig={config}>
-      <ClientConfig shopifyConfig={config}>
-        <ReadConfig />
-      </ClientConfig>
+      <ReadConfig />
     </ShopifyProvider>
   );
 }

--- a/packages/playground/server-components/src/components/Config.client.jsx
+++ b/packages/playground/server-components/src/components/Config.client.jsx
@@ -1,7 +1,0 @@
-import {ShopifyProvider} from '@shopify/hydrogen/client';
-
-export default function ClientConfig({shopifyConfig, children}) {
-  return (
-    <ShopifyProvider shopifyConfig={shopifyConfig}>{children}</ShopifyProvider>
-  );
-}

--- a/packages/playground/server-components/src/pages/config/[handle].server.jsx
+++ b/packages/playground/server-components/src/pages/config/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {ShopifyProvider, useShop} from '@shopify/hydrogen';
-import ClientConfig from '../../components/Config.client';
 
 export default function Config({params}) {
   const {handle} = params;
@@ -10,9 +9,7 @@ export default function Config({params}) {
   };
   return (
     <ShopifyProvider shopifyConfig={config}>
-      <ClientConfig shopifyConfig={config}>
-        <ReadConfig />
-      </ClientConfig>
+      <ReadConfig />
     </ShopifyProvider>
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I've been thinking more about ShopifyProvider and it looks like we can't avoid adding it back if we want to support use cases like LinkPop's. However, we can simplify things a bit by requiring ShopifyProvider only in a server component.

I'm basically playing with the idea of having isomorphic hooks (context consumers such as "useShop") that can run in both browser and server **without leaking server-only logic**. This can be done thanks to Vite's `import.meta.env.SSR`, which triggers tree-shaking at build time. With this, we can basically build **isomorphic context providers** that use our custom server-only context in the server (server component), and delegates the hydration to a normal React provider (client component) with its value serialized as props.


With these changes in this PR, `<ShopifyProvider>` becomes a **server component** that renders a client component. The latter has `shopifyConfig` serialized as props (from RSC) and simply passes it to a normal React context provider.
Later, `useShop` will know how to consume this context depending on the running environment (server/browser).

What do you think? Is this absurd? Or perhaps we can use it in more places? -- I'm using something similar in #596 as well.
This could be abstracted in a `createIsomorphicContext` tool or something like that 🤔 

Note: I'd recommend checking these changes commit by commit.

@blittle I think this is somewhat similar to what we talked back in December but a bit more shaped up :)

cc  @jplhomer @vlucas  

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
