### PR TITLE
fix: inconsistencies in prettier when generating docs

### DIFF
--- a/packages/generate-docs/src/FileResult.ts
+++ b/packages/generate-docs/src/FileResult.ts
@@ -11,6 +11,9 @@ const CONTENT_DIRECTORY_NAME = 'docs';
 const PRETTIER_CONFIG = {
   ...require('@shopify/prettier-config'),
   parser: 'markdown',
+  tabWidth: 2,
+  printWidth: 80,
+  trailingComma: 'es5',
 };
 
 export class FileResult {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Quick fix for an annoying thing I noticed when generating the docs. We add a trailing comma to the examples, but then when you push the code and the CI checks for formatting, it complains and fails. This PR should hopefully avoid that issue by bringing in the same overrides we have in the prettier config file in the root of the project.

Personally I'd prefer `trailingComma: all`, but also truly don't care, and assume this override was added by someone who does. It also creates a massive diff when I go the other way so this is fine :)

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
