### PR TITLE
[Hydrogen docs]: Update `useUrl` hook docs

### DIFF
--- a/packages/hydrogen/src/docs/hooks.md
+++ b/packages/hydrogen/src/docs/hooks.md
@@ -27,10 +27,6 @@ Hydrogen provides the following global hooks that you can use to fetch data from
     <td>Use to get current url in server or client component.</td>
   </tr>
   <tr>
-    <td><a href="/api/hydrogen/hooks/global/usequery">useQuery</a></td>
-    <td>A wrapper around <code>useQuery</code> from <code>react-query</code>. It supports Suspense calls on the server and on the client.</td>
-  </tr>
-  <tr>
     <td><a href="/api/hydrogen/hooks/global/useserverstate">useServerState</a></td>
     <td>Manage a server state when using Hydrogen as a React Server Component framework.</td>
   </tr>
@@ -41,6 +37,14 @@ Hydrogen provides the following global hooks that you can use to fetch data from
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useshopquery">useShopQuery</a></td>
     <td>Make server-only GraphQL queries to the <a href="/api/storefront">Storefront API</a>.</td>
+  </tr>
+  <tr>
+    <td><a href="/api/hydrogen/hooks/global/usequery">useQuery</a></td>
+    <td>A wrapper around <code>useQuery</code> from <code>react-query</code>. It supports Suspense calls on the server and on the client.</td>
+  </tr>
+  <tr>
+    <td><a href="/api/hydrogen/hooks/global/useurl">useUrl</a></td>
+    <td>Retrieve the current URL in a server or client component.</td>
   </tr>
 </table>
 

--- a/packages/hydrogen/src/docs/hydrogen-sdk.md
+++ b/packages/hydrogen/src/docs/hydrogen-sdk.md
@@ -92,10 +92,6 @@ The `ShopifyProvider` component relates to the following global hooks that you c
     <td>Use to get current url in server or client component.</td>
   </tr>
   <tr>
-    <td><a href="/api/hydrogen/hooks/global/usequery">useQuery</a></td>
-    <td>A wrapper around <code>useQuery</code> from <code>react-query</code>. It supports Suspense calls on the server and on the client.</td>
-  </tr>
-  <tr>
     <td><a href="/api/hydrogen/hooks/global/useserverstate">useServerState</a></td>
     <td>Manage a server state when using Hydrogen as a React Server Component framework.</td>
   </tr>
@@ -106,6 +102,14 @@ The `ShopifyProvider` component relates to the following global hooks that you c
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useshopquery">useShopQuery</a></td>
     <td>Make server-only GraphQL queries to the <a href="/api/storefront">Storefront API</a>.</td>
+  </tr>
+  <tr>
+    <td><a href="/api/hydrogen/hooks/global/usequery">useQuery</a></td>
+    <td>A wrapper around <code>useQuery</code> from <code>react-query</code>. It supports Suspense calls on the server and on the client.</td>
+  </tr>
+  <tr>
+    <td><a href="/api/hydrogen/hooks/global/useurl">useUrl</a></td>
+    <td>Retrieve the current URL in a server or client component.</td>
   </tr>
 </table>
 

--- a/packages/hydrogen/src/foundation/useQuery/README.md
+++ b/packages/hydrogen/src/foundation/useQuery/README.md
@@ -1,7 +1,7 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/foundation/useQuery and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/main/content/internal/operations/hydrogen-reference-docs.md. -->
 
 The `useQuery` hook is a wrapper around Suspense calls and
-global runtime's Cache if it exist.
+global runtime's Cache if it exists.
 It supports Suspense calls on the server and on the client.
 
 ## Example code

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -15,7 +15,7 @@ export interface HydrogenUseQueryOptions {
 
 /**
  * The `useQuery` hook is a wrapper around Suspense calls and
- * global runtime's Cache if it exist.
+ * global runtime's Cache if it exists.
  * It supports Suspense calls on the server and on the client.
  */
 export function useQuery<T>(

--- a/packages/hydrogen/src/foundation/useUrl/README.md
+++ b/packages/hydrogen/src/foundation/useUrl/README.md
@@ -1,19 +1,17 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/foundation/useUrl and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/main/content/internal/operations/hydrogen-reference-docs.md. -->
 
-Use to get current url in server or client component.
+The `useUrl` hook retrieves the current URL in a server or client component.
 
 ## Example code
 
 ```tsx
 import {useUrl} from '@shopify/hydrogen';
-
 export default function Page() {
   const url = useUrl();
-
   return <h1>Current Url is: {url.href}</h1>;
 }
 ```
 
 ## Return value
 
-The `useUrl` hook returns an [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object with the current url
+The `useUrl` hook returns a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object with the current URL.

--- a/packages/hydrogen/src/foundation/useUrl/docs/1-return-value.md
+++ b/packages/hydrogen/src/foundation/useUrl/docs/1-return-value.md
@@ -1,3 +1,3 @@
 ## Return value
 
-The `useUrl` hook returns an [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object with the current url
+The `useUrl` hook returns a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) object with the current URL.

--- a/packages/hydrogen/src/foundation/useUrl/useUrl.ts
+++ b/packages/hydrogen/src/foundation/useUrl/useUrl.ts
@@ -2,7 +2,7 @@ import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
 import {useServerRequest} from '../ServerRequestProvider';
 
 /**
- * Use to get current url in server or client component.
+ * The `useUrl` hook retrieves the current URL in a server or client component.
  */
 export function useUrl(): URL {
   if (META_ENV_SSR) {

--- a/packages/hydrogen/src/framework/docs/css-support.md
+++ b/packages/hydrogen/src/framework/docs/css-support.md
@@ -69,7 +69,7 @@ If you don't want to build with Tailwind's library and instead want to write you
    yarn dev
    ```
 
-   ```bash?filename: 'Terminal', title: 'npm or npx'
+   ```bash?filename: 'Terminal', title: 'npm'
    // Switch to your app's directory
    cd <directory>
 

--- a/packages/hydrogen/src/framework/docs/third-party-dependencies.md
+++ b/packages/hydrogen/src/framework/docs/third-party-dependencies.md
@@ -10,7 +10,7 @@ To install third party dependencies, run the following command:
 yarn add <dependency>
 ```
 
-```bash?filename: 'Terminal', title: 'npm or npx'
+```bash?filename: 'Terminal', title: 'npm'
 npm install <dependency>
 ```
 


### PR DESCRIPTION
## This PR: 
- Makes some updates to the `useUrl` hook in the Hydrogen reference docs
- Makes some minor fixes (typos)
- Relates to https://github.com/Shopify/hydrogen/pull/614 and https://github.com/Shopify/hydrogen/pull/614