### PR TITLE
feat: enable early hydration when streaming

### DIFF
--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -138,6 +138,7 @@ function SomeComponent() {
 - dx [breaking change]: remove the `<SelectedVariantImage />` component in favour of using `<Image data={product.selectedVariant.image} />`
 - fix: backticks in HTML break RSC hydration.
 - feat [breaking change]: Helmet component has been renamed to Head
+- feat: enable early hydration when streaming
 
 ## 0.10.1 - 2022-01-26
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -41,7 +41,7 @@ import {
   bufferReadableStream,
 } from './streaming.server';
 import {RSC_PATHNAME} from './constants';
-import {getScriptsFromTemplate} from './utilities/template';
+import {stripScriptsFromTemplate} from './utilities/template';
 
 declare global {
   // This is provided by a Vite plugin
@@ -253,6 +253,9 @@ async function stream(
   const state = {pathname: url.pathname, search: url.search};
   log.trace('start stream');
 
+  const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
+    stripScriptsFromTemplate(template);
+
   const {AppSSR, rscReadable} = buildAppSSR(
     {
       App,
@@ -263,7 +266,7 @@ async function stream(
       pages,
     },
     {
-      template,
+      template: noScriptTemplate,
       htmlAttrs: {lang: 'en'},
     }
   );
@@ -283,8 +286,6 @@ async function stream(
       });
     },
   });
-
-  const {bootstrapScripts, bootstrapModules} = getScriptsFromTemplate(template);
 
   let didError: Error | undefined;
 

--- a/packages/hydrogen/src/framework/Hydration/Html.tsx
+++ b/packages/hydrogen/src/framework/Hydration/Html.tsx
@@ -9,7 +9,17 @@ type HtmlOptions = {
 };
 
 export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
-  const head = template.match(/<head>(.+?)<\/head>/s)![1] || '';
+  let head = template.match(/<head>(.+?)<\/head>/s)![1] || '';
+
+  // @ts-ignore
+  if (import.meta.env.DEV) {
+    // Fix React Refresh for async scripts.
+    // https://github.com/vitejs/vite/issues/6759
+    head = head.replace(
+      />(\s*?import[\s\w]+?['"]\/@react-refresh)/,
+      ' async="">$1'
+    );
+  }
 
   return (
     <html {...htmlAttrs}>

--- a/packages/hydrogen/src/framework/Hydration/Html.tsx
+++ b/packages/hydrogen/src/framework/Hydration/Html.tsx
@@ -11,30 +11,11 @@ type HtmlOptions = {
 export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
   const head = template.match(/<head>(.+?)<\/head>/s)![1] || '';
 
-  let devEntryPoint = '';
-
-  // @ts-ignore
-  if (import.meta.env.DEV) {
-    devEntryPoint =
-      template
-        .substring(template.lastIndexOf('<script type="module"'))
-        .match(/src="(.*?)">/i)?.[1] || '';
-
-    if (!devEntryPoint) {
-      throw new Error('Could not find entry-client module in index.html');
-    }
-  }
-
   return (
     <html {...htmlAttrs}>
       <head dangerouslySetInnerHTML={{__html: head}} />
       <body {...bodyAttrs}>
         <div id="root">{children}</div>
-        {/* In production, Vite bundles the entrypoint JS inside <head> */}
-        {/* @ts-ignore because module=commonjs doesn't allow this */}
-        {import.meta.env.DEV && (
-          <script type="module" src={devEntryPoint}></script>
-        )}
       </body>
     </html>
   );

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydration-auto-import.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydration-auto-import.ts
@@ -14,7 +14,8 @@ export default () => {
     },
     resolveId(id, importer) {
       if (
-        /^\/?@shopify\/hydrogen\/entry-client$/.test(id) &&
+        (/^\/?@shopify\/hydrogen\/entry-client$/.test(id) ||
+          id.endsWith(path.sep + HYDROGEN_ENTRY_FILE)) &&
         normalizePath(importer || '').endsWith('/index.html')
       ) {
         // Make this virtual import look like a local project file

--- a/packages/hydrogen/src/streaming.server.ts
+++ b/packages/hydrogen/src/streaming.server.ts
@@ -8,6 +8,7 @@ import {
 import {renderToReadableStream as _rscRenderToReadableStream} from '@shopify/hydrogen/vendor/react-server-dom-vite/writer.browser.server';
 // @ts-ignore
 import {createFromReadableStream as _createFromReadableStream} from '@shopify/hydrogen/vendor/react-server-dom-vite';
+import type {Writable} from 'stream';
 
 export const rscRenderToReadableStream = _rscRenderToReadableStream as (
   App: JSX.Element
@@ -19,15 +20,23 @@ export const createFromReadableStream = _createFromReadableStream as (
   readRoot: () => JSX.Element;
 };
 
-export const ssrRenderToPipeableStream = _ssrRenderToPipeableStream;
+type StreamOptions = {
+  nonce?: string;
+  onCompleteShell?: () => void;
+  onCompleteAll?: () => void;
+  onError?: (error: Error) => void;
+  bootstrapScripts?: string[];
+  bootstrapModules?: string[];
+};
+
+export const ssrRenderToPipeableStream = _ssrRenderToPipeableStream as (
+  App: JSX.Element,
+  options: StreamOptions
+) => {pipe: Writable['pipe']};
+
 export const ssrRenderToReadableStream = _ssrRenderToReadableStream as (
   App: JSX.Element,
-  options: {
-    nonce?: string;
-    onCompleteShell?: () => void;
-    onCompleteAll?: () => void;
-    onError?: (error: Error) => void;
-  }
+  options: StreamOptions
 ) => ReadableStream<Uint8Array>;
 
 export function supportsReadableStream() {

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -13,7 +13,7 @@ export function getScriptsFromTemplate(template: string): {
 
   if (body) {
     const scripts = body.matchAll(
-      /<script.+?src="(?<script>([\\/\w-_\.]+?))".*?><\/script>/g
+      /<script.+?src="(?<script>([^"]+?))".*?><\/script>/g
     );
 
     for (const match of scripts) {

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -1,0 +1,33 @@
+/**
+ * Strip out script `src` values from <script> tags in a given HTML template.
+ * Returns two lists of scripts, split based on whether they are `type="module"`.
+ */
+export function getScriptsFromTemplate(template: string): {
+  bootstrapScripts: string[];
+  bootstrapModules: string[];
+} {
+  const bootstrapScripts = [] as string[];
+  const bootstrapModules = [] as string[];
+
+  const body = template.match(/<body>(.+)<\/body>/s)?.[1];
+
+  if (body) {
+    const scripts = body.matchAll(
+      /<script.+?src="(?<script>([\\/\w-_\.]+?))".*?><\/script>/g
+    );
+
+    for (const match of scripts) {
+      const scriptName = match.groups?.script;
+
+      if (!scriptName) continue;
+
+      if (match[0].includes(`type="module"`)) {
+        bootstrapModules.push(scriptName);
+      } else {
+        bootstrapScripts.push(scriptName);
+      }
+    }
+  }
+
+  return {bootstrapScripts, bootstrapModules};
+}

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -2,32 +2,27 @@
  * Strip out script `src` values from <script> tags in a given HTML template.
  * Returns two lists of scripts, split based on whether they are `type="module"`.
  */
-export function getScriptsFromTemplate(template: string): {
-  bootstrapScripts: string[];
-  bootstrapModules: string[];
-} {
+export function stripScriptsFromTemplate(template: string) {
   const bootstrapScripts = [] as string[];
   const bootstrapModules = [] as string[];
 
-  const body = template.match(/<body>(.+)<\/body>/s)?.[1];
+  const scripts = template.matchAll(
+    /<script.+?src="(?<script>([^"]+?))".*?><\/script>/g
+  );
 
-  if (body) {
-    const scripts = body.matchAll(
-      /<script.+?src="(?<script>([^"]+?))".*?><\/script>/g
-    );
+  for (const match of scripts) {
+    const scriptName = match.groups?.script;
 
-    for (const match of scripts) {
-      const scriptName = match.groups?.script;
+    if (!scriptName) continue;
 
-      if (!scriptName) continue;
-
-      if (match[0].includes(`type="module"`)) {
-        bootstrapModules.push(scriptName);
-      } else {
-        bootstrapScripts.push(scriptName);
-      }
+    if (match[0].includes(`type="module"`)) {
+      bootstrapModules.push(scriptName);
+    } else {
+      bootstrapScripts.push(scriptName);
     }
+
+    template = template.replace(match[0], '');
   }
 
-  return {bootstrapScripts, bootstrapModules};
+  return {noScriptTemplate: template, bootstrapScripts, bootstrapModules};
 }

--- a/packages/hydrogen/src/utilities/tests/template.test.ts
+++ b/packages/hydrogen/src/utilities/tests/template.test.ts
@@ -1,15 +1,19 @@
-import {getScriptsFromTemplate} from '../template';
+import {stripScriptsFromTemplate} from '../template';
 
 describe('getScriptsFromTemplate', () => {
   it('identifies scripts and modules in a template', () => {
-    const template = `<html><body>
+    const template = `<html><head>
       <script src="/foo.js"></script>
+    </head>
+    <body>
       <script src="/bar.js"></script>
       <script src="/module.js" type="module"></script>
     </body></html>`;
 
-    const {bootstrapScripts, bootstrapModules} =
-      getScriptsFromTemplate(template);
+    const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
+      stripScriptsFromTemplate(template);
+
+    expect(noScriptTemplate).not.toMatch('<script');
 
     expect(bootstrapScripts).toHaveLength(2);
     expect(bootstrapScripts[0]).toBe('/foo.js');
@@ -23,9 +27,10 @@ describe('getScriptsFromTemplate', () => {
       <script type="module" src="/src/entry-client.tsx"></script>
     </body></html>`;
 
-    const {bootstrapScripts, bootstrapModules} =
-      getScriptsFromTemplate(template);
+    const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
+      stripScriptsFromTemplate(template);
 
+    expect(noScriptTemplate).not.toMatch('<script');
     expect(bootstrapScripts).toHaveLength(0);
     expect(bootstrapModules).toHaveLength(1);
     expect(bootstrapModules[0]).toBe('/src/entry-client.tsx');
@@ -34,9 +39,10 @@ describe('getScriptsFromTemplate', () => {
   it('does not crash if no script tags', () => {
     const template = `<html><body></body></html>`;
 
-    const {bootstrapScripts, bootstrapModules} =
-      getScriptsFromTemplate(template);
+    const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
+      stripScriptsFromTemplate(template);
 
+    expect(noScriptTemplate).not.toMatch('<script');
     expect(bootstrapScripts).toHaveLength(0);
     expect(bootstrapModules).toHaveLength(0);
   });

--- a/packages/hydrogen/src/utilities/tests/template.test.ts
+++ b/packages/hydrogen/src/utilities/tests/template.test.ts
@@ -1,0 +1,43 @@
+import {getScriptsFromTemplate} from '../template';
+
+describe('getScriptsFromTemplate', () => {
+  it('identifies scripts and modules in a template', () => {
+    const template = `<html><body>
+      <script src="/foo.js"></script>
+      <script src="/bar.js"></script>
+      <script src="/module.js" type="module"></script>
+    </body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(2);
+    expect(bootstrapScripts[0]).toBe('/foo.js');
+
+    expect(bootstrapModules).toHaveLength(1);
+    expect(bootstrapModules[0]).toBe('/module.js');
+  });
+
+  it('identifies varying orders of attributes in script tags', () => {
+    const template = `<html><body>
+      <script type="module" src="/src/entry-client.tsx"></script>
+    </body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(0);
+    expect(bootstrapModules).toHaveLength(1);
+    expect(bootstrapModules[0]).toBe('/src/entry-client.tsx');
+  });
+
+  it('does not crash if no script tags', () => {
+    const template = `<html><body></body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      getScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(0);
+    expect(bootstrapModules).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Continues vitejs/vite#612 but focusing on early hydration (the original issue addressed in that PR is already fixed).

This enables early hydration using `bootstrapModules` and `bootstrapScripts` options from React 18 (in both dev and prod).

Questions:
- Should we do this also for bots (in `render`)?
- This currently grabs all the scripts in `index.html` and pushes them early in the streaming. Should we filter only those that are `/assets/*` or something similar? -- Script tags with comments inside won't be pushed early so that's a (dirty) escape hatch.

---

### Before submitting the PR, please make sure you do the following:

- [x] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`)
- [ ] Update docs in this repository for your change, if needed
