### PR TITLE
fix: CLI preview command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,9 +13,7 @@
   "main": "./dist/index.js",
   "bin": {
     "hydrogen": "./bin/hydrogen",
-    "h2": "./bin/hydrogen",
-    "create-hydrogen": "./bin/create-hydrogen",
-    "create-hydrogen-app": "./bin/create-hydrogen"
+    "h2": "./bin/hydrogen"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR removes the duplicate `bin` keys in the hydrogen-cli package.json. NPX will fail due to it already finding a file in the `usr/lib/local` folder.

addresses: https://github.com/Shopify/hydrogen/issues/759

### Before submitting the PR, please make sure you do the following:

- [ ] Run `yarn changeset add` to update the changelog, if needed
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
