### PR TITLE
[Hydrogen docs]: Augment information about SEO

### DIFF
--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -12,7 +12,7 @@ Hydrogen includes a [`Seo`](/api/hydrogen/components/primitive/seo) client compo
 
 ### `Seo` client component
 
-The [`Seo`](/api/hydrogen/components/primitive/seo) client component uses the Storefront API to generate the `<head>` tags that search engines look for. For example, [`Product.Seo`](/api/storefront/2022-01/objects/Product) is used to generate the `<head>` tags for the products page.
+The [`Seo`](/api/hydrogen/components/primitive/seo) client component uses the data from Storefront API to generate the `<head>` tags that search engines look for. For example, [`Product.Seo`](/api/storefront/2022-01/objects/Product) is used to generate the `<head>` tags for the products page.
 
 You can customize the `<head>` tags at the route level:
 
@@ -46,7 +46,7 @@ const customData = {
 
 The following example shows how to pass a `product` prop to the component to generate standard SEO-related tags for your product page:
 
-{% codeblock file, filename: 'Product.client.jsx' %}
+{% codeblock file, filename: '/products/[handle].server.jsx' %}
 
 ```jsx
 <Seo type="product" data={product} />
@@ -56,7 +56,7 @@ The following example shows how to pass a `product` prop to the component to gen
 
 If you want to add more custom `head` tags, then you can import `Helmet` from Hydrogen on any client component and use the syntax described by the [underlying Helmet library](https://github.com/nfl/react-helmet):
 
-{% codeblock file, filename: 'Product.client.jsx' %}
+{% codeblock file, filename: '/products/[handle].server.jsx' %}
 
 ```jsx
 // Import only client components.

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -1,26 +1,52 @@
-Hydrogen includes `<Seo>` client and server components. This guide describes how to customize the output of SEO-related tags in your Hydrogen client and server components.
+Hydrogen detects when a search engine crawls your shop and defaults to server-side rendering (SSR). This guide describes how to customize the output of SEO-related tags in your client and server components.
 
 ## How SEO works in Hydrogen
 
-The [Hydrogen starter template](/custom-storefronts/hydrogen/getting-started) provides a [`<DefaultSeo>`](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/components/DefaultSeo.server.jsx) server component that fetches your `shop.name` and `shop.description`. This component provides the default SEO values for every page on your website.
+Hydrogen includes a [`Seo`](/api/hydrogen/components/primitive/seo) client component that renders SEO information on a webpage. It also provides the following example SEO-related files in the [Hydrogen starter template](/custom-storefronts/hydrogen/getting-started):
 
-Hydrogen also includes a [`<Seo>`](/api/hydrogen/components/primitive/seo) client component that you can use to output the SEO-related tags in your document `head` and override the default values on the following pages:
+- [`DefaultSeo`](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/components/DefaultSeo.server.jsx): A server component that fetches the shop name and description and sets default values and templates for every page on a website
+
+- [`Sitemap.xml.server.jsx`](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx): A file that generates all products, collections, and pages URLs using the Storefront API
+
+- [`Robots.txt.server.jsx`](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/robots.txt.server.js): A file that sets default rules for which URLs can be crawled by search engines
+
+### `Seo` client component
+
+The [`Seo`](/api/hydrogen/components/primitive/seo) client component uses the Storefront API to generate the `<head>` tags that search engines look for. For example, [`Product.Seo`](/api/storefront/2022-01/objects/Product) is used to generate the `<head>` tags for the products page.
+
+You can customize the `<head>` tags at the route level:
 
 - [Default page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/components/DefaultSeo.server.jsx)
 - [Home page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/index.server.jsx)
+- [Pages page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/pages/[handle].server.jsx)
 - [Product page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/products/[handle].server.jsx)
 - [Collection page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/collections/[handle].server.jsx)
-- [Pages page](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/pages/[handle].server.jsx)
 
-### Imitating SEO robot behavior
+### `DefaultSeo` server component
 
-Hydrogen supports SEO by inspecting the `user-agent` for every request, and buffering the response to fully render it on server-side. To imitate the behaviour of a SEO robot and show the page content fully from server render for initial render, add the `?\_bot` query parameter at the end of the webpage's URL.
+The [`DefaultSeo`](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/components/DefaultSeo.server.jsx) server component fetches your shop name (`shop.name`) and description (`shop.description`). This component provides the default SEO values for every page on your website.
 
-## Client component examples
+You can override the default SEO values by passing in custom props:
+
+{% codeblock file, filename: '/products/[handle].server.jsx' %}
+
+```js
+const storeFrontData = {...};
+const customData = {
+  ...storeFrontData,
+  description: 'Custom product description',
+};
+
+<Seo type="product" data={customData} />
+```
+
+{% endcodeblock %}
+
+## Client component example
 
 The following example shows how to pass a `product` prop to the component to generate standard SEO-related tags for your product page:
 
-{% codeblock file %}
+{% codeblock file, filename: 'Product.client.jsx' %}
 
 ```jsx
 <Seo type="product" data={product} />
@@ -30,7 +56,7 @@ The following example shows how to pass a `product` prop to the component to gen
 
 If you want to add more custom `head` tags, then you can import `Helmet` from Hydrogen on any client component and use the syntax described by the [underlying Helmet library](https://github.com/nfl/react-helmet):
 
-{% codeblock file %}
+{% codeblock file, filename: 'Product.client.jsx' %}
 
 ```jsx
 // Import only client components.
@@ -47,7 +73,7 @@ return (
 
 {% endcodeblock %}
 
-## Server component examples
+## Server component example
 
 The following example shows how to include a catch-all SEO component (`<DefaultSeo>`) that queries and populates `<head>` tags as a server component:
 
@@ -80,11 +106,20 @@ export default function App({log, ...serverState}) {
 
 {% endcodeblock %}
 
+## Imitating SEO robot behavior
+
+Hydrogen supports SEO by inspecting the `user-agent` for every request, and buffering the response to fully render it on server-side.
+
+To imitate the behaviour of a SEO robot and show the page content fully from server render for initial render, add the `?\_bot` query parameter at the end of the webpage's URL.
+
 ## Limitations and considerations
 
 The following limitations and considerations apply to the [XML sitemap](https://github.com/Shopify/hydrogen/blob/main/examples/template-hydrogen-default/src/pages/sitemap.xml.server.jsx) that's included in the Hydrogen starter template:
 
-- The sitemap has a limit of 250 products, 250 collections, and 250 pages. You need to [paginate results](/api/usage/pagination-graphql) if your store has more than 250 resources. If your store has more resources than the limit, and you haven't customized the URLs of the resources, then we recommend using the Online Store version of the sitemap at `https://{store-domain}/sitemap.xml`.
+- The sitemap has a limit of 250 products, 250 collections, and 250 pages. You need to [paginate results](/api/usage/pagination-graphql) if your store has more than 250 resources.
+
+    > Tip:
+    > If your store has more resources than the limit, and you haven't customized the URLs of the resources, then we recommend using the Online Store version of the sitemap at `https://{store-domain}/sitemap.xml`.
 
 - When you add or remove pages, the sitemap is automatically updated within one day. Similarly, if you unpublish a product, then the product is removed automatically from the sitemap.
 

--- a/packages/hydrogen/src/framework/docs/seo.md
+++ b/packages/hydrogen/src/framework/docs/seo.md
@@ -118,8 +118,8 @@ The following limitations and considerations apply to the [XML sitemap](https://
 
 - The sitemap has a limit of 250 products, 250 collections, and 250 pages. You need to [paginate results](/api/usage/pagination-graphql) if your store has more than 250 resources.
 
-    > Tip:
-    > If your store has more resources than the limit, and you haven't customized the URLs of the resources, then we recommend using the Online Store version of the sitemap at `https://{store-domain}/sitemap.xml`.
+  > Tip:
+  > If your store has more resources than the limit, and you haven't customized the URLs of the resources, then we recommend using the Online Store version of the sitemap at `https://{store-domain}/sitemap.xml`.
 
 - When you add or remove pages, the sitemap is automatically updated within one day. Similarly, if you unpublish a product, then the product is removed automatically from the sitemap.
 


### PR DESCRIPTION
## This PR: 
- Adds some more context about how SEO works in Hydrogen, including the available example files in the Hydrogen starter template that provide helpful defaults / starting points
- Relates to https://github.com/Shopify/shopify-dev/pull/16194 and [Dave Yen's presentation](https://docs.google.com/presentation/d/1NELO7sMvF7iceP_6so4yUjUPd1wj657nBDC64wuNXk0/edit#slide=id.g113c9786914_0_65)

### Tophatted in Shopify.dev

![screencapture-shopify-dev-myshopify-io-custom-storefronts-hydrogen-framework-seo-2022-02-17-18_11_22](https://user-images.githubusercontent.com/65373971/154604716-8d80d21b-f460-4599-9bca-d89fb0449167.png)

