### PR TITLE
chore: skip changelog updates on prereleases

### DIFF
--- a/scripts/update-changelogs-on-version.js
+++ b/scripts/update-changelogs-on-version.js
@@ -63,6 +63,13 @@ function updateChangelogForPackage(packageLocation) {
   const newVersion = JSON.parse(readFileSync(packageJsonPath)).version;
   const changelogContent = readFileSync(changelogPath, 'utf8');
 
+  if (newVersion.includes('-')) {
+    console.log(
+      `- ${relativeChangelogPath}: Skipping as ${newVersion} is a prerelease`
+    );
+    return '';
+  }
+
   if (changelogContent.includes(`\n## ${newVersion}`)) {
     console.log(
       `- ${relativeChangelogPath}: Skipping as ${newVersion} header is already present`


### PR DESCRIPTION
I had originally removed this logic @cartogram added, because back then our release strategy was going to be a long-running experimental branch. 

We've since shifted to releasing "stable" releases during dev preview on `v0.x`, but we want to issue experimental releases occasionally to smoke test. We don't want to munge the changelog each time we issue an experimental release, though.