### PR TITLE
fix: bootstrap client entrypoint scripts as defined in index.html

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -40,6 +40,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Fix: add charset to content type in HTML responses
 - Feat: Simplify Helmet usage and make it compatible with RSC
 - The `Seo.client` component has been moved from `src/components` to `@shopify/hydrogen`. The props of the `Seo.client` component also changed to always take in `type` and `data`. Refer to the [`Seo` component reference] (../src/components/Seo/README.md) for more details. [#539](https://github.com/Shopify/hydrogen/pull/539)
+- Fix: Ensure the client entrypoint script path referenced in `index.html` is used to render the app (defaults to `entry-client.jsx`)
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -30,6 +30,7 @@ import {renderToReadableStream as rscRenderToReadableStream} from '@shopify/hydr
 // @ts-ignore
 import {createFromReadableStream} from '@shopify/hydrogen/vendor/react-server-dom-vite';
 import type {RealHelmetData} from './foundation/Helmet/Helmet';
+import {getScriptsFromTemplate} from './utilities/template';
 
 declare global {
   // This is provided by a Vite plugin
@@ -145,6 +146,9 @@ const renderHydrogen: ServerHandler = (App, {pages}) => {
       pages,
     });
 
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
     const [rscReadableForFizz, rscReadableForFlight] = (
       rscRenderToReadableStream(<ReactAppRSC />) as ReadableStream<Uint8Array>
     ).tee();
@@ -193,6 +197,8 @@ const renderHydrogen: ServerHandler = (App, {pages}) => {
 
       const ssrReadable: ReadableStream = renderToReadableStream(ReactAppSSR, {
         nonce,
+        bootstrapScripts,
+        bootstrapModules,
         onCompleteShell() {
           log.trace('worker ready to stream');
 
@@ -317,6 +323,8 @@ const renderHydrogen: ServerHandler = (App, {pages}) => {
 
       const {pipe} = renderToPipeableStream(ReactAppSSR, {
         nonce,
+        bootstrapScripts,
+        bootstrapModules,
         onCompleteShell() {
           log.trace('node ready to stream');
           /**

--- a/packages/hydrogen/src/framework/Hydration/Html.tsx
+++ b/packages/hydrogen/src/framework/Hydration/Html.tsx
@@ -16,11 +16,6 @@ export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
       <head dangerouslySetInnerHTML={{__html: head}} />
       <body {...bodyAttrs}>
         <div id="root">{children}</div>
-        {/* In production, Vite bundles the entrypoint JS inside <head> */}
-        {/* @ts-ignore because module=commonjs doesn't allow this */}
-        {import.meta.env.DEV && (
-          <script type="module" src="/src/entry-client.jsx"></script>
-        )}
       </body>
     </html>
   );

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -1,0 +1,33 @@
+/**
+ * Strip out script `src` values from <script> tags in a given HTML template.
+ * Returns two lists of scripts, split based on whether they are `type="module"`.
+ */
+export function getScriptsFromTemplate(template: string): {
+  bootstrapScripts: string[];
+  bootstrapModules: string[];
+} {
+  const bootstrapScripts = [] as string[];
+  const bootstrapModules = [] as string[];
+
+  const body = template.match(/<body>(.+)<\/body>/s)?.[1];
+
+  if (body) {
+    const scripts = body.matchAll(
+      /<script.+?src="(?<script>([\\/\w-_\.]+?))".*?><\/script>/g
+    );
+
+    for (const match of scripts) {
+      const scriptName = match.groups?.script;
+
+      if (!scriptName) continue;
+
+      if (match[0].includes(`type="module"`)) {
+        bootstrapModules.push(scriptName);
+      } else {
+        bootstrapScripts.push(scriptName);
+      }
+    }
+  }
+
+  return {bootstrapScripts, bootstrapModules};
+}

--- a/packages/hydrogen/src/utilities/tests/template.test.ts
+++ b/packages/hydrogen/src/utilities/tests/template.test.ts
@@ -1,0 +1,43 @@
+import {getScriptsFromTemplate} from '../template';
+
+describe('getScriptsFromTemplate', () => {
+  it('identifies scripts and modules in a template', () => {
+    const template = `<html><body>
+      <script src="/foo.js"></script>
+      <script src="/bar.js"></script>
+      <script src="/module.js" type="module"></script>
+    </body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(2);
+    expect(bootstrapScripts[0]).toBe('/foo.js');
+
+    expect(bootstrapModules).toHaveLength(1);
+    expect(bootstrapModules[0]).toBe('/module.js');
+  });
+
+  it('identifies varying orders of attributes in script tags', () => {
+    const template = `<html><body>
+      <script type="module" src="/src/entry-client.tsx"></script>
+    </body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(0);
+    expect(bootstrapModules).toHaveLength(1);
+    expect(bootstrapModules[0]).toBe('/src/entry-client.tsx');
+  });
+
+  it('does not crash if no script tags', () => {
+    const template = `<html><body></body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(0);
+    expect(bootstrapModules).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We currently hardcode a reference to `entry-client.jsx` in `Html.tsx`. This breaks when users attempt to change the file to be TypeScript.

This PR makes the server entrypoint smarter and leverages React 18's new `bootstrapScripts` and `bootstrapModules` SSR option which injects the script tags early enough so progressive Hydration happens as the response is streamed.

The server entrypoint uses regex to parse the user's template, grabs the `<script>` tags, and parses their contents to determine the values to provide to the React 18 streaming renderer.

Fixes vitejs/vite#427 

**IMPORTANT**: This is currently blocked by a bug in `@vitejs/plugin-react` documented here: https://github.com/vitejs/vite-plugin-react/issues/14

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`)
- [x] Update docs in this repository for your change, if needed
