### PR TITLE
dx [breaking change]: Remove render props (function-as-a-child) pattern from Metafield

### DIFF
--- a/examples/template-hydrogen-default/src/components/ProductDetails.client.jsx
+++ b/examples/template-hydrogen-default/src/components/ProductDetails.client.jsx
@@ -3,6 +3,7 @@ import {
   flattenConnection,
   useProduct,
   useMoney,
+  useParsedMetafields,
 } from '@shopify/hydrogen/client';
 import ProductOptions from './ProductOptions.client';
 import Gallery from './Gallery.client';
@@ -117,6 +118,21 @@ function SizeChart() {
 export default function ProductDetails({product}) {
   const initialVariant = flattenConnection(product.variants)[0];
 
+  const productMetafields = useParsedMetafields(product.metafields);
+  const sizeChartMetafield = productMetafields.find(
+    (metafield) =>
+      metafield.namespace === 'my_fields' && metafield.key === 'size_chart',
+  );
+  const sustainableMetafield = productMetafields.find(
+    (metafield) =>
+      metafield.namespace === 'my_fields' && metafield.key === 'sustainable',
+  );
+  const lifetimeWarrantyMetafield = productMetafields.find(
+    (metafield) =>
+      metafield.namespace === 'my_fields' &&
+      metafield.key === 'lifetime_warranty',
+  );
+
   return (
     <>
       <Product product={product} initialVariantId={initialVariant.id}>
@@ -155,88 +171,69 @@ export default function ProductDetails({product}) {
             {/* Product Options */}
             <div className="mt-8">
               <ProductOptions />
-              <Product.Metafield namespace="my_fields" keyName="size_chart">
-                {({value}) => {
-                  return value ? (
-                    <a
-                      href="#size-chart"
-                      className="block underline text-gray-500 text-sm tracking-wide my-4"
-                    >
-                      Size Chart
-                    </a>
-                  ) : null;
-                }}
-              </Product.Metafield>
+              {sizeChartMetafield?.value && (
+                <a
+                  href="#size-chart"
+                  className="block underline text-gray-500 text-sm tracking-wide my-4"
+                >
+                  Size Chart
+                </a>
+              )}
               <AddToCartMarkup />
               <div className="flex items space-x-4">
-                <Product.Metafield namespace="my_fields" keyName="sustainable">
-                  {({value}) => {
-                    return value ? (
-                      <span className="flex items-center mb-8">
-                        <svg
-                          width="24"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="stroke-current text-blue-600 mr-3"
-                        >
-                          <path
-                            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364-.7071-.7071M6.34315 6.34315l-.70711-.70711m12.72796.00005-.7071.70711M6.3432 17.6569l-.70711.7071M16 12c0 2.2091-1.7909 4-4 4-2.20914 0-4-1.7909-4-4 0-2.20914 1.79086-4 4-4 2.2091 0 4 1.79086 4 4Z"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                        <span className="text-sm text-gray-900 font-medium">
-                          Sustainable Material
-                        </span>
-                      </span>
-                    ) : null;
-                  }}
-                </Product.Metafield>
-                <Product.Metafield
-                  namespace="my_fields"
-                  keyName="lifetime_warranty"
-                >
-                  {({value}) => {
-                    return value ? (
-                      <span className="flex items-center mb-8">
-                        <svg
-                          width="24"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="stroke-current text-blue-600 mr-3"
-                        >
-                          <path
-                            d="M9 12L11 14L15 10M20.6179 5.98434C20.4132 5.99472 20.2072 5.99997 20 5.99997C16.9265 5.99997 14.123 4.84453 11.9999 2.94434C9.87691 4.84446 7.07339 5.99985 4 5.99985C3.79277 5.99985 3.58678 5.9946 3.38213 5.98422C3.1327 6.94783 3 7.95842 3 9.00001C3 14.5915 6.82432 19.2898 12 20.622C17.1757 19.2898 21 14.5915 21 9.00001C21 7.95847 20.8673 6.94791 20.6179 5.98434Z"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                        <span className="text-sm text-gray-900 font-medium">
-                          Lifetime Warranty
-                        </span>
-                      </span>
-                    ) : null;
-                  }}
-                </Product.Metafield>
+                {sustainableMetafield?.value && (
+                  <span className="flex items-center mb-8">
+                    <svg
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="stroke-current text-blue-600 mr-3"
+                    >
+                      <path
+                        d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364-.7071-.7071M6.34315 6.34315l-.70711-.70711m12.72796.00005-.7071.70711M6.3432 17.6569l-.70711.7071M16 12c0 2.2091-1.7909 4-4 4-2.20914 0-4-1.7909-4-4 0-2.20914 1.79086-4 4-4 2.2091 0 4 1.79086 4 4Z"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    <span className="text-sm text-gray-900 font-medium">
+                      Sustainable Material
+                    </span>
+                  </span>
+                )}
+                {lifetimeWarrantyMetafield?.value && (
+                  <span className="flex items-center mb-8">
+                    <svg
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="stroke-current text-blue-600 mr-3"
+                    >
+                      <path
+                        d="M9 12L11 14L15 10M20.6179 5.98434C20.4132 5.99472 20.2072 5.99997 20 5.99997C16.9265 5.99997 14.123 4.84453 11.9999 2.94434C9.87691 4.84446 7.07339 5.99985 4 5.99985C3.79277 5.99985 3.58678 5.9946 3.38213 5.98422C3.1327 6.94783 3 7.95842 3 9.00001C3 14.5915 6.82432 19.2898 12 20.622C17.1757 19.2898 21 14.5915 21 9.00001C21 7.95847 20.8673 6.94791 20.6179 5.98434Z"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    <span className="text-sm text-gray-900 font-medium">
+                      Lifetime Warranty
+                    </span>
+                  </span>
+                )}
               </div>
             </div>
             {/* Product Description */}
             <Product.Description className="prose border-t border-gray-200 pt-6 text-black text-md" />
-            <Product.Metafield namespace="my_fields" keyName="size_chart">
-              {({value}) => {
-                return value ? (
-                  <div className="border-t border-gray-200">
-                    <SizeChart />
-                  </div>
-                ) : null;
-              }}
-            </Product.Metafield>
+            {sizeChartMetafield?.value && (
+              <div className="border-t border-gray-200">
+                <SizeChart />
+              </div>
+            )}
           </div>
         </div>
       </Product>

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -31,11 +31,14 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `useCartLinesUpdateCallback`
   - `useCartNoteUpdateCallback`
 - Feat: Transition away from deprecated currency selector in favor of country selector
-- dx: The following money components no longer allow the function-as-a-child (also known as "render props") pattern; see #589. For customization, use the `useMoney()` hook.
-  - `<Money>`
-  - `<CartLinePrice>`
-  - `<ProductPrice>`
-  - `<SelectedVariantPrice>`
+- dx: The following money components no longer allow the function-as-a-child (also known as "render props") pattern; see #589.
+  - `<Money>` Use `useMoney()` for customization
+  - `<CartLinePrice>` Use `useMoney()` for customization
+  - `<ProductPrice>` Use `useMoney()` for customization
+  - `<SelectedVariantPrice>` Use `useMoney()` for customization
+  - `<Metafield>` Use `useParsedMetafields()` for customization
+  - `<ProductMetafield>` Use `useParsedMetafields()` for customization
+  - `<SelectedVariantMetafield>` Use `useParsedMetafields()` for customization
 - refactor: `<Metafield>` now renders `ratings` as a `<span>` with text instead of stars; `multi_line_text_field` inside of a `<span>` instead of a `<div>`
 - Fix: add charset to content type in HTML responses
 - Fix header shift when cart is opened by @Francismori7 in #600

--- a/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
+++ b/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
@@ -1,4 +1,4 @@
-import React, {ElementType, ReactElement} from 'react';
+import React, {ElementType} from 'react';
 import {Props} from '../types';
 import {useShop} from '../../foundation';
 import {getMeasurementAsString} from '../../utilities';
@@ -11,8 +11,6 @@ import {MediaImage} from '../../types';
 export interface MetafieldProps {
   /** A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API. */
   metafield: ParsedMetafield;
-  /** A render function that takes a `Metafield` object as an argument. Refer to [Render props](#render-props). */
-  children?: (value: ParsedMetafield) => ReactElement;
   /** An HTML tag to be rendered as the base element wrapper. The default value varies depending on [`metafield.type`](/apps/metafields/definitions/types). */
   as?: ElementType;
 }
@@ -21,11 +19,7 @@ export interface MetafieldProps {
  * The `Metafield` component renders the value of a Storefront
  * API's [Metafield object](/api/storefront/reference/common-objects/metafield).
  *
- * When a render function is provided, it passes the Metafield object with a value
- * that was parsed according to the Metafield's `type` field. For more information,
- * refer to the [Render props](#render-props) section.
-
- * When no render function is provided, it renders a smart default of the
+ * Renders a smart default of the
  * Metafield's `value`. For more information, refer to the [Default Output](#default-output) section.
  */
 export function Metafield<TTag extends ElementType>(
@@ -37,10 +31,6 @@ export function Metafield<TTag extends ElementType>(
   if (metafield.value == null) {
     console.warn(`No metafield value for ${metafield}`);
     return null;
-  }
-
-  if (typeof children === 'function') {
-    return children(metafield);
   }
 
   switch (metafield.type) {

--- a/packages/hydrogen/src/components/Metafield/README.md
+++ b/packages/hydrogen/src/components/Metafield/README.md
@@ -3,11 +3,7 @@
 The `Metafield` component renders the value of a Storefront
 API's [Metafield object](/api/storefront/reference/common-objects/metafield).
 
-When a render function is provided, it passes the Metafield object with a value
-that was parsed according to the Metafield's `type` field. For more information,
-refer to the [Render props](#render-props) section.
-
-When no render function is provided, it renders a smart default of the
+Renders a smart default of the
 Metafield's `value`. For more information, refer to the [Default Output](#default-output) section.
 
 ## Example code
@@ -20,31 +16,14 @@ export function Product({product}) {
 
   return <Metafield metafield={metafield} />;
 }
-
-export function ProductWithRenderProp({product}) {
-  const metafield = product.metafields.edges.map(({node}) => node)[0];
-
-  return (
-    <Metafield metafield={metafield}>
-      {(metafield) => {
-        return (
-          <p>
-            {metafield.namespace} {metafield.key}: {metafield.value}
-          </p>
-        );
-      }}
-    </Metafield>
-  );
-}
 ```
 
 ## Props
 
-| Name      | Type                                                  | Description                                                                                                                                           |
-| --------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| metafield | <code>ParsedMetafield</code>                          | A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API.                                                     |
-| children? | <code>(value: ParsedMetafield) => ReactElement</code> | A render function that takes a `Metafield` object as an argument. Refer to [Render props](#render-props).                                             |
-| as?       | <code>ElementType</code>                              | An HTML tag to be rendered as the base element wrapper. The default value varies depending on [`metafield.type`](/apps/metafields/definitions/types). |
+| Name      | Type                         | Description                                                                                                                                           |
+| --------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| metafield | <code>ParsedMetafield</code> | A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API.                                                     |
+| as?       | <code>ElementType</code>     | An HTML tag to be rendered as the base element wrapper. The default value varies depending on [`metafield.type`](/apps/metafields/definitions/types). |
 
 ## Default output
 

--- a/packages/hydrogen/src/components/Metafield/examples/metafield.example.tsx
+++ b/packages/hydrogen/src/components/Metafield/examples/metafield.example.tsx
@@ -5,19 +5,3 @@ export function Product({product}) {
 
   return <Metafield metafield={metafield} />;
 }
-
-export function ProductWithRenderProp({product}) {
-  const metafield = product.metafields.edges.map(({node}) => node)[0];
-
-  return (
-    <Metafield metafield={metafield}>
-      {(metafield) => {
-        return (
-          <p>
-            {metafield.namespace} {metafield.key}: {metafield.value}
-          </p>
-        );
-      }}
-    </Metafield>
-  );
-}

--- a/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
@@ -61,40 +61,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'date'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'date'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The date is {(value as Date).toLocaleDateString()}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [
-          `The date is `,
-          (metafield.value as Date).toLocaleDateString(),
-        ],
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -138,37 +104,6 @@ describe('<Metafield />', () => {
 
       expect(component).toContainReactComponent('p', {
         children: (metafield.value as Date).toLocaleString(),
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'date_time'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'date_time'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The date is {(value as Date).toLocaleString()}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The date is `, (metafield.value as Date).toLocaleString()],
       });
     });
 
@@ -224,36 +159,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'weight'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const component = mountWithProviders(
-        <Metafield metafield={getParsedMetafield({type: 'weight'})}>
-          {() => {
-            return <p>The weight is 10 lbs</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: `The weight is 10 lbs`,
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -303,36 +208,6 @@ describe('<Metafield />', () => {
 
       expect(component).toContainReactComponent('p', {
         children: '10 L',
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'volume'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const component = mountWithProviders(
-        <Metafield metafield={getParsedMetafield({type: 'volume'})}>
-          {() => {
-            return <p>The volume is 10 l</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: `The volume is 10 l`,
       });
     });
 
@@ -388,36 +263,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'dimension'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const component = mountWithProviders(
-        <Metafield metafield={getParsedMetafield({type: 'dimension'})}>
-          {() => {
-            return <p>The length is 5 cm</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: `The length is 5 cm`,
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -451,38 +296,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'single_line_text_field'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const component = mountWithProviders(
-        <Metafield
-          metafield={getParsedMetafield({type: 'single_line_text_field'})}
-        >
-          {() => {
-            return <p>Hello world</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: `Hello world`,
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -500,38 +313,6 @@ describe('<Metafield />', () => {
 
   describe('with `multi_line_text_field` type metafield', () => {
     it.todo('renders the text in a `RawHtml` by default');
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'multi_line_text_field'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const component = mountWithProviders(
-        <Metafield
-          metafield={getParsedMetafield({type: 'multi_line_text_field'})}
-        >
-          {() => {
-            return <p>Hello world</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: `Hello world`,
-      });
-    });
 
     it('allows passthrough props', () => {
       const component = mountWithProviders(
@@ -559,36 +340,6 @@ describe('<Metafield />', () => {
       expect(component).toContainReactComponent('a', {
         children: metafield.value,
         href: metafield.value as string,
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return <p>Hello world</p>;
-      });
-      const metafield = getParsedMetafield({type: 'url'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const component = mountWithProviders(
-        <Metafield metafield={getParsedMetafield({type: 'url'})}>
-          {() => {
-            return <p>Hello world</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: `Hello world`,
       });
     });
 
@@ -626,37 +377,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'json'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'json'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The value is {JSON.stringify(value)}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The value is `, JSON.stringify(metafield.value)],
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -688,37 +408,6 @@ describe('<Metafield />', () => {
 
       expect(component).toContainReactComponent('p', {
         children: metafield.value,
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'color'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'color'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The color is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The color is `, metafield.value],
       });
     });
 
@@ -756,37 +445,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'product_reference'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'product_reference'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The reference is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The reference is `, metafield.value],
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -821,37 +479,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'page_reference'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'page_reference'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The reference is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The reference is `, metafield.value],
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -883,37 +510,6 @@ describe('<Metafield />', () => {
 
       expect(component).toContainReactComponent('p', {
         children: metafield.value,
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'variant_reference'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'variant_reference'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The reference is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The reference is `, metafield.value],
       });
     });
 
@@ -982,37 +578,6 @@ describe('<Metafield />', () => {
         });
       });
 
-      it('passes the metafield as a render prop to the children render function', () => {
-        const children = jest.fn().mockImplementation(() => {
-          return null;
-        });
-        const metafield = getParsedMetafield({type: 'file_reference'});
-
-        mountWithProviders(
-          <Metafield metafield={metafield}>{children}</Metafield>
-        );
-
-        expect(children).toHaveBeenCalledWith({
-          ...metafield,
-          value: metafield.value,
-        });
-      });
-
-      it('renders its children', () => {
-        const metafield = getParsedMetafield({type: 'file_reference'});
-        const component = mountWithProviders(
-          <Metafield metafield={metafield}>
-            {({value}) => {
-              return <p>The reference is {value}</p>;
-            }}
-          </Metafield>
-        );
-
-        expect(component).toContainReactComponent('p', {
-          children: [`The reference is `, metafield.value],
-        });
-      });
-
       it('allows passthrough props', () => {
         const component = mountWithProviders(
           <Metafield
@@ -1045,37 +610,6 @@ describe('<Metafield />', () => {
 
       expect(component).toContainReactComponent('p', {
         children: (metafield.value as boolean).toString(),
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'boolean'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'boolean'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The value is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The value is `, metafield.value],
       });
     });
 
@@ -1113,37 +647,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'number_integer'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'number_integer'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The int is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The int is `, metafield.value],
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -1178,37 +681,6 @@ describe('<Metafield />', () => {
       });
     });
 
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'number_decimal'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'number_decimal'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The number is {value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The number is `, metafield.value],
-      });
-    });
-
     it('allows passthrough props', () => {
       const component = mountWithProviders(
         <Metafield
@@ -1229,37 +701,6 @@ describe('<Metafield />', () => {
 
       expect(component).toContainReactComponent('span', {
         children: (metafield.value as Rating).value,
-      });
-    });
-
-    it('passes the metafield as a render prop to the children render function', () => {
-      const children = jest.fn().mockImplementation(() => {
-        return null;
-      });
-      const metafield = getParsedMetafield({type: 'rating'});
-
-      mountWithProviders(
-        <Metafield metafield={metafield}>{children}</Metafield>
-      );
-
-      expect(children).toHaveBeenCalledWith({
-        ...metafield,
-        value: metafield.value,
-      });
-    });
-
-    it('renders its children', () => {
-      const metafield = getParsedMetafield({type: 'rating'});
-      const component = mountWithProviders(
-        <Metafield metafield={metafield}>
-          {({value}) => {
-            return <p>The rating is {(value as any)!.value}</p>;
-          }}
-        </Metafield>
-      );
-
-      expect(component).toContainReactComponent('p', {
-        children: [`The rating is `, (metafield.value as any).value],
       });
     });
 

--- a/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
+++ b/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
@@ -1,9 +1,11 @@
-import React, {ElementType, ReactNode} from 'react';
+import React, {ElementType} from 'react';
 import {Metafield} from '../Metafield';
 import {useProduct} from '../../hooks/useProduct/useProduct';
 import {Props} from '../types';
+import {MetafieldProps} from '../Metafield/Metafield.client';
 
-export interface ProductMetafieldProps {
+export interface ProductMetafieldProps
+  extends Omit<MetafieldProps, 'metafield'> {
   /** A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the product's
    * metafield.
    */
@@ -12,8 +14,6 @@ export interface ProductMetafieldProps {
    * product's metafield.
    */
   namespace: string;
-  /** A render function that takes a `Metafield` object as its argument. */
-  children?: ReactNode;
 }
 
 /**
@@ -42,5 +42,12 @@ export function ProductMetafield<TTag extends ElementType>(
       metafield.namespace === namespace && metafield.key === keyName
   );
 
-  return field ? <Metafield metafield={field} {...passthroughProps} /> : null;
+  if (field === null || field === undefined) {
+    console.warn(
+      `Product does not have a value for metafield. ProductID:${product.id} namespace:${namespace} keyName:${keyName}`
+    );
+    return null;
+  }
+
+  return <Metafield metafield={field} {...passthroughProps} />;
 }

--- a/packages/hydrogen/src/components/ProductMetafield/README.md
+++ b/packages/hydrogen/src/components/ProductMetafield/README.md
@@ -16,29 +16,14 @@ export function Product({product}) {
     </ProductProvider>
   );
 }
-
-export function ProductWithRenderProp({product}) {
-  return (
-    <ProductProvider product={product}>
-      <ProductMetafield namespace="my_fields" keyName="manufacture_date">
-        {({value}) => {
-          return (
-            <p>This product was manufactured on {value.toLocaleDateString()}</p>
-          );
-        }}
-      </ProductMetafield>
-    </ProductProvider>
-  );
-}
 ```
 
 ## Props
 
-| Name      | Type                   | Description                                                                                                               |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| keyName   | <code>string</code>    | A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the product's metafield.       |
-| namespace | <code>string</code>    | A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the product's metafield. |
-| children? | <code>ReactNode</code> | A render function that takes a `Metafield` object as its argument.                                                        |
+| Name      | Type                | Description                                                                                                               |
+| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| keyName   | <code>string</code> | A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the product's metafield.       |
+| namespace | <code>string</code> | A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the product's metafield. |
 
 ## Component type
 

--- a/packages/hydrogen/src/components/ProductMetafield/examples/product-metafield.example.tsx
+++ b/packages/hydrogen/src/components/ProductMetafield/examples/product-metafield.example.tsx
@@ -7,17 +7,3 @@ export function Product({product}) {
     </ProductProvider>
   );
 }
-
-export function ProductWithRenderProp({product}) {
-  return (
-    <ProductProvider product={product}>
-      <ProductMetafield namespace="my_fields" keyName="manufacture_date">
-        {({value}) => {
-          return (
-            <p>This product was manufactured on {value.toLocaleDateString()}</p>
-          );
-        }}
-      </ProductMetafield>
-    </ProductProvider>
-  );
-}

--- a/packages/hydrogen/src/components/SelectedVariantMetafield/README.md
+++ b/packages/hydrogen/src/components/SelectedVariantMetafield/README.md
@@ -19,32 +19,14 @@ export function Product({product}) {
     </ProductProvider>
   );
 }
-
-export function ProductWithRenderProp({product}) {
-  return (
-    <ProductProvider product={product}>
-      <SelectedVariantMetafield
-        namespace="my_fields"
-        keyName="manufacture_date"
-      >
-        {({value}) => {
-          return (
-            <p>This variant was manufactured on {value.toLocaleDateString()}</p>
-          );
-        }}
-      </SelectedVariantMetafield>
-    </ProductProvider>
-  );
-}
 ```
 
 ## Props
 
-| Name      | Type                   | Description                                                                                                                        |
-| --------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| keyName   | <code>string</code>    | A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the selected variant's metafield.       |
-| namespace | <code>string</code>    | A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the selected variant's metafield. |
-| children? | <code>ReactNode</code> | A render function that takes a `Metafield` object as its argument.                                                                 |
+| Name      | Type                | Description                                                                                                                        |
+| --------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| keyName   | <code>string</code> | A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the selected variant's metafield.       |
+| namespace | <code>string</code> | A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the selected variant's metafield. |
 
 ## Component type
 

--- a/packages/hydrogen/src/components/SelectedVariantMetafield/SelectedVariantMetafield.client.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantMetafield/SelectedVariantMetafield.client.tsx
@@ -1,15 +1,15 @@
-import React, {ElementType, ReactNode} from 'react';
+import React, {ElementType} from 'react';
 import {Props} from '../types';
 import {useProduct} from '../../hooks/useProduct/useProduct';
 import {Metafield} from '../Metafield';
+import {MetafieldProps} from '../Metafield/Metafield.client';
 
-export interface SelectedVariantMetafieldProps {
+export interface SelectedVariantMetafieldProps
+  extends Omit<MetafieldProps, 'metafield'> {
   /** A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the selected variant's metafield. */
   keyName: string;
   /** A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the selected variant's metafield. */
   namespace: string;
-  /** A render function that takes a `Metafield` object as its argument. */
-  children?: ReactNode;
 }
 
 /**
@@ -34,7 +34,13 @@ export function SelectedVariantMetafield<TTag extends ElementType>(
     }
   )?.node;
 
-  return metafield ? (
-    <Metafield metafield={metafield} {...passthroughProps} />
-  ) : null;
+  if (metafield === null || metafield === undefined) {
+    console.warn(
+      `Product does not have a value for metafield. ProductID:${product.id} namespace:${namespace} keyName:${keyName}`
+    );
+
+    return null;
+  }
+
+  return <Metafield metafield={metafield} {...passthroughProps} />;
 }

--- a/packages/hydrogen/src/components/SelectedVariantMetafield/examples/selected-variant-metafield.example.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantMetafield/examples/selected-variant-metafield.example.tsx
@@ -10,20 +10,3 @@ export function Product({product}) {
     </ProductProvider>
   );
 }
-
-export function ProductWithRenderProp({product}) {
-  return (
-    <ProductProvider product={product}>
-      <SelectedVariantMetafield
-        namespace="my_fields"
-        keyName="manufacture_date"
-      >
-        {({value}) => {
-          return (
-            <p>This variant was manufactured on {value.toLocaleDateString()}</p>
-          );
-        }}
-      </SelectedVariantMetafield>
-    </ProductProvider>
-  );
-}


### PR DESCRIPTION
BREAKING CHANGE: The following components no longer allow render props / function-as-a-child pattern:

- Metafield
- ProductMetafield
- SelectedVariantMetafield

See #589

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
