### PR TITLE
fix: avoid leaking useServerRequest logic to browser

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -36,8 +36,3 @@ jest.mock('@shopify/react-testing/build/cjs/compat.js', () => {
     },
   };
 });
-
-// TODO Remove when Jest supports import.meta
-jest.mock('./packages/hydrogen/src/utilities/meta-env-ssr', () => ({
-  META_ENV_SSR: false,
-}));

--- a/packages/hydrogen/src/foundation/Helmet/Helmet.client.tsx
+++ b/packages/hydrogen/src/foundation/Helmet/Helmet.client.tsx
@@ -4,8 +4,7 @@ import {
   Helmet as ActualHelmet,
   HelmetData,
 } from 'react-helmet-async';
-import {useServerRequest} from '../ServerRequestProvider';
-import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
+import {useEnvContext} from '../ssr-interop';
 
 export type RealHelmetData = {context: {helmet: HelmetData}};
 
@@ -15,10 +14,7 @@ export function Helmet({
   children,
   ...props
 }: HelmetProps & {children: React.ReactNode}) {
-  // @ts-ignore
-  const helmetData = META_ENV_SSR
-    ? useServerRequest().ctx.helmet
-    : clientHelmetData;
+  const helmetData = useEnvContext((req) => req.ctx.helmet, clientHelmetData);
 
   return (
     // @ts-ignore

--- a/packages/hydrogen/src/foundation/ssr-interop.ts
+++ b/packages/hydrogen/src/foundation/ssr-interop.ts
@@ -1,0 +1,28 @@
+/**
+ * This file is used for compatibility between browser and server environments.
+ * The browser loads this file as is, without leaking server logic.
+ * In the server, this file is transformed by Vite to inject server logic.
+ * NOTE: Do not remove SSR comments in this file, it's used in Vite plugin
+ */
+
+import {useContext, Context} from 'react';
+import type {ServerComponentRequest} from '../framework/Hydration/ServerComponentRequest.server';
+//@SSR import {useServerRequest} from './ServerRequestProvider';
+
+// This is replaced by Vite to import.meta.env.SSR
+export const META_ENV_SSR = false;
+
+type ServerGetter<T> = (request: ServerComponentRequest) => T;
+
+const reactContextType = Symbol.for('react.context');
+
+export function useEnvContext<T>(
+  serverGetter: ServerGetter<T>,
+  clientPayload?: any
+) {
+  //@SSR if (META_ENV_SSR) return serverGetter(useServerRequest());
+
+  return clientPayload && clientPayload.$$typeof === reactContextType
+    ? useContext(clientPayload as Context<T>)
+    : (clientPayload as T);
+}

--- a/packages/hydrogen/src/foundation/useShop/use-shop.tsx
+++ b/packages/hydrogen/src/foundation/useShop/use-shop.tsx
@@ -1,15 +1,11 @@
-import {useContext} from 'react';
 import {ShopifyContext} from '../ShopifyProvider';
-import {useServerRequest} from '../ServerRequestProvider';
-import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
+import {useEnvContext} from '../ssr-interop';
 
 /**
  * The `useShop` hook provides access to values within `shopify.config.js`. It must be a descendent of a `ShopifyProvider` component.
  */
 export function useShop() {
-  const config = META_ENV_SSR
-    ? useServerRequest().ctx.shopifyConfig
-    : useContext(ShopifyContext);
+  const config = useEnvContext((req) => req.ctx.shopifyConfig, ShopifyContext);
 
   if (!config) {
     throw new Error('No Shopify Context found');

--- a/packages/hydrogen/src/foundation/useUrl/tests/useUrl.test.tsx
+++ b/packages/hydrogen/src/foundation/useUrl/tests/useUrl.test.tsx
@@ -23,17 +23,18 @@ describe('useUrl()', () => {
   });
 
   describe('SSR', () => {
+    let mockUrl = '';
+
     beforeAll(() => {
-      jest.doMock('../../../utilities/meta-env-ssr', () => ({
+      jest.doMock('../../ssr-interop', () => ({
         META_ENV_SSR: true,
+        useEnvContext: () => ({url: mockUrl}),
       }));
     });
 
     it('returns url object using useServerRequest url', () => {
-      const mockUrl =
+      mockUrl =
         'https://hydrogen-preview.myshopify.com/collections/freestyle-collection';
-
-      useServerRequestMock.mockReturnValue({url: mockUrl});
 
       const callbackSpy = jest.fn();
 
@@ -42,10 +43,8 @@ describe('useUrl()', () => {
     });
 
     it('returns url object using a parsed url from state param when the pathname is /react', () => {
-      const mockUrl =
+      mockUrl =
         'https://hydrogen-preview.myshopify.com/react?state=%7B%22pathname%22%3A%22%2Fproducts%2Fmail-it-in-freestyle-snowboard%3Ftest%3D123%26something-else%3Danother';
-
-      useServerRequestMock.mockReturnValue({url: mockUrl});
 
       const callbackSpy = jest.fn();
 
@@ -60,11 +59,6 @@ describe('useUrl()', () => {
 
   describe('non SSR', () => {
     const oldLocation = window.location;
-    beforeAll(() => {
-      jest.doMock('../../../utilities/meta-env-ssr', () => ({
-        META_ENV_SSR: false,
-      }));
-    });
 
     beforeEach(() => {
       Object.defineProperty(window, 'location', {

--- a/packages/hydrogen/src/foundation/useUrl/useUrl.ts
+++ b/packages/hydrogen/src/foundation/useUrl/useUrl.ts
@@ -1,12 +1,11 @@
-import {META_ENV_SSR} from '../../utilities/meta-env-ssr';
-import {useServerRequest} from '../ServerRequestProvider';
+import {useEnvContext, META_ENV_SSR} from '../ssr-interop';
 
 /**
  * The `useUrl` hook retrieves the current URL in a server or client component.
  */
 export function useUrl(): URL {
   if (META_ENV_SSR) {
-    const serverUrl = new URL(useServerRequest().url);
+    const serverUrl = new URL(useEnvContext((req) => req.url));
 
     if (serverUrl.pathname === '/react') {
       const state = JSON.parse(serverUrl.searchParams.get('state') || '{}');

--- a/packages/hydrogen/src/framework/plugin.ts
+++ b/packages/hydrogen/src/framework/plugin.ts
@@ -4,6 +4,7 @@ import type {Plugin} from 'vite';
 import hydrogenMiddleware from './plugins/vite-plugin-hydrogen-middleware';
 // @ts-ignore
 import rsc from '@shopify/hydrogen/vendor/react-server-dom-vite/plugin';
+import ssrInterop from './plugins/vite-plugin-ssr-interop';
 import purgeQueryCache from './plugins/vite-plugin-purge-query-cache';
 import inspect from 'vite-plugin-inspect';
 import react from '@vitejs/plugin-react';
@@ -19,6 +20,7 @@ export default (
     hydrogenConfig(),
     hydrogenMiddleware(shopifyConfig, pluginOptions),
     react(),
+    ssrInterop(),
     rsc({
       clientComponentPaths: [
         path.join(

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-ssr-interop.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-ssr-interop.ts
@@ -1,0 +1,15 @@
+import type {Plugin} from 'vite';
+
+export default () => {
+  return {
+    name: 'vite-plugin-ssr-interop',
+    enforce: 'pre',
+    transform(code, id, options = {}) {
+      if (options.ssr && id.includes('foundation/ssr-interop')) {
+        return code
+          .replace(/(\s*META_ENV_SSR\s*=\s*)false/, '$1import.meta.env.SSR')
+          .replace(/\/\/@SSR\s*/g, '');
+      }
+    },
+  } as Plugin;
+};

--- a/packages/hydrogen/src/utilities/meta-env-ssr.ts
+++ b/packages/hydrogen/src/utilities/meta-env-ssr.ts
@@ -1,3 +1,0 @@
-// This is mocked in Jest
-// @ts-ignore
-export const META_ENV_SSR = import.meta.env.SSR;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For some unknown reason, `import.meta.env.SSR` is not triggering tree-shaking in files that end in `.client.jsx`. Recently, we renamed `Helmet` to be a client component (in #618 ) and this started leaking `useServerRequest` to the browser. It might be a bug in Vite but it's not easy to reproduce.

I've added an "ssr-interop" file that by default contains browser-only logic. When running in the server, Vite will inject server logic for RSC. This fixes the previous issue and also should make it simpler to extract components in `hydrogen-ui`. I think this file should be moved to `hydrogen-ui` and then modified by `hydrogen-framework` to inject server logic. That way, using `hydrogen-ui` with other non-RSC frameworks should work.

We should only import `useServerRequest` in server-only files. If we are in a shared file (like a client component), then the new `useEnvContext` should be the way to go.


---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
