### PR TITLE
@cartogram/unit price remove caf prop

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -39,6 +39,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `<Metafield>` Use `useParsedMetafields()` for customization
   - `<ProductMetafield>` Use `useParsedMetafields()` for customization
   - `<SelectedVariantMetafield>` Use `useParsedMetafields()` for customization
+  - `<UnitPrice>` Use `useMoney()` for customization
 - refactor: `<Metafield>` now renders `ratings` as a `<span>` with text instead of stars; `multi_line_text_field` inside of a `<span>` instead of a `<div>`
 - Fix: add charset to content type in HTML responses
 - Fix header shift when cart is opened by @Francismori7 in #600

--- a/packages/hydrogen/src/components/UnitPrice/README.md
+++ b/packages/hydrogen/src/components/UnitPrice/README.md
@@ -3,9 +3,6 @@
 The `UnitPrice` component renders a string with a [UnitPrice](/themes/pricing-payments/unit-pricing) as the
 [Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
 
-If `children` is a function, then it will provide render props for the `children` corresponding to the object
-returned by the `useMoney` hook and the `UnitPriceMeasurement` object.
-
 ## Example code
 
 ```tsx
@@ -45,37 +42,15 @@ export default function Product() {
     />
   );
 }
-
-export default function ProductWithCustomUnitPrice() {
-  const {data} = useShopQuery({query: QUERY});
-  const selectedVariant = data.product.variants.edges[0].node;
-
-  return (
-    <UnitPrice
-      unitPrice={selectedVariant.unitPrice}
-      unitPriceMeasurement={selectedVariant.unitPriceMeasurement}
-    >
-      {({amount, currencyCode, currencyNarrowSymbol, referenceUnit}) => {
-        return (
-          <>
-            <span>{`${currencyNarrowSymbol}${amount}/${referenceUnit}`}</span>
-            <span>{currencyCode}</span>
-          </>
-        );
-      }}
-    </UnitPrice>
-  );
-}
 ```
 
 ## Props
 
-| Name                 | Type                              | Description                                                                                      |
-| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------ |
-| unitPrice            | <code>MoneyV2</code>              | A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2).                          |
-| unitPriceMeasurement | <code>UnitPriceMeasurement</code> | A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).      |
-| children?            | <code>ReactNode</code>            | A function that takes an object returned by the `UnitPrice` component and returns a `ReactNode`. |
-| as?                  | <code>ElementType</code>          | An HTML tag to be rendered as the base element wrapper. The default is `div`.                    |
+| Name                 | Type                              | Description                                                                                 |
+| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------- |
+| unitPrice            | <code>MoneyV2</code>              | A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2).                     |
+| unitPriceMeasurement | <code>UnitPriceMeasurement</code> | A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement). |
+| as?                  | <code>ElementType</code>          | An HTML tag to be rendered as the base element wrapper. The default is `div`.               |
 
 ## Component type
 

--- a/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
@@ -1,7 +1,6 @@
-import React, {ElementType, ReactNode} from 'react';
+import React, {ElementType} from 'react';
 import {Props} from '../types';
 import {UnitPriceMeasurement, MoneyV2} from '../../graphql/types/types';
-import {useMoney} from '../../hooks';
 import {Money} from '../Money';
 import {UnitPriceFragment as Fragment} from '../../graphql/graphql-constants';
 
@@ -10,8 +9,6 @@ export interface UnitPriceProps {
   unitPrice: MoneyV2;
   /** A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement). */
   unitPriceMeasurement: UnitPriceMeasurement;
-  /** A function that takes an object returned by the `UnitPrice` component and returns a `ReactNode`. */
-  children?: ReactNode;
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
   as?: ElementType;
 }
@@ -19,31 +16,16 @@ export interface UnitPriceProps {
 /**
  * The `UnitPrice` component renders a string with a [UnitPrice](/themes/pricing-payments/unit-pricing) as the
  * [Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
- *
- * If `children` is a function, then it will provide render props for the `children` corresponding to the object
- * returned by the `useMoney` hook and the `UnitPriceMeasurement` object.
  */
 export function UnitPrice<TTag extends ElementType>(
   props: Props<TTag> & UnitPriceProps
 ) {
-  const {unitPrice, unitPriceMeasurement, children, as, ...passthroughProps} =
-    props;
+  const {unitPrice, unitPriceMeasurement, as, ...passthroughProps} = props;
   const Wrapper: any = as ?? 'div';
-  const unitPriceMoneyObject = useMoney(unitPrice);
-  const unitPriceAndMeasurementObject = {
-    ...unitPriceMoneyObject,
-    ...unitPriceMeasurement,
-  };
 
   return (
     <Wrapper {...passthroughProps}>
-      {typeof children === 'function' ? (
-        children(unitPriceAndMeasurementObject)
-      ) : (
-        <>
-          <Money money={unitPrice} />/{unitPriceMeasurement.referenceUnit}
-        </>
-      )}
+      <Money money={unitPrice} />/{unitPriceMeasurement.referenceUnit}
     </Wrapper>
   );
 }

--- a/packages/hydrogen/src/components/UnitPrice/examples/unit-price.example.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/examples/unit-price.example.tsx
@@ -34,24 +34,3 @@ export default function Product() {
     />
   );
 }
-
-export default function ProductWithCustomUnitPrice() {
-  const {data} = useShopQuery({query: QUERY});
-  const selectedVariant = data.product.variants.edges[0].node;
-
-  return (
-    <UnitPrice
-      unitPrice={selectedVariant.unitPrice}
-      unitPriceMeasurement={selectedVariant.unitPriceMeasurement}
-    >
-      {({amount, currencyCode, currencyNarrowSymbol, referenceUnit}) => {
-        return (
-          <>
-            <span>{`${currencyNarrowSymbol}${amount}/${referenceUnit}`}</span>
-            <span>{currencyCode}</span>
-          </>
-        );
-      }}
-    </UnitPrice>
-  );
-}

--- a/packages/hydrogen/src/foundation/useUrl/README.md
+++ b/packages/hydrogen/src/foundation/useUrl/README.md
@@ -6,8 +6,10 @@ The `useUrl` hook retrieves the current URL in a server or client component.
 
 ```tsx
 import {useUrl} from '@shopify/hydrogen';
+
 export default function Page() {
   const url = useUrl();
+
   return <h1>Current Url is: {url.href}</h1>;
 }
 ```

--- a/packages/hydrogen/src/hooks/useProductOptions/README.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/README.md
@@ -25,7 +25,7 @@ export function MyComponent() {
         value={selectedVariant?.id}
         onChange={(e) =>
           setSelectedVariant(
-            variants.find((variant) => variant.id === e.target.value)
+            variants.find((variant) => variant.id === e.target.value),
           )
         }
       >


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

BREAKING CHANGE:

UnitPrice no longer use the function-as-a-child (aka "render props") pattern.

Part of https://github.com/Shopify/hydrogen/issues/589


### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
