### PR TITLE
chore: fix Seo component noisy tests

### DIFF
--- a/packages/hydrogen/src/components/Seo/tests/DefaultPageSeo.test.tsx
+++ b/packages/hydrogen/src/components/Seo/tests/DefaultPageSeo.test.tsx
@@ -60,7 +60,7 @@ describe('<DefaultPageSeo />', () => {
     jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {
       const [firstArgument] = args;
 
-      // If the first argument is an error, and it doesn't match our regex.
+      // If the first argument is an error, and it matches our regex.
       if (
         typeof firstArgument === 'string' &&
         ERROR_TO_IGNORE.test(firstArgument)

--- a/packages/hydrogen/src/components/Seo/tests/DefaultPageSeo.test.tsx
+++ b/packages/hydrogen/src/components/Seo/tests/DefaultPageSeo.test.tsx
@@ -44,6 +44,36 @@ const defaultProps = {
 };
 
 describe('<DefaultPageSeo />', () => {
+  beforeAll(() => {
+    // TODO: we may want to move this to our global jest setup if we find that
+    // we need to ignore a number of errors across multiple test files.
+
+    // When we mount the Helmet component in our wrapper it is rendered in a <div />.
+    // Nesting an <html /> component inside a <div /> is invalid HTML and React complains
+    // Since it’s only in test, we can safely ignore this error.
+    const ERROR_TO_IGNORE = /Warning: validateDOMNesting(...)/;
+
+    // Cache the original console error so we can pass errors through
+    // by calling it with errors that don't match our regex check.
+    const originalTestConsoleError = console.error.bind(console);
+
+    jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {
+      const [firstArgument] = args;
+
+      // If the first argument is an error, and it doesn't match our regex.
+      if (
+        typeof firstArgument === 'string' &&
+        ERROR_TO_IGNORE.test(firstArgument)
+      ) {
+        // Ignore the error by returning early.
+        return;
+      }
+
+      // Continue to report all other errors
+      originalTestConsoleError(...args);
+    });
+  });
+
   describe('default', () => {
     it("renders <meta /> with property='og:type'", () => {
       const wrapper = mount(<DefaultPageSeo {...defaultProps} />);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Started working on the `hydrogen-ui` and noticed some noisy console errors in the DefaultSeo tests. This PR cleans those up.

For tophatting, see this image:

<img width="1018" alt="Screen Shot 2022-02-08 at 23 41 55" src="https://user-images.githubusercontent.com/462077/153088513-65d9ba89-230b-4ac7-bc16-bc022897811a.png">


### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
