### PR TITLE
feat: Configure src/ directory via Vite middleware config

### DIFF
--- a/packages/hydrogen/src/framework/Hydration/Html.tsx
+++ b/packages/hydrogen/src/framework/Hydration/Html.tsx
@@ -11,7 +11,7 @@ type HtmlOptions = {
 export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
   const head = template.match(/<head>(.+?)<\/head>/s)![1] || '';
 
-  // TODO: find a way to reference vite config or shopify config, use to set the script src dir
+  // TODO: find a way to reference vite config or shopify config, use to set the script src dir in line 23
   return (
     <html {...htmlAttrs}>
       <head dangerouslySetInnerHTML={{__html: head}} />

--- a/packages/hydrogen/src/framework/Hydration/Html.tsx
+++ b/packages/hydrogen/src/framework/Hydration/Html.tsx
@@ -11,6 +11,7 @@ type HtmlOptions = {
 export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
   const head = template.match(/<head>(.+?)<\/head>/s)![1] || '';
 
+  // TODO: find a way to reference vite config or shopify config, use to set the script src dir
   return (
     <html {...htmlAttrs}>
       <head dangerouslySetInnerHTML={{__html: head}} />

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -46,7 +46,7 @@ export default (
             shopifyConfig,
             indexTemplate: getIndexTemplate,
             getServerEntrypoint: async () =>
-              await server.ssrLoadModule(`${pluginOptions.srcDirectory || '/src'}/entry-server`),
+              await server.ssrLoadModule(`${pluginOptions.srcDir || '/src'}/entry-server`),
             devServer: server,
             cache: pluginOptions?.devCache
               ? (new InMemoryCache() as unknown as Cache)

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -8,7 +8,7 @@ import {InMemoryCache} from '../cache/in-memory';
 
 export default (
   shopifyConfig: ShopifyConfig,
-  pluginOptions: HydrogenVitePluginOptions
+  pluginOptions: HydrogenVitePluginOptions = {}
 ) => {
   return {
     name: 'vite-plugin-hydrogen-middleware',
@@ -46,7 +46,7 @@ export default (
             shopifyConfig,
             indexTemplate: getIndexTemplate,
             getServerEntrypoint: async () =>
-              await server.ssrLoadModule('/src/entry-server'),
+              await server.ssrLoadModule(`${pluginOptions.srcDirectory || '/src'}/entry-server`),
             devServer: server,
             cache: pluginOptions?.devCache
               ? (new InMemoryCache() as unknown as Cache)

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -139,5 +139,5 @@ export interface CacheOptions {
 export interface HydrogenVitePluginOptions {
   devCache?: boolean;
   purgeQueryCacheOnBuild?: boolean;
-  srcDirectory?: string;
+  srcDir?: string;
 }

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -139,4 +139,5 @@ export interface CacheOptions {
 export interface HydrogenVitePluginOptions {
   devCache?: boolean;
   purgeQueryCacheOnBuild?: boolean;
+  srcDirectory?: string;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Similar to how [Vite configs support `assetDir` and `publicDir` options](https://vitejs.dev/config/#publicdir), we'd like to be able to specify a `srcDir` instead of every project requiring entry files in `./src/`.

### Additional context

This is to support efforts to incrementally adopt hydrogen and support use cases like monorepos. Examples of this include [implementing Hydrogen in the existing brochure2 app](Shopify/brochure2#31358) and an effort to consolidate the linkpop-web and linkpop repos into a [monorepo](https://github.com/Shopify/linkpop/issues/2291).

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes Shopify/website-fe#123`)
- [ ] Update docs in this repository for your change, if needed
