### PR TITLE
fix: prevent client components from being cached in development

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -63,6 +63,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - feat: pass HYDROGEN_ASSET_BASE_URL into config to set base URL for compiled assets
 - dx [breaking change]: `<Product />` and `<CartLine />` aliases have been removed; use the original components `<ProductProvider />` and `<CartLineProvider />` instead. Their nested component aliases, such as `<Product.Image />`, have also been removed; in this example you should use `<ProductImage />`.
 - feat: remove React Router on the client and introduce Hydrogen the `<Link>` component and `useNavigate` hook
+- fix: prevent client components from being cached during development
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/framework/plugin.ts
+++ b/packages/hydrogen/src/framework/plugin.ts
@@ -2,6 +2,7 @@ import type {HydrogenVitePluginOptions, ShopifyConfig} from '../types';
 import hydrogenConfig from './plugins/vite-plugin-hydrogen-config';
 import type {Plugin} from 'vite';
 import hydrogenMiddleware from './plugins/vite-plugin-hydrogen-middleware';
+import hydrogenClientMiddleware from './plugins/vite-plugin-hydrogen-client-middleware';
 // @ts-ignore
 import rsc from '@shopify/hydrogen/vendor/react-server-dom-vite/plugin';
 import ssrInterop from './plugins/vite-plugin-ssr-interop';
@@ -18,6 +19,7 @@ export default (
     process.env.VITE_INSPECT && inspect(),
 
     hydrogenConfig(),
+    hydrogenClientMiddleware(),
     hydrogenMiddleware(shopifyConfig, pluginOptions),
     react(),
     ssrInterop(),

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-client-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-client-middleware.ts
@@ -1,0 +1,41 @@
+import {send, type Plugin} from 'vite';
+
+/**
+ * This dev server middleware prevents Vite from applying immutable cache control headers to client
+ * components. These client components are part of the user's local source, but since they are
+ * referenced via import globs in the `react-dom-server-vite` NPM package, Vite assumes they
+ * are 3P deps that can be cached. This middleware responds to the requests early with `no-cache`.
+ */
+export default () => {
+  return {
+    name: 'vite-plugin-hydrogen-client-middleware',
+    enforce: 'pre',
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const url = req.url!;
+
+        try {
+          if (
+            url.includes('.client.js') &&
+            url.includes('?v=') &&
+            !url.includes('node_modules')
+          ) {
+            const result = await server.transformRequest(url, {html: false});
+            if (result) {
+              return send(req, res, result.code, 'js', {
+                etag: result.etag,
+                cacheControl: 'no-cache',
+                headers: server.config.server.headers,
+                map: result.map,
+              });
+            }
+          }
+        } catch (e) {
+          next(e);
+        }
+
+        next();
+      });
+    },
+  } as Plugin;
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Client components are being cached in development when they should not be. This PR returns client components with a `no-cache` header.

Fixes #296 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
