### PR TITLE
Fix issue with components that accept an 'as' prop

### DIFF
--- a/.changeset/cyan-beans-drive.md
+++ b/.changeset/cyan-beans-drive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix issue with components that take in the `as` prop not validating other props when a component is passed to `as`.

--- a/packages/hydrogen/src/components/CartLinePrice/CartLinePrice.client.tsx
+++ b/packages/hydrogen/src/components/CartLinePrice/CartLinePrice.client.tsx
@@ -3,7 +3,8 @@ import {useCartLine} from '../CartLineProvider';
 import {Money, MoneyProps} from '../Money';
 import {Props} from '../types';
 
-export interface CartLinePriceProps extends Omit<MoneyProps, 'data'> {
+export interface CartLinePriceProps<TTag>
+  extends Omit<MoneyProps<TTag>, 'data'> {
   /** The type of price. Valid values:`regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
 }
@@ -13,7 +14,7 @@ export interface CartLinePriceProps extends Omit<MoneyProps, 'data'> {
  * compare at price. It must be a descendent of a `CartLineProvider` component.
  */
 export function CartLinePrice<TTag extends ElementType>(
-  props: Props<TTag> & CartLinePriceProps
+  props: Props<TTag> & CartLinePriceProps<TTag>
 ) {
   const cartLine = useCartLine();
   const {priceType = 'regular', ...passthroughProps} = props;

--- a/packages/hydrogen/src/components/CartLineProductTitle/CartLineProductTitle.client.tsx
+++ b/packages/hydrogen/src/components/CartLineProductTitle/CartLineProductTitle.client.tsx
@@ -9,7 +9,7 @@ import {useCartLine} from '../CartLineProvider';
 export function CartLineProductTitle<TTag extends ElementType>(
   props: Props<TTag> & {
     /** An HTML tag to be rendered as the base element wrapper. The default is `span`.  */
-    as?: ElementType;
+    as?: TTag;
   }
 ) {
   const cartLine = useCartLine();

--- a/packages/hydrogen/src/components/CartLineProductTitle/tests/CartLineProductTitle.test.tsx
+++ b/packages/hydrogen/src/components/CartLineProductTitle/tests/CartLineProductTitle.test.tsx
@@ -3,27 +3,42 @@ import {mount} from '@shopify/react-testing';
 import {CartLineProvider} from '../../CartLineProvider';
 import {CartLineProductTitle} from '../CartLineProductTitle.client';
 import {CART_LINE} from '../../CartLineProvider/tests/fixtures';
+import {Link} from '../../Link/index';
 
-it('displays the title', () => {
-  const wrapper = mount(
-    <CartLineProvider line={CART_LINE}>
-      <CartLineProductTitle />
-    </CartLineProvider>
-  );
+describe(`<CartLineProductTitle/>`, () => {
+  it('displays the title', () => {
+    const wrapper = mount(
+      <CartLineProvider line={CART_LINE}>
+        <CartLineProductTitle />
+      </CartLineProvider>
+    );
 
-  expect(wrapper).toContainReactComponent('span', {
-    children: CART_LINE.merchandise.product.title,
+    expect(wrapper).toContainReactComponent('span', {
+      children: CART_LINE.merchandise.product.title,
+    });
   });
-});
 
-it('allows tag to be customized', () => {
-  const wrapper = mount(
-    <CartLineProvider line={CART_LINE}>
-      <CartLineProductTitle as="h2" />
-    </CartLineProvider>
-  );
+  it('allows tag to be customized', () => {
+    const wrapper = mount(
+      <CartLineProvider line={CART_LINE}>
+        <CartLineProductTitle as="h2" />
+      </CartLineProvider>
+    );
 
-  expect(wrapper).toContainReactComponent('h2', {
-    children: CART_LINE.merchandise.product.title,
+    expect(wrapper).toContainReactComponent('h2', {
+      children: CART_LINE.merchandise.product.title,
+    });
+  });
+
+  it(`validates props on components passed to the 'as' prop`, () => {
+    const wrapper = mount(
+      <CartLineProvider line={CART_LINE}>
+        <CartLineProductTitle as={Link} to="/test" />
+      </CartLineProvider>
+    );
+
+    expect(wrapper).toContainReactComponent(Link, {
+      to: '/test',
+    });
   });
 });

--- a/packages/hydrogen/src/components/CartLineQuantity/CartLineQuantity.client.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantity/CartLineQuantity.client.tsx
@@ -9,7 +9,7 @@ import {useCartLine} from '../CartLineProvider';
 export function CartLineQuantity<TTag extends ElementType>(
   props: Props<TTag> & {
     /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
-    as?: ElementType;
+    as?: TTag;
   }
 ) {
   const cartLine = useCartLine();

--- a/packages/hydrogen/src/components/CartLineQuantity/tests/CartLineQuantity.test.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantity/tests/CartLineQuantity.test.tsx
@@ -3,9 +3,10 @@ import {mount} from '@shopify/react-testing';
 import {CartLineProvider} from '../../CartLineProvider';
 import {CartLineQuantity} from '../CartLineQuantity.client';
 import {CART_LINE} from '../../CartLineProvider/tests/fixtures';
+import {Link} from '../../Link/index';
 
 describe('<CartLineQuantity />', () => {
-  it.skip('displays the quantity', () => {
+  it('displays the quantity', () => {
     const wrapper = mount(
       <CartLineProvider line={CART_LINE}>
         <CartLineQuantity />
@@ -17,7 +18,7 @@ describe('<CartLineQuantity />', () => {
     });
   });
 
-  it.skip('allows a custom tag', () => {
+  it('allows a custom tag', () => {
     const wrapper = mount(
       <CartLineProvider line={CART_LINE}>
         <CartLineQuantity as="p" />
@@ -26,6 +27,18 @@ describe('<CartLineQuantity />', () => {
 
     expect(wrapper).toContainReactComponent('p', {
       children: CART_LINE.quantity,
+    });
+  });
+
+  it(`validates props for a component passed to the 'as' prop`, () => {
+    const wrapper = mount(
+      <CartLineProvider line={CART_LINE}>
+        <CartLineQuantity as={Link} to="/test" />
+      </CartLineProvider>
+    );
+
+    expect(wrapper).toContainReactComponent(Link, {
+      to: '/test',
     });
   });
 });

--- a/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
+++ b/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
@@ -8,11 +8,11 @@ import {MetafieldFragment as Fragment} from '../../graphql/graphql-constants';
 import {Image} from '../Image';
 import {MediaImage} from '../../types';
 
-export interface MetafieldProps {
+export interface MetafieldProps<TTag> {
   /** A [Metafield object](/api/storefront/reference/common-objects/metafield) from the Storefront API. */
   data: ParsedMetafield;
   /** An HTML tag to be rendered as the base element wrapper. The default value varies depending on [metafield.type](/apps/metafields/types). */
-  as?: ElementType;
+  as?: TTag;
 }
 
 /**
@@ -23,7 +23,7 @@ export interface MetafieldProps {
  * Metafield's `value`. For more information, refer to the [Default Output](#default-output) section.
  */
 export function Metafield<TTag extends ElementType>(
-  props: Props<TTag> & MetafieldProps
+  props: Props<TTag> & MetafieldProps<TTag>
 ) {
   const {data, children, as, ...passthroughProps} = props;
   const {locale} = useShop();

--- a/packages/hydrogen/src/components/Metafield/components/StarRating/StarRating.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/StarRating.tsx
@@ -5,14 +5,14 @@ import {Rating} from '../../../../types';
 export const STAR_EMPTY = '☆';
 export const STAR_FILLED = '★';
 
-export interface StarRatingProps {
+export interface StarRatingProps<TTag> {
   rating: Rating;
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
-  as?: ElementType;
+  as?: TTag;
 }
 
 export function StarRating<TTag extends ElementType>(
-  props: Props<TTag> & StarRatingProps
+  props: Props<TTag> & StarRatingProps<TTag>
 ) {
   const {as, rating, ...passthroughProps} = props;
 

--- a/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
@@ -3,6 +3,7 @@ import {getParsedMetafield} from '../../../../../utilities/tests/metafields';
 import {mount} from '@shopify/react-testing';
 import {StarRating, Star} from '../StarRating';
 import {Rating} from '../../../../../types';
+import {Link} from '../../../../Link/index';
 
 describe('<StarRating />', () => {
   it('renders the number of stars in the rating scale', () => {
@@ -37,6 +38,17 @@ describe('<StarRating />', () => {
     );
     expect(component).toContainReactComponentTimes(Star, 1, {
       percentFilled: partialStarFill,
+    });
+  });
+
+  it(`validates props when passed a component to the 'as' prop`, () => {
+    const rating = getParsedMetafield({type: 'rating'});
+    const component = mount(
+      <StarRating rating={rating.value as Rating} as={Link} to="/test" />
+    );
+
+    expect(component).toContainReactComponent(Link, {
+      to: '/test',
     });
   });
 });

--- a/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
@@ -6,6 +6,7 @@ import {RawHtml} from '../../RawHtml';
 import {Image} from '../../Image';
 import {getMediaImage} from '../../../utilities/tests/media';
 import type {Rating} from '../../../types';
+import {Link} from '../../Link/index';
 
 describe('<Metafield />', () => {
   it('renders nothing when the metafield value is undefined', () => {
@@ -26,6 +27,19 @@ describe('<Metafield />', () => {
     expect(console.warn).toHaveBeenCalledWith(
       `No metafield value for ${metafield}`
     );
+  });
+
+  it(`validates props when a component is passed to the 'as' prop`, () => {
+    const component = mountWithProviders(
+      <Metafield
+        data={getParsedMetafield({type: 'number_integer'})}
+        as={Link}
+        to="/test"
+      />
+    );
+    expect(component).toContainReactComponent(Link, {
+      to: '/test',
+    });
   });
 
   describe('with `date` type metafield', () => {

--- a/packages/hydrogen/src/components/Money/Money.client.tsx
+++ b/packages/hydrogen/src/components/Money/Money.client.tsx
@@ -4,9 +4,9 @@ import {Props} from '../types';
 import {MoneyV2} from '../../graphql/types/types';
 import {MoneyFragment as Fragment} from '../../graphql/graphql-constants';
 
-export interface MoneyProps {
+export interface MoneyProps<TTag> {
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
-  as?: ElementType;
+  as?: TTag;
   /** A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2). */
   data: MoneyV2;
 }
@@ -17,7 +17,7 @@ export interface MoneyProps {
  * `defaultLocale` in the `shopify.config.js` file.
  */
 export function Money<TTag extends ElementType>(
-  props: Props<TTag> & MoneyProps
+  props: Props<TTag> & MoneyProps<TTag>
 ) {
   const {data, as, ...passthroughProps} = props;
   const moneyObject = useMoney(data);

--- a/packages/hydrogen/src/components/Money/tests/Money.test.tsx
+++ b/packages/hydrogen/src/components/Money/tests/Money.test.tsx
@@ -3,6 +3,7 @@ import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {CurrencyCode} from '../../../graphql/types/types';
 import {getPrice} from '../../../utilities/tests/price';
 import {Money} from '../Money.client';
+import {Link} from '../../Link/index';
 
 describe('<Money />', () => {
   it('renders a formatted money string', () => {
@@ -27,5 +28,13 @@ describe('<Money />', () => {
     );
 
     expect(component).toHaveReactProps({className: 'money'});
+  });
+
+  it(`validates props when a component is passed to the 'as' prop`, () => {
+    const component = mountWithProviders(
+      <Money data={getPrice()} as={Link} to="/test" />
+    );
+
+    expect(component).toContainReactComponent(Link, {to: '/test'});
   });
 });

--- a/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
+++ b/packages/hydrogen/src/components/ProductMetafield/ProductMetafield.client.tsx
@@ -5,8 +5,8 @@ import {Props} from '../types';
 import {MetafieldProps} from '../Metafield/Metafield.client';
 import {flattenConnection} from '../../utilities';
 
-export interface ProductMetafieldProps
-  extends Omit<MetafieldProps, 'metafield'> {
+export interface ProductMetafieldProps<TTag>
+  extends Omit<MetafieldProps<TTag>, 'metafield'> {
   /** A string corresponding to the [key](/api/storefront/reference/common-objects/metafield) of the product's
    * metafield.
    */
@@ -25,7 +25,7 @@ export interface ProductMetafieldProps
  * It must be a descendent of a `ProductProvider` component.
  */
 export function ProductMetafield<TTag extends ElementType>(
-  props: Props<TTag> & Omit<ProductMetafieldProps, 'data'>
+  props: Props<TTag> & Omit<ProductMetafieldProps<TTag>, 'data'>
 ) {
   const product = useProduct();
 

--- a/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
+++ b/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
@@ -5,7 +5,8 @@ import {useProduct} from '../ProductProvider';
 import {Props} from '../types';
 import {UnitPrice} from '../UnitPrice';
 
-export interface ProductPriceProps extends Omit<MoneyProps, 'data'> {
+export interface ProductPriceProps<TTag>
+  extends Omit<MoneyProps<TTag>, 'data'> {
   /** The type of price. Valid values: `regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
   /** The type of value. Valid values: `min` (default), `max` or `unit`. */
@@ -19,7 +20,7 @@ export interface ProductPriceProps extends Omit<MoneyProps, 'data'> {
  * [`priceRange`](/api/storefront/reference/products/productpricerange)'s `maxVariantPrice` or `minVariantPrice`, for either the regular price or compare at price range. It must be a descendent of the `ProductProvider` component.
  */
 export function ProductPrice<TTag extends ElementType>(
-  props: Props<TTag> & ProductPriceProps
+  props: Props<TTag> & ProductPriceProps<TTag>
 ) {
   const product = useProduct();
   const {

--- a/packages/hydrogen/src/components/ProductTitle/ProductTitle.client.tsx
+++ b/packages/hydrogen/src/components/ProductTitle/ProductTitle.client.tsx
@@ -12,7 +12,7 @@ export function ProductTitle<TTag extends ElementType = 'span'>(
     /** An HTML tag to wrap the title. If not specified, then the
      * title is wrapped in a `span` element.
      */
-    as?: ElementType;
+    as?: TTag;
   }
 ) {
   const product = useProduct();

--- a/packages/hydrogen/src/components/ProductTitle/tests/ProductTitle.test.tsx
+++ b/packages/hydrogen/src/components/ProductTitle/tests/ProductTitle.test.tsx
@@ -3,6 +3,7 @@ import {getProduct} from '../../../utilities/tests/product';
 import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {ProductProvider} from '../../ProductProvider';
 import {ProductTitle} from '../ProductTitle.client';
+import {Link} from '../../Link/index';
 
 describe('<ProductTitle />', () => {
   it('renders the product title in a <span> by default', () => {
@@ -28,6 +29,19 @@ describe('<ProductTitle />', () => {
 
     expect(price).toContainReactComponent('p', {
       children: product.title,
+    });
+  });
+
+  it(`does prop validation when using a component for the 'as' prop`, () => {
+    const product = getProduct();
+    const price = mountWithProviders(
+      <ProductProvider data={product} initialVariantId="">
+        <ProductTitle as={Link} to="/test" />
+      </ProductProvider>
+    );
+
+    expect(price).toContainReactComponent(Link, {
+      to: '/test',
     });
   });
 });

--- a/packages/hydrogen/src/components/RawHtml/RawHtml.tsx
+++ b/packages/hydrogen/src/components/RawHtml/RawHtml.tsx
@@ -8,13 +8,13 @@ import {Props} from '../types';
 //   FORBID_ATTR: ['style'],
 // };
 
-export interface RawHtmlProps {
+export interface RawHtmlProps<TTag> {
   /** An HTML string. */
   string: string;
   /** Whether the HTML string should be sanitized with `isomorphic-dompurify`. */
   unsanitized?: boolean;
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
-  as?: ElementType;
+  as?: TTag;
 }
 
 /**
@@ -26,7 +26,7 @@ export interface RawHtmlProps {
  * To keep the text unsanitized, set the `unsanitized` prop to `true`.
  */
 export function RawHtml<TTag extends ElementType>(
-  props: Props<TTag> & RawHtmlProps
+  props: Props<TTag> & RawHtmlProps<TTag>
 ) {
   const {string, unsanitized, as, ...passthroughProps} = props;
   const Wrapper = as ?? 'div';

--- a/packages/hydrogen/src/components/RawHtml/tests/RawHtml.test.tsx
+++ b/packages/hydrogen/src/components/RawHtml/tests/RawHtml.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-
 import {RawHtml} from '../RawHtml';
+import {Link} from '../../Link/index';
 
 describe('<RawHtml />', () => {
   it('renders a `div` with dangerously set inner HTML', () => {
@@ -27,6 +27,16 @@ describe('<RawHtml />', () => {
       dangerouslySetInnerHTML: {
         __html: '<p>Hello, World.</p>',
       },
+    });
+  });
+
+  it(`validates props when a component is passed to the 'as' prop`, () => {
+    const component = mount(
+      <RawHtml as={Link} to="/test" string="<p>Hello, World.</p>" />
+    );
+
+    expect(component).toContainReactComponent(Link, {
+      to: '/test',
     });
   });
 });

--- a/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
@@ -4,13 +4,13 @@ import {UnitPriceMeasurement, MoneyV2} from '../../graphql/types/types';
 import {Money} from '../Money';
 import {UnitPriceFragment as Fragment} from '../../graphql/graphql-constants';
 
-export interface UnitPriceProps {
+export interface UnitPriceProps<TTag> {
   /** A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2). */
   data: MoneyV2;
   /** A [`UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement). */
   measurement: UnitPriceMeasurement;
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
-  as?: ElementType;
+  as?: TTag;
 }
 
 /**
@@ -18,7 +18,7 @@ export interface UnitPriceProps {
  * [Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
  */
 export function UnitPrice<TTag extends ElementType>(
-  props: Props<TTag> & UnitPriceProps
+  props: Props<TTag> & UnitPriceProps<TTag>
 ) {
   const {data, measurement, as, ...passthroughProps} = props;
   const Wrapper: any = as ?? 'div';

--- a/packages/hydrogen/src/components/UnitPrice/tests/UnitPrice.test.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/tests/UnitPrice.test.tsx
@@ -3,6 +3,7 @@ import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {getUnitPriceMeasurement} from '../../../utilities/tests/unitPriceMeasurement';
 import {getPrice} from '../../../utilities/tests/price';
 import {UnitPrice} from '../UnitPrice.client';
+import {Link} from '../../Link/index';
 
 const unitPrice = getPrice();
 const unitPriceMeasurement = getUnitPriceMeasurement();
@@ -27,5 +28,18 @@ describe('<UnitPrice />', () => {
     );
 
     expect(component).toHaveReactProps({className: 'unitPriceMeasurement'});
+  });
+
+  it(`validates props when a component is passed to the 'as' prop`, () => {
+    const component = mountWithProviders(
+      <UnitPrice
+        as={Link}
+        to="/test"
+        data={unitPrice}
+        measurement={unitPriceMeasurement}
+      />
+    );
+
+    expect(component).toContainReactComponent(Link, {to: '/test'});
   });
 });


### PR DESCRIPTION
### Description

Fixes #756 by using `TTag` instead of `ElementType` for the `as` prop. Adds tests to help with that as well. 

### Additional context

---

### Before submitting the PR, please make sure you do the following:

- [x] Run `yarn changeset add` to update the changelog, if needed
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
