### PR TITLE
feat: Update MediaFile component to allow more props

### DIFF
--- a/examples/template-hydrogen-default/src/components/Gallery.client.jsx
+++ b/examples/template-hydrogen-default/src/components/Gallery.client.jsx
@@ -47,8 +47,10 @@ export default function Gallery() {
             className="w-[80vw] md:w-auto h-full md:h-auto object-cover object-center transition-all snap-start border border-gray-200 flex-shrink-0 rounded-lg"
             data={med}
             options={{
-              height: '485',
-              crop: 'center',
+              image: {
+                height: '485',
+                crop: 'center',
+              },
             }}
             {...extraProps}
           />

--- a/packages/hydrogen/src/components/ExternalVideo/ExternalVideo.tsx
+++ b/packages/hydrogen/src/components/ExternalVideo/ExternalVideo.tsx
@@ -18,12 +18,20 @@ export interface ExternalVideoProps {
 
 type PropsWeControl = 'src';
 
+type ExternalVideoComponentProps<TTag extends React.ElementType = 'iframe'> =
+  Props<TTag, PropsWeControl> & ExternalVideoProps;
+
+export type ExternalVideoComponentPassthroughProps = Omit<
+  ExternalVideoComponentProps,
+  PropsWeControl | 'data' | 'options'
+>;
+
 /**
  * The `ExternalVideo` component renders an embedded video for the Storefront
  * API's [`ExternalVideo` object](/api/storefront/reference/products/externalvideo).
  */
 export function ExternalVideo<TTag extends React.ElementType = 'iframe'>(
-  props: Props<TTag, PropsWeControl> & ExternalVideoProps
+  props: ExternalVideoComponentProps<TTag>
 ) {
   const {
     data,

--- a/packages/hydrogen/src/components/ExternalVideo/index.ts
+++ b/packages/hydrogen/src/components/ExternalVideo/index.ts
@@ -1,5 +1,6 @@
 export {
   ExternalVideo,
-  ExternalVideoProps,
+  type ExternalVideoProps,
   ExternalVideoFragment,
+  type ExternalVideoComponentPassthroughProps,
 } from './ExternalVideo';

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -24,18 +24,18 @@ export interface MediaImageProps extends BaseImageProps {
   /** An object with the keys `url`, `altText`, `id`, `width` and `height`. Refer to the
    * Storefront API's [`Image` object](/api/storefront/reference/common-objects/image).
    */
-  data: Pick<ImageType, 'altText' | 'url' | 'id' | 'width' | 'height'>;
+  data: Omit<ImageType, 'originalSrc' | 'src' | 'transformedSrc'>;
   /** An object of image size options for Shopify CDN images. */
   options?: ImageSizeOptions;
 }
 
 export interface ExternalImageProps extends BaseImageProps {
   /** A URL string. This string can be an absolute path or a relative path depending on the `loader`. */
-  src: string;
+  src: HTMLImageElement['src'];
   /** The integer value for the width of the image. This is a required prop when `src` is present. */
-  width: number;
+  width: HTMLImageElement['width'];
   /** The integer value for the height of the image. This is a required prop when `src` is present. */
-  height: number;
+  height: HTMLImageElement['height'];
 }
 
 export type ImageProps = MediaImageProps | ExternalImageProps;
@@ -63,12 +63,23 @@ function convertShopifyImageData({
   };
 }
 
+type ImageComponentProps<TTag extends React.ElementType = 'img'> = Props<
+  TTag,
+  PropsWeControl
+> &
+  ImageProps;
+
+export type ImageComponentPassthroughProps = Omit<
+  ImageComponentProps,
+  keyof ImageProps | PropsWeControl
+>;
+
 /**
  * The `Image` component renders an image for the Storefront API's
  * [`Image` object](/api/storefront/reference/common-objects/image).
  */
 export function Image<TTag extends React.ElementType = 'img'>(
-  props: Props<TTag, PropsWeControl> & ImageProps
+  props: ImageComponentProps<TTag>
 ) {
   const {
     data,

--- a/packages/hydrogen/src/components/Image/index.ts
+++ b/packages/hydrogen/src/components/Image/index.ts
@@ -1,1 +1,7 @@
-export {Image, ImageProps, ImageFragment, MediaImageProps} from './Image';
+export {
+  Image,
+  type ImageProps,
+  ImageFragment,
+  type MediaImageProps,
+  type ImageComponentPassthroughProps,
+} from './Image';

--- a/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
+++ b/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
@@ -1,13 +1,28 @@
 import * as React from 'react';
-import {Image, MediaImageProps} from '../Image';
-import {Video, VideoProps} from '../Video';
-import {ExternalVideo, ExternalVideoProps} from '../ExternalVideo';
-import {ModelViewer, ModelViewerProps} from '../ModelViewer';
+import {
+  Image,
+  type MediaImageProps,
+  type ImageComponentPassthroughProps,
+} from '../Image';
+import {
+  Video,
+  type VideoProps,
+  type VideoComponentPassthroughProps,
+} from '../Video';
+import {
+  ExternalVideo,
+  type ExternalVideoProps,
+  type ExternalVideoComponentPassthroughProps,
+} from '../ExternalVideo';
+import {
+  ModelViewer,
+  type ModelViewerProps,
+  type ModelViewerComponentPassthroughProps,
+} from '../ModelViewer';
 import {MediaFileFragment as Fragment} from '../../graphql/graphql-constants';
 import {Media as MediaType} from '../../graphql/types/types';
 
 export type Media = Pick<MediaType, 'mediaContentType'>;
-
 type MediaImageMedia = Media & {image: MediaImageProps['data']};
 type ModelViewerMedia = Media & ModelViewerProps['data'];
 type ExternalVideoMedia = Media & ExternalVideoProps['data'];
@@ -15,9 +30,24 @@ type VideoMedia = Media & VideoProps['data'];
 
 export interface MediaFileProps {
   /** A [Media object](/api/storefront/reference/products/media). */
-  data: MediaImageMedia | ModelViewerMedia | ExternalVideoMedia | VideoMedia;
+  data: MediaImageMedia | VideoMedia | ExternalVideoMedia | ModelViewerMedia;
   /** The options for the `Image`, `Video`, `ExternalVideo`, or `ModelViewer` components. */
-  options?: VideoProps['options'] | ExternalVideoProps['options'];
+  options?: {
+    image?: MediaImageProps['options'];
+    video?: VideoProps['options'];
+    externalVideo?: ExternalVideoProps['options'] & {
+      width?: HTMLIFrameElement['width'];
+      height?: HTMLIFrameElement['height'];
+    };
+    modelViewer: never;
+  };
+  /** Props that are passed directly to the HTML element that is rendered by the components */
+  passthroughProps?: {
+    image?: ImageComponentPassthroughProps;
+    video?: VideoComponentPassthroughProps;
+    externalVideo?: ExternalVideoComponentPassthroughProps;
+    modelViewer?: ModelViewerComponentPassthroughProps;
+  };
 }
 
 /**
@@ -29,37 +59,45 @@ export interface MediaFileProps {
 export function MediaFile({
   data,
   options,
-  ...passthroughProps
+  passthroughProps,
+  ...rest
 }: MediaFileProps) {
   switch (data.mediaContentType) {
     case 'IMAGE': {
       return (
         <Image
-          {...passthroughProps}
+          {...rest}
+          {...passthroughProps?.image}
           data={(data as MediaImageMedia).image}
-          options={options as MediaImageProps['options']}
+          options={options?.image}
         />
       );
     }
     case 'VIDEO':
       return (
         <Video
-          {...passthroughProps}
+          {...rest}
+          {...passthroughProps?.video}
           data={data as VideoMedia}
-          options={options as VideoProps['options']}
+          options={options?.video}
         />
       );
     case 'EXTERNAL_VIDEO':
       return (
         <ExternalVideo
-          {...passthroughProps}
+          {...rest}
+          {...passthroughProps?.externalVideo}
           data={data as ExternalVideoMedia}
-          options={options as ExternalVideoProps['options']}
+          options={options?.externalVideo}
         />
       );
     case 'MODEL_3D':
       return (
-        <ModelViewer {...passthroughProps} data={data as ModelViewerMedia} />
+        <ModelViewer
+          {...rest}
+          {...passthroughProps?.modelViewer}
+          data={data as ModelViewerMedia}
+        />
       );
     default:
       return null;

--- a/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
+++ b/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
@@ -141,12 +141,20 @@ declare global {
   }
 }
 
+type ModelViewerComponentProps<TTag extends ElementType = 'model-viewer'> =
+  Props<TTag, PropsWeControl> & ModelViewerProps;
+
+export type ModelViewerComponentPassthroughProps = Omit<
+  ModelViewerComponentProps,
+  PropsWeControl
+>;
+
 /**
  * The `ModelViewer` component renders a 3D model (with the `model-viewer` tag) for
  * the Storefront API's [`Model3d` object](/api/storefront/reference/products/model3d).
  */
-export function ModelViewer<TTag extends ElementType>(
-  props: Props<TTag, PropsWeControl> & ModelViewerProps
+export function ModelViewer<TTag extends ElementType = 'model-viewer'>(
+  props: ModelViewerComponentProps<TTag>
 ) {
   const [modelViewer, setModelViewer] = useState<undefined | HTMLElement>(
     undefined

--- a/packages/hydrogen/src/components/ModelViewer/index.ts
+++ b/packages/hydrogen/src/components/ModelViewer/index.ts
@@ -1,1 +1,5 @@
-export {ModelViewer, ModelViewerProps} from './ModelViewer.client';
+export {
+  ModelViewer,
+  type ModelViewerProps,
+  type ModelViewerComponentPassthroughProps,
+} from './ModelViewer.client';

--- a/packages/hydrogen/src/components/Video/Video.tsx
+++ b/packages/hydrogen/src/components/Video/Video.tsx
@@ -20,11 +20,19 @@ export interface VideoProps {
   options?: ImageSizeOptions;
 }
 
+type VideoComponentProps<TTag extends React.ElementType = 'video'> =
+  Props<TTag> & VideoProps;
+
+export type VideoComponentPassthroughProps = Omit<
+  VideoComponentProps,
+  'data' | 'options'
+>;
+
 /**
  * The `Video` component renders a `video` for the Storefront API's [`Video` object](/api/storefront/reference/products/video).
  */
 export function Video<TTag extends React.ElementType = 'video'>(
-  props: Props<TTag> & VideoProps
+  props: VideoComponentProps<TTag>
 ) {
   const {
     data,

--- a/packages/hydrogen/src/components/Video/index.ts
+++ b/packages/hydrogen/src/components/Video/index.ts
@@ -1,2 +1,2 @@
-export type {VideoProps} from './Video';
+export type {VideoProps, VideoComponentPassthroughProps} from './Video';
 export {Video, VideoFragment} from './Video';


### PR DESCRIPTION
BREAKING CHANGE:

The MediaFile component's 'options' prop now takes in unique options for each type of component it renders. It also takes in unique passthroughProps for each component type.

### Description

This is intended to close #686. 

### Additional context

Honestly, I don't know what I think about this solution. MediaFile trying to take in all the props for all the different components and be intelligent about them is pretty difficult. Especially trying to get the types correct for all these different scenarios. 

This also doesn't handle merging duplicate props together, such as `passthroughProps.image.className` with `className`. 

I don't know, I'm not sure how I feel about this. Thoughts?

---

### Before submitting the PR, please make sure you do the following:

- [ ] Add your change under the `Unreleased` heading in the package's `CHANGELOG.md`
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
