### PR TITLE
fix: broken media files in demo store

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -77,6 +77,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
   - `<UnitPrice>`: renamed unitPrice prop to data, unitPriceMeasurement prop to measurement
   - `<ProductProvider>`: renamed product prop to data
   - `<CartProvider>`: renamed cart prop to data
+- fix: broken 3d models in demo store
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
+++ b/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
@@ -9,7 +9,7 @@ import {Media as MediaType} from '../../graphql/types/types';
 export type Media = Pick<MediaType, 'mediaContentType'>;
 
 type MediaImageMedia = Media & MediaImageProps['data'];
-type ModelViewerMedia = Media & ModelViewerProps['data'];
+type ModelViewerMedia = Media & {model: ModelViewerProps['data']};
 type ExternalVideoMedia = Media & ExternalVideoProps['data'];
 type VideoMedia = Media & VideoProps['data'];
 
@@ -59,7 +59,10 @@ export function MediaFile({
       );
     case 'MODEL_3D':
       return (
-        <ModelViewer {...passthroughProps} data={data as ModelViewerMedia} />
+        <ModelViewer
+          {...passthroughProps}
+          data={(data as ModelViewerMedia).model}
+        />
       );
     default:
       return null;

--- a/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
+++ b/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
@@ -154,13 +154,8 @@ export function ModelViewer<TTag extends ElementType>(
   const callbackRef = useCallback((node) => {
     setModelViewer(node);
   }, []);
-  const {
-    model,
-    id = model.id,
-    children,
-    className,
-    ...passthroughProps
-  } = props;
+
+  const {id, children, className, data: model, ...passthroughProps} = props;
 
   const modelViewerLoadedStatus = useLoadScript(
     'https://unpkg.com/@google/model-viewer@v1.8.0/dist/model-viewer.min.js',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Similar fix as https://github.com/Shopify/hydrogen/pull/692 but for 3d models. The changes to the `data` prop naming seems to have caused a few errors in the ProductDetails Gallery component. In this PR I am getting the model data directly from the `data` prop.

<img width="1291" alt="Screen Shot 2022-02-16 at 15 07 25" src="https://user-images.githubusercontent.com/462077/154287040-6b0279a7-7705-41cf-82ad-6786e402ca00.png">

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
