### PR TITLE
fix: Always pass in a MoneyV2 to useMoney, and then compare amount

### DIFF
--- a/examples/template-hydrogen-default/src/components/ProductDetails.client.jsx
+++ b/examples/template-hydrogen-default/src/components/ProductDetails.client.jsx
@@ -18,14 +18,16 @@ function ProductPriceMarkup() {
   const product = useProduct();
   const variantPrice = useMoney(product.selectedVariant.priceV2);
   const variantCompareAtPrice = useMoney(
-    product.selectedVariant.compareAtPriceV2,
+    product.selectedVariant.compareAtPriceV2 ?? product.selectedVariant.priceV2,
   );
   return (
     <div className="flex md:flex-col items-end font-semibold text-lg md:items-start md:mb-4">
-      <span className="text-gray-500 line-through text-lg mr-2.5">
-        {variantCompareAtPrice.currencyNarrowSymbol}
-        {variantCompareAtPrice.amount}
-      </span>
+      {variantPrice.amount !== variantCompareAtPrice.amount && (
+        <span className="text-gray-500 line-through text-lg mr-2.5">
+          {variantCompareAtPrice.currencyNarrowSymbol}
+          {variantCompareAtPrice.amount}
+        </span>
+      )}
       <span className="text-gray-900">
         {variantPrice.currencyCode} {variantPrice.currencyNarrowSymbol}
         {variantPrice.amount}

--- a/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
@@ -1,7 +1,7 @@
 import React, {ReactNode, useMemo} from 'react';
 import {useProductOptions, useParsedMetafields} from '../../hooks';
 import {flattenConnection} from '../../utilities';
-import {ProductContext} from './context';
+import {ProductContext, ProductContextType} from './context';
 import {Product} from './types';
 import {ProductProviderFragment as Fragment} from '../../graphql/graphql-constants';
 
@@ -42,7 +42,7 @@ export function ProductProvider({
   });
   const metafields = useParsedMetafields(product.metafields);
 
-  const providerValue = useMemo(() => {
+  const providerValue = useMemo<ProductContextType>(() => {
     return {
       ...product,
       metafields,

--- a/packages/hydrogen/src/hooks/useMoney/hooks.tsx
+++ b/packages/hydrogen/src/hooks/useMoney/hooks.tsx
@@ -73,7 +73,7 @@ export function useMoney(money: MoneyV2): UseMoneyValue {
     currencyDisplay: 'narrowSymbol',
   }).formatToParts(amount);
 
-  const moneyValue = useMemo(
+  const moneyValue = useMemo<UseMoneyValue>(
     () => ({
       currencyCode: money.currencyCode,
       currencyName:


### PR DESCRIPTION
To determine if they need to render.

<!-- Thank you for contributing! -->

### Description

Fixes the issue raised by @wizardlyhel in [this comment](https://github.com/Shopify/hydrogen/pull/595#issuecomment-1029481066)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
