### PR TITLE
fix: override turbo cache when running CI build

### DIFF
--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -1,6 +1,8 @@
 name: Tests and Lint
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -29,7 +31,7 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-engines --network-timeout 36000
 
       - name: Build the code
-        run: yarn build
+        run: yarn build --force
 
       - name: Check formatting
         run: yarn format:check

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -43,8 +43,8 @@ export function AddToCartButton<TTag extends React.ElementType = 'button'>(
   const variantId =
     explicitVariantId ??
     product?.selectedVariant?.id ??
-    product?.variants.find((variant) => variant.availableForSale)?.id ??
-    product?.variants[0]?.id ??
+    product?.variants?.find((variant) => variant.availableForSale)?.id ??
+    product?.variants?.[0]?.id ??
     '';
   const disabled =
     explicitVariantId === null ||

--- a/shipit.experimental.yml
+++ b/shipit.experimental.yml
@@ -1,7 +1,7 @@
 deploy:
   override:
     - >-
-      yarn workspace @shopify/hydrogen build &&
+      yarn workspace @shopify/hydrogen build --force &&
       git diff &&
       node_modules/.bin/lerna publish from-package
       --no-git-tag-version

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,7 +1,7 @@
 deploy:
   override:
     - >-
-      yarn workspace @shopify/hydrogen build &&
+      yarn workspace @shopify/hydrogen build --force &&
       git diff &&
       node_modules/.bin/lerna publish from-package
       --no-git-tag-version


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We're cachin' on GitHub Actions since we have fancy Turbo #383. This isn't ideal, though, because we happen to use `tsc` to catch type errors. And if there's a cache hit, we potentially miss errors on CI runs.

This also ensures we're running CI on `main`.

Finally, it fixes a TS bug we did not catch due to aforementioned caching.

_I am sorry_.