### PR TITLE
Sitemap Update

### DIFF
--- a/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx
+++ b/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx
@@ -21,68 +21,90 @@ export default function Sitemap({response}) {
 function shopSitemap(data) {
   const urlOrigin = 'https://hydrogen-preview.myshopify.com';
 
+  const productsData = flattenConnection(data.products).map((product) => {
+    const url = product.onlineStoreUrl
+      ? product.onlineStoreUrl
+      : `${urlOrigin}/products/${product.handle}`;
+
+    const finalObject = {
+      url,
+      lastMod: product.updatedAt,
+      changeFreq: 'daily',
+    };
+
+    if (product.featuredImage.url) {
+      finalObject.image = {
+        url: product.featuredImage.url,
+      };
+
+      if (product.title) {
+        finalObject.image.title = product.title;
+      }
+
+      if (product.featuredImage.altText) {
+        finalObject.image.caption = product.featuredImage.altText;
+      }
+
+      return finalObject;
+    }
+  });
+
+  const collectionsData = flattenConnection(data.collections).map(
+    (collection) => {
+      const url = collection.onlineStoreUrl
+        ? collection.onlineStoreUrl
+        : `${urlOrigin}/collections/${collection.handle}`;
+
+      return {
+        url,
+        lastMod: collection.updatedAt,
+        changeFreq: 'daily',
+      };
+    },
+  );
+
+  const pagesData = flattenConnection(data.pages).map((page) => {
+    const url = page.onlineStoreUrl
+      ? page.onlineStoreUrl
+      : `${urlOrigin}/pages/${page.handle}`;
+
+    return {
+      url,
+      lastMod: page.updatedAt,
+      changeFreq: 'weekly',
+    };
+  });
+
+  const urlsDatas = [...productsData, ...collectionsData, ...pagesData];
+
   return `
     <urlset
       xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
       xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
     >
-      ${flattenConnection(data.products)
-        .map((product) => {
-          const url = product.onlineStoreUrl
-            ? product.onlineStoreUrl
-            : `${urlOrigin}/products/${product.handle}`;
-
-          return `
-          <url>
-            <loc>${url}</loc>
-            <lastmod>${product.updatedAt}</lastmod>
-            <changefreq>daily</changefreq>
-            <image:image>
-              <image:loc>
-                ${product?.featuredImage?.url}
-              </image:loc>
-              <image:title>
-                ${product?.title ?? ''}
-              </image:title>
-              <image:caption>
-                ${product?.featuredImage?.altText ?? ''}
-              </image:caption>
-            </image:image>
-          </url>
-        `;
-        })
-        .join('')}
-      ${flattenConnection(data.collections)
-        .map((collection) => {
-          const url = collection.onlineStoreUrl
-            ? collection.onlineStoreUrl
-            : `${urlOrigin}/collections/${collection.handle}`;
-
-          return `
-          <url>
-            <loc>${url}</loc>
-            <lastmod>${collection.updatedAt}</lastmod>
-            <changefreq>daily</changefreq>
-          </url>
-        `;
-        })
-        .join('')}
-      ${flattenConnection(data.pages)
-        .map((page) => {
-          const url = page.onlineStoreUrl
-            ? page.onlineStoreUrl
-            : `${urlOrigin}/pages/${page.handle}`;
-
-          return `
-          <url>
-            <loc>${url}</loc>
-            <lastmod>${page.updatedAt}</lastmod>
-            <changefreq>weekly</changefreq>
-          </url>
-        `;
-        })
-        .join('')}
+      ${urlsDatas.map((url) => renderUrlTag(url)).join('')}
     </urlset>`;
+}
+
+function renderUrlTag({url, lastMod, changeFreq, image}) {
+  return `
+    <url>
+      <loc>${url}</loc>
+      <lastmod>${lastMod}</lastmod>
+      <changefreq>${changeFreq}</changefreq>
+      ${
+        image
+          ? `
+        <image:image>
+          <image:loc>${image.url}</image:loc>
+          <image:title>${image.title ?? ''}</image:title>
+          <image:caption>${image.caption ?? ''}</image:caption>
+        </image:image>`
+          : ''
+      }
+      
+    </url>
+  `;
 }
 
 const QUERY = gql`

--- a/packages/hydrogen/src/framework/docs/pages.md
+++ b/packages/hydrogen/src/framework/docs/pages.md
@@ -222,9 +222,6 @@ Custom responses provide the following benefits:
 
 The following example shows how to create a custom sitemap by adding a new server component called `pages/sitemap.xml.server.jsx`. The custom response object returns the sitemap.
 
-> Tip:
-> Hydrogen's starter includes a `pages/sitemap.xml.server.jsx` component which serves a sitemap at `/sitemap.xml`.
-
 {% codeblock file, filename: '/pages/my-products.server.jsx' %}
 
 ```jsx
@@ -291,6 +288,18 @@ const QUERY = gql`
 ```
 
 {% endcodeblock %}
+
+#### Limitations and considerations
+
+The [Hydrogen starter template](/custom-storefronts/hydrogen/getting-started) includes a `pages/sitemap.xml.server.jsx` component which serves a sitemap at `/sitemap.xml`. The following limitations and considerations apply to the [XML sitemap](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx) that's included in the Hydrogen starter template:
+
+- The sitemap has a limit of 250 products, 250 collections, and 250 pages. You need to [paginate results](/api/usage/pagination-graphql) if your store has more than 250 resources.
+
+- When you add or remove pages, the sitemap is automatically updated within one day. Similarly, if you unpublish a product, then the product is removed automatically from the sitemap.
+
+- The sitemap is cached for 24 hours.
+
+- By default, the sitemap uses the [`onlineStoreUrl`](/api/storefront/2022-01/objects/Product) field from the Storefront API as the URL. It falls back to the Hydrogen starter template URL structure, which is based on resource's handle.
 
 ### Build a JSON API
 

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -12,10 +12,6 @@ Hydrogen also includes a [`<Seo>`](/api/hydrogen/components/primitive/seo) clien
 - [Collection page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/collections/[handle].server.jsx)
 - [Pages page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/pages/[handle].server.jsx)
 
-### Updating the XML sitemap
-
-When you add or remove pages, the [XML sitemap](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx) that's included in the Hydrogen starter template is automatically updated within one day. Similarly, if you unpublish a product, then the product is removed automatically from the sitemap.
-
 ### Imitating SEO robot behavior
 
 Hydrogen supports SEO by inspecting the `user-agent` for every request, and buffering the response to fully render it on server-side. To imitate the behaviour of a SEO robot and show the page content fully from server render for initial render, add the `?\_bot` query parameter at the end of the webpage's URL.
@@ -86,6 +82,18 @@ export default function App({log, ...serverState}) {
 ```
 
 {% endcodeblock %}
+
+## Limitations and considerations
+
+The following limitations and considerations apply to the [XML sitemap](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx) that's included in the Hydrogen starter template:
+
+- The sitemap has a limit of 250 products, 250 collections, and 250 pages. You need to [paginate results](/api/usage/pagination-graphql) if your store has more than 250 resources.
+
+- When you add or remove pages, the sitemap is automatically updated within one day. Similarly, if you unpublish a product, then the product is removed automatically from the sitemap.
+
+- The sitemap is cached for 24 hours.
+
+- By default, the sitemap uses the [`onlineStoreUrl`](/api/storefront/2022-01/objects/Product) field from the Storefront API as the URL. It falls back to the Hydrogen starter template URL structure, which is based on resource's handle.
 
 ## Next steps
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Todo:
- [x] add scope on when resources should show up in sitemap (such as availability in Online Store Channel or status of product)
- [x] Change `MAX_URLS` (google limit is [50K per sitemap](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap#:~:text=All%20formats%20limit%20a%20single,your%20list%20into%20multiple%20sitemaps), the API limit is 250)
- [ ] ~~Add main sitemap that break up sitemap file if its too large (for large shop that has more than 50K products for example)~~ This cannot be done for now since the API does not offer anyway to find out the total number of resources at once
- [x] use `onlineStoreUrl` instead of building url from handle (Using this field means the resource is one: available in Online Store Channel, two: online store is no longer password protected)
- [x] Make a generic sitemap utility
- [ ] ~~Make a re-usable sitemap component that allow for url overwrite~~not for now

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
