### PR TITLE
Fix external video issues for rc (close #454)

### DIFF
--- a/examples/template-hydrogen-default/src/components/Gallery.client.jsx
+++ b/examples/template-hydrogen-default/src/components/Gallery.client.jsx
@@ -10,12 +10,13 @@ import {
 export default function Gallery() {
   const {media, selectedVariant} = useProduct();
 
-  const featuredMedia = selectedVariant.image || media[0].image;
-  const featuredMediaSrc = featuredMedia.url.split('?')[0];
+  const featuredMedia = selectedVariant.image || media[0]?.image;
+  const featuredMediaSrc = featuredMedia?.url.split('?')[0];
   const galleryMedia = media.filter((med) => {
     if (
       med.mediaContentType === MODEL_3D_TYPE ||
-      med.mediaContentType === VIDEO_TYPE
+      med.mediaContentType === VIDEO_TYPE ||
+      med.mediaContentType === EXTERNAL_VIDEO_TYPE
     ) {
       return true;
     }
@@ -63,3 +64,4 @@ const MODEL_3D_PROPS = {
   interactionPromptThreshold: '0',
 };
 const VIDEO_TYPE = 'VIDEO';
+const EXTERNAL_VIDEO_TYPE = 'EXTERNAL_VIDEO';

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -51,6 +51,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - fix: Clear browser fetch cache by @wizardlyhel in [#591](https://github.com/Shopify/hydrogen/pull/591)
 - refactor: use featureImage instead of images(first:1) on product query
 - fix: target future release to use '2022-01' API Version
+- fix: render error in `Gallery.client.jsx` component when product resource has an external video or no images.
+- fix: ensure youtube external videos are embed compatible urls
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/components/ExternalVideo/tests/ExternalVideo.test.tsx
+++ b/packages/hydrogen/src/components/ExternalVideo/tests/ExternalVideo.test.tsx
@@ -65,4 +65,19 @@ describe('<ExternalVideo />', () => {
       className: 'fancy',
     });
   });
+
+  it('transforms a valid youtube shortened url to an embed compatibile url', () => {
+    const invalidUrl = 'https://youtu.be/a2YSgfwXc9c';
+    const validUrl = invalidUrl.replace(/youtu\.be/, 'www.youtube.com/embed');
+    const component = mount(
+      <ExternalVideo
+        video={getExternalVideo({
+          embeddedUrl: invalidUrl,
+        })}
+      />
+    );
+    expect(component).toContainReactComponent('iframe', {
+      src: validUrl,
+    });
+  });
 });

--- a/packages/hydrogen/src/utilities/video_parameters.ts
+++ b/packages/hydrogen/src/utilities/video_parameters.ts
@@ -68,6 +68,10 @@ export function addParametersToEmbeddedVideoUrl(
 }
 
 export function useEmbeddedVideoUrl(url: string, parameters?: YouTube | Vimeo) {
+  // Ensure a youtube shortened url is changed to an iFrame compatible embed link.
+  // TODO: Fix is needed for SFAPI version 2022-01. Starting 2022-04 embeddedUrl has been marked as deprecated and replaced with
+  // embedUrl. When the pinned SFAPI version is 2022-04 line can be removed in favor of changes on PR #455
+  url = url.replace(/youtu.be/, 'www.youtube.com/embed');
   return useMemo(() => {
     if (!parameters) {
       return url;

--- a/packages/hydrogen/src/utilities/video_parameters.ts
+++ b/packages/hydrogen/src/utilities/video_parameters.ts
@@ -71,7 +71,7 @@ export function useEmbeddedVideoUrl(url: string, parameters?: YouTube | Vimeo) {
   // Ensure a youtube shortened url is changed to an iFrame compatible embed link.
   // TODO: Fix is needed for SFAPI version 2022-01. Starting 2022-04 embeddedUrl has been marked as deprecated and replaced with
   // embedUrl. When the pinned SFAPI version is 2022-04 line can be removed in favor of changes on PR #455
-  url = url.replace(/youtu.be/, 'www.youtube.com/embed');
+  url = url.replace(/youtu\.be/, 'www.youtube.com/embed');
   return useMemo(() => {
     if (!parameters) {
       return url;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

PR solves External Video issues noted on [Issue #454](https://github.com/Shopify/hydrogen/issues/454).

1. Corrects two rendering errors in `Gallery.client.jsx` component. First, prevents render error if product resource has no images. Second, prevents a render error if product resource has an external video from youtube or vimeo.
2. Ensures that a youtube external video for a product resource is embed compatible in an iFrame. Vimeo external videos are not impacted and continue to work without issue.

### Additional context

This PR provides provides a solution to the issues and changes referenced on [PR #455](https://github.com/Shopify/hydrogen/pull/455). The difference being this PR does not introduce a breaking change requiring the Storefront API version used for Hydrogen to be `2022-04`. This allows the rendering errors to be corrected while working with the proposed rc version of the Storefront API being `2022-01`.

When `2022-04` or later becomes the pinned version for Hydrogen, the changes here to [video_parameters.ts](https://github.com/Shopify/hydrogen/blob/76421b161706443050fa0ff34f2f5e7e0ade0022/packages/hydrogen/src/utilities/video_parameters.ts#L71-L74) can be removed in favor of the changes in [PR #455](https://github.com/Shopify/hydrogen/pull/455) which uses the new [embedUrl](https://shopify.dev/api/storefront/2022-04/objects/externalvideo#fields) field of the ExternalVideo type. The [embedUrl](https://shopify.dev/api/storefront/2022-04/objects/externalvideo#fields) field will always return an iFrame compatible url for a youtube video. 

