### PR TITLE
chore: add test for HMR for client components

### DIFF
--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -298,5 +298,27 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
         async () => await untilUpdated(() => page.textContent('h1'), newheading)
       );
     });
+
+    it('updates the contents when a client component file changes', async () => {
+      if (isBuild) {
+        return;
+      }
+
+      const fullPath = resolve(
+        __dirname,
+        '../',
+        'src/components/Counter.client.jsx'
+      );
+      const newButtonText = 'add';
+
+      await page.goto(`${getServerUrl()}/about`);
+      await untilUpdated(() => page.textContent('button'), 'increase');
+      await edit(
+        fullPath,
+        (code) => code.replace('increase', newButtonText),
+        async () =>
+          await untilUpdated(() => page.textContent('button'), newButtonText)
+      );
+    });
   });
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a test case for Hot Module Reloading for client side component edits. This is currently broken on main (hence the intentionally failing test right now), but will be fixed in https://github.com/Shopify/hydrogen/pull/648.

The current failure in CI is a pretty accurate representation of what happens in real life, see comparison below:

<img width="1004" alt="Screen Shot 2022-02-10 at 21 53 44" src="https://user-images.githubusercontent.com/462077/153495193-35304ca5-2f18-4a5c-b396-91f869c1eb4f.png">

<img width="935" alt="Screen Shot 2022-02-08 at 23 33 59" src="https://user-images.githubusercontent.com/462077/153495320-baf2c815-5448-4212-a56f-3176e3107b4f.png">



### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
