### PR TITLE
feat(rc): add variantId prop to ProductMetafield component

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -139,6 +139,7 @@ function SomeComponent() {
 - fix: backticks in HTML break RSC hydration.
 - feat [breaking change]: Helmet component has been renamed to Head
 - feat: enable early hydration when streaming
+- feat: add variantId prop to `<ProductMetafield />` component
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
+++ b/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
@@ -15,7 +15,7 @@ export interface ProductMetafieldProps
    * product's metafield.
    */
   namespace: string;
-  /** If provided, use this variant's metafield corresponding to this Id instead of the product's metafield. */
+  /** The ID of the variant. If provided, then use the metafield corresponding to the variant ID instead of the product's metafield. */
   variantId?: string;
 }
 

--- a/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
+++ b/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
@@ -3,6 +3,7 @@ import {Metafield} from '../Metafield';
 import {useProduct} from '../../hooks/useProduct/useProduct';
 import {Props} from '../types';
 import {MetafieldProps} from '../Metafield/Metafield.client';
+import {flattenConnection} from '../../utilities';
 
 export interface ProductMetafieldProps
   extends Omit<MetafieldProps, 'metafield'> {
@@ -14,6 +15,8 @@ export interface ProductMetafieldProps
    * product's metafield.
    */
   namespace: string;
+  /** If provided, use this variant's metafield corresponding to this Id instead of the product's metafield. */
+  variantId?: string;
 }
 
 /**
@@ -22,7 +25,7 @@ export interface ProductMetafieldProps
  * It must be a descendent of a `ProductProvider` component.
  */
 export function ProductMetafield<TTag extends ElementType>(
-  props: Props<TTag> & ProductMetafieldProps
+  props: Props<TTag> & Omit<ProductMetafieldProps, 'data'>
 ) {
   const product = useProduct();
 
@@ -35,17 +38,38 @@ export function ProductMetafield<TTag extends ElementType>(
     return null;
   }
 
-  const {namespace, keyName, ...passthroughProps} = props;
+  const {namespace, keyName, variantId, ...passthroughProps} = props;
 
-  const field = product.metafields.find(
+  const metafields = variantId
+    ? flattenConnection(
+        product.variants?.find(({id}) => id === variantId)?.metafields ?? {}
+      )
+    : product.metafields;
+
+  const field = metafields?.find(
     (metafield) =>
       metafield.namespace === namespace && metafield.key === keyName
   );
 
   if (field === null || field === undefined) {
+    const message = 'does not have a value for metafield.';
+    const productOrVariant = variantId ? `Variant` : 'Product';
+
+    const logItems = {
+      variantId: variantId,
+      ProductId: product.id,
+      namespace,
+      keyName,
+    };
+
     console.warn(
-      `Product does not have a value for metafield. ProductID:${product.id} namespace:${namespace} keyName:${keyName}`
+      [
+        productOrVariant,
+        message,
+        ...Object.entries(logItems).map(([key, val]) => `${key}: ${val}`),
+      ].join(' ')
     );
+
     return null;
   }
 

--- a/packages/hydrogen/src/components/ProductMetafield/tests/ProductMetafield.test.tsx
+++ b/packages/hydrogen/src/components/ProductMetafield/tests/ProductMetafield.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {getProduct, getVariant} from '../../../utilities/tests/product';
+import {getRawMetafield} from '../../../utilities/tests/metafields';
+import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
+import {ProductProvider} from '../../ProductProvider';
+import {ProductMetafield} from '../ProductMetafield.client';
+import {Metafield} from '../../Metafield';
+
+describe('<ProductMetafield/>', () => {
+  it('renders <Metafield /> and passes the product’s metafield data as the data prop', () => {
+    const metafield = getRawMetafield({
+      key: 'some_string',
+      namespace: 'my_fields',
+      type: 'single_line_text_field' as const,
+      value: 'my value string',
+    });
+    const product = getProduct({
+      metafields: {
+        edges: [{node: metafield as any}],
+      },
+    });
+    const wrapper = mountWithProviders(
+      <ProductProvider data={product} initialVariantId="">
+        <ProductMetafield
+          namespace={metafield.namespace}
+          keyName={metafield.key}
+        />
+      </ProductProvider>
+    );
+
+    expect(wrapper).toContainReactComponent(Metafield, {
+      data: expect.objectContaining(metafield),
+    });
+  });
+
+  it('renders <Metafield /> and passes the variant’s metafield data as the data prop when a variantId is provided', () => {
+    const variantId = '123';
+    const metafield = getRawMetafield({
+      key: 'some_string',
+      namespace: 'my_fields',
+      type: 'single_line_text_field' as const,
+      value: 'my value string',
+    });
+    const variant = getVariant({
+      id: variantId,
+      metafields: {
+        edges: [{node: metafield}],
+      } as any,
+    });
+    const product = getProduct({variants: {edges: [{node: variant as any}]}});
+    const wrapper = mountWithProviders(
+      <ProductProvider data={product} initialVariantId="">
+        <ProductMetafield
+          namespace={metafield.namespace}
+          keyName={metafield.key}
+          variantId={variantId}
+        />
+      </ProductProvider>
+    );
+
+    expect(wrapper).toContainReactComponent(Metafield, {
+      data: expect.objectContaining(metafield),
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#592 

Adds a `variantId` prop to the `<ProductMetafield  />` component. This will be used to deprecate/remove the `<SelectedVariantMetafield />` component.

### Additional context

There were no tests for this component previously, but I added a few here.

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
