### PR TITLE
feat: use RSC when rendering for bots

### DIFF
--- a/packages/hydrogen/src/streaming.server.ts
+++ b/packages/hydrogen/src/streaming.server.ts
@@ -1,0 +1,31 @@
+import {
+  // @ts-ignore
+  renderToPipeableStream as _ssrRenderToPipeableStream, // Only available in Node context
+  // @ts-ignore
+  renderToReadableStream as _ssrRenderToReadableStream, // Only available in Browser/Worker context
+} from 'react-dom/server';
+// @ts-ignore
+import {renderToReadableStream as _rscRenderToReadableStream} from '@shopify/hydrogen/vendor/react-server-dom-vite/writer.browser.server';
+// @ts-ignore
+import {createFromReadableStream as _createFromReadableStream} from '@shopify/hydrogen/vendor/react-server-dom-vite';
+
+export const rscRenderToReadableStream = _rscRenderToReadableStream as (
+  App: JSX.Element
+) => ReadableStream<Uint8Array>;
+
+export const createFromReadableStream = _createFromReadableStream as (
+  rs: ReadableStream<Uint8Array>
+) => {
+  readRoot: () => JSX.Element;
+};
+
+export const ssrRenderToPipeableStream = _ssrRenderToPipeableStream;
+export const ssrRenderToReadableStream = _ssrRenderToReadableStream as (
+  App: JSX.Element,
+  options: {
+    nonce?: string;
+    onCompleteShell?: () => void;
+    onCompleteAll?: () => void;
+    onError?: (error: Error) => void;
+  }
+) => ReadableStream<Uint8Array>;

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -231,7 +231,7 @@ export default async function testCases({getServerUrl}: TestOptions) {
 
     const body = streamedChunks.join('');
     expect(body).toContain('var __flight=[];');
-    expect(body).not.toContain('__flight.push(`S1:"react.suspense"'); // We're not including RSC
+    expect(body).toContain('__flight.push(`S1:"react.suspense"');
     expect(body).toContain('<div c="5">');
     expect(body).toContain('>footer!<');
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This requires #618 to be merged first.

Now that Helmet is compatible with RSC, this changes how `render` works to call and consume RSC, then SSR. It also includes the RSC response embedded in the HTML for bots to avoid waterfall request.

I've also extracted all the React streaming functions in a different file to give it types (React only has Flow :/).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
