### PR TITLE
[Hydrogen docs]: Adding missing props to `ProductPrice` and `ProductMetafield`

### DIFF
--- a/packages/hydrogen/src/components/ProductMetafield/README.md
+++ b/packages/hydrogen/src/components/ProductMetafield/README.md
@@ -20,10 +20,11 @@ export function Product({product}) {
 
 ## Props
 
-| Name      | Type                | Description                                                                                                               |
-| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| keyName   | <code>string</code> | A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the product's metafield.       |
-| namespace | <code>string</code> | A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the product's metafield. |
+| Name       | Type                | Description                                                                                                                    |
+| ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| keyName    | <code>string</code> | A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the product's metafield.            |
+| namespace  | <code>string</code> | A string corresponding to the [namespace](/api/storefront/reference/common-objects/metafield) of the product's metafield.      |
+| variantId? | <code>string</code> | The ID of the variant. If provided, then use the metafield corresponding to the variant ID instead of the product's metafield. |
 
 ## Component type
 

--- a/packages/hydrogen/src/components/ProductPrice/README.md
+++ b/packages/hydrogen/src/components/ProductPrice/README.md
@@ -19,10 +19,11 @@ export function Product({product}) {
 
 ## Props
 
-| Name       | Type                                      | Description                                                          |
-| ---------- | ----------------------------------------- | -------------------------------------------------------------------- |
-| priceType? | <code>"regular" &#124; "compareAt"</code> | The type of price. Valid values: `regular` (default) or `compareAt`. |
-| valueType? | <code>"max" &#124; "min"</code>           | The type of value. Valid values: `min` (default) or `max`.           |
+| Name       | Type                                          | Description                                                          |
+| ---------- | --------------------------------------------- | -------------------------------------------------------------------- |
+| priceType? | <code>"regular" &#124; "compareAt"</code>     | The type of price. Valid values: `regular` (default) or `compareAt`. |
+| valueType? | <code>"max" &#124; "min" &#124; "unit"</code> | The type of value. Valid values: `min` (default), `max`, or `unit`.  |
+| variantId? | <code>string</code>                           | The ID of the variant.                                               |
 
 ## Component type
 


### PR DESCRIPTION
## This PR: 
- Adds some missing props to the READMEs for `ProductPrice` and `ProductMetafield`
- Relates to https://github.com/Shopify/hydrogen/pull/728 and https://github.com/Shopify/hydrogen/pull/730