### PR TITLE
fix: pass nested image data field from media file to underly Image component

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -77,7 +77,6 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `<UnitPrice>`: renamed unitPrice prop to data, unitPriceMeasurement prop to measurement
   - `<ProductProvider>`: renamed product prop to data
   - `<CartProvider>`: renamed cart prop to data
-  - fix: broken images in demo store
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -77,6 +77,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `<UnitPrice>`: renamed unitPrice prop to data, unitPriceMeasurement prop to measurement
   - `<ProductProvider>`: renamed product prop to data
   - `<CartProvider>`: renamed cart prop to data
+- fix: broken images in demo store
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -77,7 +77,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `<UnitPrice>`: renamed unitPrice prop to data, unitPriceMeasurement prop to measurement
   - `<ProductProvider>`: renamed product prop to data
   - `<CartProvider>`: renamed cart prop to data
-- fix: broken images in demo store
+  - fix: broken images in demo store
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
+++ b/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
@@ -8,7 +8,7 @@ import {Media as MediaType} from '../../graphql/types/types';
 
 export type Media = Pick<MediaType, 'mediaContentType'>;
 
-type MediaImageMedia = Media & MediaImageProps['data'];
+type MediaImageMedia = Media & {image: MediaImageProps['data']};
 type ModelViewerMedia = Media & ModelViewerProps['data'];
 type ExternalVideoMedia = Media & ExternalVideoProps['data'];
 type VideoMedia = Media & VideoProps['data'];
@@ -36,7 +36,7 @@ export function MediaFile({
       return (
         <Image
           {...passthroughProps}
-          data={data as MediaImageMedia}
+          data={(data as MediaImageMedia).image}
           options={options as MediaImageProps['options']}
         />
       );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes this error that was happening on the product details pages of the demo store.

<img width="1212" alt="Screen Shot 2022-02-16 at 15 11 57" src="https://user-images.githubusercontent.com/462077/154282105-2f1e0de8-c62d-47c5-b567-b08e50bda593.png">

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
