### PR TITLE
refactor: renamed money prop on <Money/> to data

### DIFF
--- a/packages/hydrogen/src/components/CartEstimatedCost/CartEstimatedCost.client.tsx
+++ b/packages/hydrogen/src/components/CartEstimatedCost/CartEstimatedCost.client.tsx
@@ -37,7 +37,7 @@ export function CartEstimatedCost<TTag extends ElementType>(
   }
 
   return (
-    <Money {...passthroughProps} money={amount}>
+    <Money {...passthroughProps} data={amount}>
       {children}
     </Money>
   );

--- a/packages/hydrogen/src/components/CartEstimatedCost/tests/CartEstimatedCost.test.tsx
+++ b/packages/hydrogen/src/components/CartEstimatedCost/tests/CartEstimatedCost.test.tsx
@@ -47,7 +47,7 @@ describe('<CartEstimatedCost />', () => {
 
     const expectedMoney = CART_WITH_LINES.estimatedCost.totalAmount;
     expect(wrapper).toContainReactComponent(Money, {
-      money: expectedMoney,
+      data: expectedMoney,
     });
   });
 
@@ -60,7 +60,7 @@ describe('<CartEstimatedCost />', () => {
 
     const expectedMoney = CART_WITH_LINES.estimatedCost.subtotalAmount;
     expect(wrapper).toContainReactComponent(Money, {
-      money: expectedMoney,
+      data: expectedMoney,
     });
   });
 
@@ -73,7 +73,7 @@ describe('<CartEstimatedCost />', () => {
 
     const expectedMoney = CART_WITH_LINES.estimatedCost.totalTaxAmount;
     expect(wrapper).toContainReactComponent(Money, {
-      money: expectedMoney,
+      data: expectedMoney,
     });
   });
 
@@ -86,7 +86,7 @@ describe('<CartEstimatedCost />', () => {
 
     const expectedMoney = CART_WITH_LINES.estimatedCost.totalDutyAmount;
     expect(wrapper).toContainReactComponent(Money, {
-      money: expectedMoney,
+      data: expectedMoney,
     });
   });
 });

--- a/packages/hydrogen/src/components/CartLinePrice/CartLinePrice.client.tsx
+++ b/packages/hydrogen/src/components/CartLinePrice/CartLinePrice.client.tsx
@@ -3,7 +3,7 @@ import {useCartLine} from '../CartLineProvider';
 import {Money, MoneyProps} from '../Money';
 import {Props} from '../types';
 
-export interface CartLinePriceProps extends Omit<MoneyProps, 'money'> {
+export interface CartLinePriceProps extends Omit<MoneyProps, 'data'> {
   /** The type of price. Valid values:`regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
 }
@@ -30,7 +30,7 @@ export function CartLinePrice<TTag extends ElementType>(
   return (
     <Money
       {...passthroughProps}
-      money={{
+      data={{
         amount: price.amount * cartLine.quantity,
         currencyCode: price.currencyCode,
       }}

--- a/packages/hydrogen/src/components/CartLinePrice/tests/CartLinePrice.test.tsx
+++ b/packages/hydrogen/src/components/CartLinePrice/tests/CartLinePrice.test.tsx
@@ -26,7 +26,7 @@ describe('<CartLinePrice />', () => {
     );
 
     expect(wrapper).toContainReactComponent(Money, {
-      money: {amount: 50, currencyCode: CurrencyCode.Usd},
+      data: {amount: 50, currencyCode: CurrencyCode.Usd},
     });
   });
 
@@ -49,7 +49,7 @@ describe('<CartLinePrice />', () => {
     );
 
     expect(wrapper).toContainReactComponent(Money, {
-      money: {amount: 60, currencyCode: CurrencyCode.Usd},
+      data: {amount: 60, currencyCode: CurrencyCode.Usd},
     });
   });
 
@@ -73,7 +73,7 @@ describe('<CartLinePrice />', () => {
     );
 
     expect(wrapper).toContainReactComponent(Money, {
-      money: {amount: 100, currencyCode: CurrencyCode.Usd},
+      data: {amount: 100, currencyCode: CurrencyCode.Usd},
     });
   });
 

--- a/packages/hydrogen/src/components/Money/Money.client.tsx
+++ b/packages/hydrogen/src/components/Money/Money.client.tsx
@@ -8,7 +8,7 @@ export interface MoneyProps {
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
   as?: ElementType;
   /** A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2). */
-  money: MoneyV2;
+  data: MoneyV2;
 }
 
 /**
@@ -19,8 +19,8 @@ export interface MoneyProps {
 export function Money<TTag extends ElementType>(
   props: Props<TTag> & MoneyProps
 ) {
-  const {money, as, ...passthroughProps} = props;
-  const moneyObject = useMoney(money);
+  const {data, as, ...passthroughProps} = props;
+  const moneyObject = useMoney(data);
   const Wrapper = as ?? 'div';
 
   return <Wrapper {...passthroughProps}>{moneyObject.localizedString}</Wrapper>;

--- a/packages/hydrogen/src/components/Money/README.md
+++ b/packages/hydrogen/src/components/Money/README.md
@@ -29,14 +29,14 @@ const QUERY = gql`
 export default function Product() {
   const {data} = useShopQuery({query: QUERY});
 
-  return <Money money={data.product.variants.edges[0].node.priceV2} />;
+  return <Money data={data.product.variants.edges[0].node.priceV2} />;
 }
 
 export default function ProductWithCustomMoney() {
   const {data} = useShopQuery({query: QUERY});
 
   return (
-    <Money money={data.product.variants.edges[0].node.priceV2}>
+    <Money data={data.product.variants.edges[0].node.priceV2}>
       {({amount, currencyCode, currencyNarrowSymbol}) => {
         return (
           <>
@@ -55,7 +55,7 @@ export default function ProductWithCustomMoney() {
 | Name      | Type                     | Description                                                                              |
 | --------- | ------------------------ | ---------------------------------------------------------------------------------------- |
 | as?       | <code>ElementType</code> | A `ReactNode` element.                                                                   |
-| money     | <code>MoneyV2</code>     | A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2).                  |
+| data      | <code>MoneyV2</code>     | A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2).                  |
 | children? | <code>ReactNode</code>   | A function that takes an object return by the `useMoney` hook and returns a `ReactNode`. |
 
 ## Component type

--- a/packages/hydrogen/src/components/Money/examples/money.example.tsx
+++ b/packages/hydrogen/src/components/Money/examples/money.example.tsx
@@ -19,5 +19,5 @@ const QUERY = gql`
 export default function Product() {
   const {data} = useShopQuery({query: QUERY});
 
-  return <Money money={data.product.variants.edges[0].node.priceV2} />;
+  return <Money data={data.product.variants.edges[0].node.priceV2} />;
 }

--- a/packages/hydrogen/src/components/Money/tests/Money.test.tsx
+++ b/packages/hydrogen/src/components/Money/tests/Money.test.tsx
@@ -7,7 +7,7 @@ import {Money} from '../Money.client';
 describe('<Money />', () => {
   it('renders a formatted money string', () => {
     const money = getPrice({currencyCode: CurrencyCode.Usd});
-    const component = mountWithProviders(<Money money={money} />);
+    const component = mountWithProviders(<Money data={money} />);
 
     expect(component).toContainReactText(`$${money.amount}`);
   });
@@ -16,14 +16,14 @@ describe('<Money />', () => {
     const money = getPrice({
       currencyCode: CurrencyCode.Eur,
     });
-    const component = mountWithProviders(<Money money={money} />);
+    const component = mountWithProviders(<Money data={money} />);
 
     expect(component).toContainReactText(`€${money.amount}`);
   });
 
   it('allows pass-through props to the wrapping component', () => {
     const component = mountWithProviders(
-      <Money money={getPrice()} className="money" />
+      <Money data={getPrice()} className="money" />
     );
 
     expect(component).toHaveReactProps({className: 'money'});

--- a/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
+++ b/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
@@ -4,7 +4,7 @@ import {Money, MoneyProps} from '../Money';
 import {useProduct} from '../ProductProvider';
 import {Props} from '../types';
 
-export interface ProductPriceProps extends Omit<MoneyProps, 'money'> {
+export interface ProductPriceProps extends Omit<MoneyProps, 'data'> {
   /** The type of price. Valid values: `regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
   /** The type of value. Valid values: `min` (default) or `max`. */
@@ -45,5 +45,5 @@ export function ProductPrice<TTag extends ElementType>(
     return null;
   }
 
-  return <Money {...passthroughProps} money={price} />;
+  return <Money {...passthroughProps} data={price} />;
 }

--- a/packages/hydrogen/src/components/ProductPrice/tests/ProductPrice.test.tsx
+++ b/packages/hydrogen/src/components/ProductPrice/tests/ProductPrice.test.tsx
@@ -15,7 +15,7 @@ describe('<ProductPrice />', () => {
     );
 
     expect(price).toContainReactComponent(Money, {
-      money: product.priceRange.minVariantPrice,
+      data: product.priceRange.minVariantPrice,
     });
   });
 
@@ -28,7 +28,7 @@ describe('<ProductPrice />', () => {
     );
 
     expect(price).toContainReactComponent(Money, {
-      money: product.priceRange.maxVariantPrice,
+      data: product.priceRange.maxVariantPrice,
     });
   });
 
@@ -41,7 +41,7 @@ describe('<ProductPrice />', () => {
     );
 
     expect(price).toContainReactComponent(Money, {
-      money: product.compareAtPriceRange.minVariantPrice,
+      data: product.compareAtPriceRange.minVariantPrice,
     });
   });
 
@@ -54,7 +54,7 @@ describe('<ProductPrice />', () => {
     );
 
     expect(price).toContainReactComponent(Money, {
-      money: product.compareAtPriceRange.maxVariantPrice,
+      data: product.compareAtPriceRange.maxVariantPrice,
     });
   });
 

--- a/packages/hydrogen/src/components/SelectedVariantPrice/SelectedVariantPrice.client.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantPrice/SelectedVariantPrice.client.tsx
@@ -3,7 +3,7 @@ import {useProduct} from '../ProductProvider';
 import {Money, MoneyProps} from '../Money';
 import {Props} from '../types';
 
-export interface SelectedVariantPriceProps extends Omit<MoneyProps, 'money'> {
+export interface SelectedVariantPriceProps extends Omit<MoneyProps, 'data'> {
   /** The type of price. Valid values: `regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
 }
@@ -33,5 +33,5 @@ export function SelectedVariantPrice<TTag extends ElementType>(
     return null;
   }
 
-  return <Money {...passthroughProps} money={price} />;
+  return <Money {...passthroughProps} data={price} />;
 }

--- a/packages/hydrogen/src/components/SelectedVariantPrice/tests/SelectedVariantPrice.test.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantPrice/tests/SelectedVariantPrice.test.tsx
@@ -16,7 +16,7 @@ describe('<SelectedVariantPrice />', () => {
     );
 
     expect(price).toContainReactComponent(Money, {
-      money: selectedVariant.priceV2,
+      data: selectedVariant.priceV2,
     });
   });
 
@@ -30,7 +30,7 @@ describe('<SelectedVariantPrice />', () => {
     );
 
     expect(price).toContainReactComponent(Money, {
-      money: selectedVariant.compareAtPriceV2,
+      data: selectedVariant.compareAtPriceV2,
     });
   });
 

--- a/packages/hydrogen/src/components/SelectedVariantUnitPrice/SelectedVariantUnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantUnitPrice/SelectedVariantUnitPrice.client.tsx
@@ -20,8 +20,8 @@ export function SelectedVariantUnitPrice<TTag extends ElementType>(
     product.selectedVariant?.unitPriceMeasurement ? (
     <UnitPrice
       {...props}
-      unitPrice={product.selectedVariant.unitPrice}
-      unitPriceMeasurement={product.selectedVariant.unitPriceMeasurement}
+      data={product.selectedVariant.unitPrice}
+      measurement={product.selectedVariant.unitPriceMeasurement}
     />
   ) : null;
 }

--- a/packages/hydrogen/src/components/SelectedVariantUnitPrice/tests/SelectedVariantUnitPrice.test.tsx
+++ b/packages/hydrogen/src/components/SelectedVariantUnitPrice/tests/SelectedVariantUnitPrice.test.tsx
@@ -16,8 +16,8 @@ describe('<SelectedVariantUnitPrice />', () => {
     );
 
     expect(component).toContainReactComponent(UnitPrice, {
-      unitPrice: selectedVariant.unitPrice,
-      unitPriceMeasurement: selectedVariant.unitPriceMeasurement,
+      data: selectedVariant.unitPrice,
+      measurement: selectedVariant.unitPriceMeasurement,
     });
   });
 });

--- a/packages/hydrogen/src/components/UnitPrice/README.md
+++ b/packages/hydrogen/src/components/UnitPrice/README.md
@@ -37,8 +37,8 @@ export default function Product() {
 
   return (
     <UnitPrice
-      unitPrice={selectedVariant.unitPrice}
-      unitPriceMeasurement={selectedVariant.unitPriceMeasurement}
+      data={selectedVariant.unitPrice}
+      measurement={selectedVariant.unitPriceMeasurement}
     />
   );
 }
@@ -46,11 +46,11 @@ export default function Product() {
 
 ## Props
 
-| Name                 | Type                              | Description                                                                                 |
-| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------- |
-| unitPrice            | <code>MoneyV2</code>              | A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2).                     |
-| unitPriceMeasurement | <code>UnitPriceMeasurement</code> | A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement). |
-| as?                  | <code>ElementType</code>          | An HTML tag to be rendered as the base element wrapper. The default is `div`.               |
+| Name        | Type                              | Description                                                                                 |
+| ----------- | --------------------------------- | ------------------------------------------------------------------------------------------- |
+| data        | <code>MoneyV2</code>              | A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2).                     |
+| measurement | <code>UnitPriceMeasurement</code> | A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement). |
+| as?         | <code>ElementType</code>          | An HTML tag to be rendered as the base element wrapper. The default is `div`.               |
 
 ## Component type
 

--- a/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
@@ -6,9 +6,9 @@ import {UnitPriceFragment as Fragment} from '../../graphql/graphql-constants';
 
 export interface UnitPriceProps {
   /** A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2). */
-  unitPrice: MoneyV2;
+  data: MoneyV2;
   /** A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement). */
-  unitPriceMeasurement: UnitPriceMeasurement;
+  measurement: UnitPriceMeasurement;
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
   as?: ElementType;
 }
@@ -20,12 +20,12 @@ export interface UnitPriceProps {
 export function UnitPrice<TTag extends ElementType>(
   props: Props<TTag> & UnitPriceProps
 ) {
-  const {unitPrice, unitPriceMeasurement, as, ...passthroughProps} = props;
+  const {data, measurement, as, ...passthroughProps} = props;
   const Wrapper: any = as ?? 'div';
 
   return (
     <Wrapper {...passthroughProps}>
-      <Money data={unitPrice} />/{unitPriceMeasurement.referenceUnit}
+      <Money data={data} />/{measurement.referenceUnit}
     </Wrapper>
   );
 }

--- a/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
@@ -25,7 +25,7 @@ export function UnitPrice<TTag extends ElementType>(
 
   return (
     <Wrapper {...passthroughProps}>
-      <Money money={unitPrice} />/{unitPriceMeasurement.referenceUnit}
+      <Money data={unitPrice} />/{unitPriceMeasurement.referenceUnit}
     </Wrapper>
   );
 }

--- a/packages/hydrogen/src/components/UnitPrice/examples/unit-price.example.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/examples/unit-price.example.tsx
@@ -29,8 +29,8 @@ export default function Product() {
 
   return (
     <UnitPrice
-      unitPrice={selectedVariant.unitPrice}
-      unitPriceMeasurement={selectedVariant.unitPriceMeasurement}
+      data={selectedVariant.unitPrice}
+      measurement={selectedVariant.unitPriceMeasurement}
     />
   );
 }

--- a/packages/hydrogen/src/components/UnitPrice/tests/UnitPrice.test.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/tests/UnitPrice.test.tsx
@@ -10,10 +10,7 @@ const unitPriceMeasurement = getUnitPriceMeasurement();
 describe('<UnitPrice />', () => {
   it('renders unit price measurement for product in correct format', () => {
     const component = mountWithProviders(
-      <UnitPrice
-        unitPrice={unitPrice}
-        unitPriceMeasurement={unitPriceMeasurement}
-      />
+      <UnitPrice data={unitPrice} measurement={unitPriceMeasurement} />
     );
 
     const expectedUnitPrice = `CA$${unitPrice.amount}/${unitPriceMeasurement.referenceUnit}`;
@@ -24,8 +21,8 @@ describe('<UnitPrice />', () => {
     const component = mountWithProviders(
       <UnitPrice
         className="unitPriceMeasurement"
-        unitPrice={unitPrice}
-        unitPriceMeasurement={unitPriceMeasurement}
+        data={unitPrice}
+        measurement={unitPriceMeasurement}
       />
     );
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Part of https://github.com/Shopify/hydrogen/issues/627

- [x] renamed money prop for `<Money/> ` to data
- [x] renamed unitPrice & unitPriceMeasurement prop for `<UnitPrice/>`  to data & measurement

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository for your change, if needed
