### PR TITLE
Search fix

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -45,6 +45,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Feat: Simplify Helmet usage and make it compatible with RSC
 - The `Seo.client` component has been moved from `src/components` to `@shopify/hydrogen`. The props of the `Seo.client` component also changed to always take in `type` and `data`. Refer to the [`Seo` component reference] (../src/components/Seo/README.md) for more details. [#539](https://github.com/Shopify/hydrogen/pull/539)
 - feat: added `useUrl` hook that allows the consumer to get the current url in server or client component
+- fix: fix bug where search param is not being pass along during RSC streaming call [#623](https://github.com/Shopify/hydrogen/pull/623)
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -414,7 +414,7 @@ const renderHydrogen: ServerHandler = (App, {pages}) => {
    */
   const hydrate: Hydrator = async function (
     url: URL,
-    {request, response, isStreamable, dev}
+    {request, response, isStreamable}
   ) {
     const log = getLoggerFromContext(request);
     const state = JSON.parse(url.searchParams.get('state') || '{}');

--- a/packages/hydrogen/src/foundation/Helmet/Helmet.tsx
+++ b/packages/hydrogen/src/foundation/Helmet/Helmet.tsx
@@ -5,6 +5,7 @@ import {
   HelmetData,
 } from 'react-helmet-async';
 import {useServerRequest} from '../ServerRequestProvider';
+import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
 
 export type RealHelmetData = {context: {helmet: HelmetData}};
 
@@ -15,7 +16,7 @@ export function Helmet({
   ...props
 }: HelmetProps & {children: React.ReactNode}) {
   // @ts-ignore
-  const helmetData = import.meta.env.SSR
+  const helmetData = META_ENV_SSR
     ? useServerRequest().ctx.helmet
     : clientHelmetData;
 

--- a/packages/hydrogen/src/foundation/Router/ServerStateRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/ServerStateRouter.client.tsx
@@ -15,11 +15,14 @@ export function ServerStateRouter() {
   const location = useLocation();
 
   useEffect(() => {
-    if (serverState.pathname !== location.pathname) {
+    if (
+      serverState.pathname !== location.pathname ||
+      serverState.search !== location.search
+    ) {
       setIsNavigating(true);
-      setServerState('pathname', location.pathname);
+      setServerState({pathname: location.pathname, search: location.search});
     }
-  }, [location.pathname, setServerState]);
+  }, [location.pathname, location.search, setServerState]);
 
   useEffect(() => {
     /**

--- a/packages/hydrogen/src/foundation/useShop/use-shop.tsx
+++ b/packages/hydrogen/src/foundation/useShop/use-shop.tsx
@@ -1,10 +1,7 @@
 import {useContext} from 'react';
 import {ShopifyContext} from '../ShopifyProvider';
 import {useServerRequest} from '../ServerRequestProvider';
-// @ts-ignore
 import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
-
-// let contextValue: ShopifyContextValue | null = null;
 
 /**
  * The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.

--- a/packages/hydrogen/src/framework/docs/server-state.md
+++ b/packages/hydrogen/src/framework/docs/server-state.md
@@ -20,7 +20,7 @@ navigator.geolocation.getCurrentPosition((data) => {
 
 ## Managing server state
 
-The most basic example of `state` is the `page` prop, which Hydrogen manages for you whenever your URL location changes. The server state is passed as a prop to page components. However, you can set any state that you want within client components using the [`useServerState`](/api/hydrogen/hooks/global/useserverstate) hook:
+The most basic example of `state` is the `pathname` and `search` prop, which Hydrogen manages for you whenever your URL location changes. The server state is passed as a prop to page components. However, you can set any state that you want within client components using the [`useServerState`](/api/hydrogen/hooks/global/useserverstate) hook:
 
 ```js
 import {useServerState} from '@shopify/hydrogen/client';

--- a/packages/hydrogen/src/framework/docs/work-with-rsc.md
+++ b/packages/hydrogen/src/framework/docs/work-with-rsc.md
@@ -83,19 +83,19 @@ Sharing state information between the client and server is important for common 
 
 ![A diagram that illustrates the workflow for sharing state information between client and server](/assets/custom-storefronts/hydrogen/hydrogen-sharing-state-information.png)
 
-1. `App.server.jsx` relies on the `page` state to choose the correct route to render. To change routes, the client updates the `page` state:
+1. `App.server.jsx` relies on the `pathname` and `search` state to choose the correct route to render. To change routes, the client updates the `page` state:
 
    {% codeblock file, filename: 'ProductDetails.client.jsx' %}
 
    ```js
    useEffect(() => {
-     setServerState('page', location.pathname);
-   }, [location.pathname, setServerState]);
+     setServerState({pathname: location.pathname, search: location.search});
+   }, [location.pathname, location.search, setServerState]);
    ```
 
    {% endcodeblock %}
 
-2. The `page` state is sent to the server. This happens through a `useServerResponse` fetch call. It's a special server endpoint called `/react` which accepts `state` as a query parameter.
+2. The `pathname` and `search` state is sent to the server. This happens through a `useServerResponse` fetch call. It's a special server endpoint called `/react` which accepts `state` as a query parameter.
 3. The `/react` endpoint returns the wire representation for the new state.
 4. The state is partially hydrated (made interactive) and rendered into the DOM, similar to how the initial page was made interactive.
 

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -74,7 +74,7 @@ export const log: Logger = {
 
 const SERVER_RESPONSE_MAP: Record<string, string> = {
   str: 'streaming SSR',
-  rsc: 'server Components',
+  rsc: 'Server Components',
   ssr: 'buffered SSR',
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes the bug where RSC streaming call doesnt pass along the search param to the server, which results in `useServerRequest().url` not returning search query params during RSC streaming call.

The PR also add in some random refactor of things I found in the code base

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
