### PR TITLE
Avoid using `any` in some of the mini-oxygen types

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Improves some types, avoid using `any` in `mini-oxygen`
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/cli/src/commands/preview/mini-oxygen/core.ts
+++ b/packages/cli/src/commands/preview/mini-oxygen/core.ts
@@ -1,4 +1,9 @@
-import {CorePlugin, MiniflareCore} from '@miniflare/core';
+import {
+  CorePlugin,
+  CorePluginSignatures,
+  MiniflareCore,
+  MiniflareCoreOptions,
+} from '@miniflare/core';
 import {CachePlugin} from '@miniflare/cache';
 import {VMScriptRunner} from '@miniflare/runner-vm';
 import {Log, LogLevel} from '@miniflare/shared';
@@ -6,8 +11,8 @@ import {Log, LogLevel} from '@miniflare/shared';
 import {createServer} from './server';
 import {StorageFactory} from './storage';
 
-export class MiniOxygen extends MiniflareCore<any> {
-  constructor(options: any) {
+export class MiniOxygen extends MiniflareCore<CorePluginSignatures> {
+  constructor(options: MiniflareCoreOptions<CorePluginSignatures>) {
     const storageFactory = new StorageFactory();
     super(
       PLUGINS,
@@ -23,7 +28,7 @@ export class MiniOxygen extends MiniflareCore<any> {
   }
 
   async dispose() {
-    await super.dispose();
+    return super.dispose();
   }
 
   createServer({assets = []}: {assets?: string[]} = {}) {

--- a/packages/cli/src/commands/preview/mini-oxygen/server.ts
+++ b/packages/cli/src/commands/preview/mini-oxygen/server.ts
@@ -27,14 +27,24 @@ function createAssetMiddleware(assets: string[]): NextHandleFunction {
   };
 }
 
-function createRequestMiddleware(mf: MiniOxygen): any {
-  return async (req: any, res: any) => {
+function createRequestMiddleware(mf: MiniOxygen): NextHandleFunction {
+  return async (req, res) => {
     let response;
     let status = 500;
     let headers = {};
 
+    const reqHeaders: Record<string, string> = {};
+    for (const key in req.headers) {
+      const val = req.headers[key];
+      if (Array.isArray(val)) {
+        reqHeaders[key] = val.join(',');
+      } else if (val !== undefined) {
+        reqHeaders[key] = val;
+      }
+    }
     const request = new Request(urlFromRequest(req), {
-      ...req,
+      method: req.method,
+      headers: reqHeaders,
     });
 
     try {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Makes TypeScript typings more specific and avoids using `any` in mini-oxygen

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
