### PR TITLE
fix: add to cart tests

### DIFF
--- a/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
@@ -68,7 +68,7 @@ describe('AddToCartButton', () => {
         const id = '123';
         const component = mountWithCartProvider(
           <AddToCartButton variantId={id}>Add to cart</AddToCartButton>,
-          {linesAdd: mockLinesAdd}
+          {linesAdd: mockLinesAdd, cart: {id: '456'}}
         );
         component.find('button')?.trigger('onClick');
 
@@ -118,7 +118,7 @@ describe('AddToCartButton', () => {
             >
               <AddToCartButton>Add to cart</AddToCartButton>
             </ProductProvider>,
-            {linesAdd: mockLinesAdd}
+            {linesAdd: mockLinesAdd, cart: {id: '456'}}
           );
 
           component.find('button')?.trigger('onClick');
@@ -183,7 +183,7 @@ describe('AddToCartButton', () => {
             <ProductProvider data={product}>
               <AddToCartButton>Add to cart</AddToCartButton>
             </ProductProvider>,
-            {linesAdd: mockLinesAdd}
+            {linesAdd: mockLinesAdd, cart: {id: '456'}}
           );
 
           component.find('button')?.trigger('onClick');
@@ -250,7 +250,7 @@ describe('AddToCartButton', () => {
           });
         });
 
-        it.only('calls createCart with the first variant when non are available', () => {
+        it('calls createCart with the first variant when non are available', () => {
           const mockCreateCart = jest.fn();
           const product = getProduct({
             variants: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes up a few mistakes with these tests:

- Removes a `only` on an AddToCart test that was accidentally left in.
- Provides a `cart.id` for the tests that require it for testing the `linesAdd` method

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
