### PR TITLE
test: fix flaky tests for HMR

### DIFF
--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -291,20 +291,16 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
       const newButtonText = 'add';
 
       await page.goto(getServerUrl() + '/about');
-      await untilUpdated(() => page.textContent('button'), 'increase');
+
       await edit(
         fullPath,
         (code) => code.replace('increase count', newButtonText),
-        async () =>
-          await untilUpdated(() => page.textContent('button'), newButtonText)
+        () => untilUpdated(() => page.textContent('button'), 'increase'),
+        () => untilUpdated(() => page.textContent('button'), newButtonText)
       );
     });
 
-    // TODO: This test is flaky in CI. It's not clear why, but this is what we know:
-    //  - Any test after we use the edit/untilUpdated combo will fail
-    //  - In other words, this test will pass if we put it before the previous one
-    //  - If we do the previous point, the last test will fail instead
-    it.skip('updates the contents when a server component file changes', async () => {
+    it('updates the contents when a server component file changes', async () => {
       if (isBuild) {
         return;
       }
@@ -314,12 +310,11 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
 
       await page.goto(getServerUrl());
 
-      await untilUpdated(() => page.textContent('h1'), 'Home');
-
       await edit(
         fullPath,
         (code) => code.replace('<h1>Home', `<h1>${newheading}`),
-        async () => await untilUpdated(() => page.textContent('h1'), newheading)
+        () => untilUpdated(() => page.textContent('h1'), 'Home'),
+        () => untilUpdated(() => page.textContent('h1'), newheading)
       );
     });
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Related to this comment in code:

>    // TODO: This test is flaky in CI. It's not clear why, but this is what we know:
    //  - Any test after we use the edit/untilUpdated combo will fail
    //  - In other words, this test will pass if we put it before the previous one
    //  - If we do the previous point, the last test will fail instead

Also, we are getting [random e2e errors on CI](https://github.com/Shopify/hydrogen/runs/5276151153?check_suite_focus=true) `You are trying to "import" a file after the Jest environment has been torn down`.

I've run the CI twice to ensure the random error doesn't show up in any of the 4 environments.

<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
