### PR TITLE
[Hydrogen docs]: Fix links to metafield types documentation

### DIFF
--- a/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
+++ b/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
@@ -11,7 +11,7 @@ import {MediaImage} from '../../types';
 export interface MetafieldProps {
   /** A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API. */
   metafield: ParsedMetafield;
-  /** An HTML tag to be rendered as the base element wrapper. The default value varies depending on [`metafield.type`](/apps/metafields/definitions/types). */
+  /** An HTML tag to be rendered as the base element wrapper. The default value varies depending on [metafield.type](/apps/metafields/types). */
   as?: ElementType;
 }
 

--- a/packages/hydrogen/src/components/Metafield/README.md
+++ b/packages/hydrogen/src/components/Metafield/README.md
@@ -23,7 +23,7 @@ export function Product({product}) {
 | Name      | Type                         | Description                                                                                                                                           |
 | --------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | metafield | <code>ParsedMetafield</code> | A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API.                                                     |
-| as?       | <code>ElementType</code>     | An HTML tag to be rendered as the base element wrapper. The default value varies depending on [`metafield.type`](/apps/metafields/definitions/types). |
+| as?       | <code>ElementType</code>     | An HTML tag to be rendered as the base element wrapper. The default value varies depending on [metafield.type](/apps/metafields/types). |
 
 ## Default output
 

--- a/packages/hydrogen/src/components/Metafield/README.md
+++ b/packages/hydrogen/src/components/Metafield/README.md
@@ -20,9 +20,9 @@ export function Product({product}) {
 
 ## Props
 
-| Name      | Type                         | Description                                                                                                                                           |
-| --------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| metafield | <code>ParsedMetafield</code> | A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API.                                                     |
+| Name      | Type                         | Description                                                                                                                             |
+| --------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| metafield | <code>ParsedMetafield</code> | A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API.                                       |
 | as?       | <code>ElementType</code>     | An HTML tag to be rendered as the base element wrapper. The default value varies depending on [metafield.type](/apps/metafields/types). |
 
 ## Default output


### PR DESCRIPTION
## This PR: 
- Fixes a couple of links to the metafield types documentation
- Relates to https://github.com/Shopify/shopify-dev/pull/15399