### PR TITLE
chore: only publish to stackblitz on stable release

### DIFF
--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -2,7 +2,7 @@ name: Publish to Stackblitz
 
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I was thinking it would be good to issue GH Releases for `experimental` and prereleases. This gives us an opportunity to formally write up migration steps that the community can follow before we consider a release stable.

We need to ensure the `stackblitz` branch doesn't accidentally get updated when we do this. This PR changes the GH Actions workflow to run on `released` instead of `published`.