### PR TITLE
Wrap client-side apps with StrictMode by default

### DIFF
--- a/.changeset/tricky-brooms-crash.md
+++ b/.changeset/tricky-brooms-crash.md
@@ -2,4 +2,6 @@
 '@shopify/hydrogen': patch
 ---
 
-Client-side apps now have React's StrictMode component wrapping the whole app.
+Client-side apps now have React's `StrictMode` component wrapping the whole app, with an option to disable it. If you do turn it off, it is recommended that you still include the `StrictMode` component at as high of a level as possible in your React tree.
+
+See also [React 17's docs](https://reactjs.org/docs/strict-mode.html) on `StrictMode`, and [React 18's updates](https://github.com/reactwg/react-18/discussions/19) to `StrictMode`.

--- a/.changeset/tricky-brooms-crash.md
+++ b/.changeset/tricky-brooms-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Client-side apps now have React's StrictMode component wrapping the whole app.

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -1,5 +1,11 @@
-import React, {Suspense, useState} from 'react';
-// @ts-ignore
+import React, {
+  Suspense,
+  useState,
+  StrictMode,
+  Fragment,
+  type ElementType,
+} from 'react';
+// @ts-expect-error hydrateRoot isn't on the TS types yet, but we're using React 18 so it exists
 import {hydrateRoot} from 'react-dom';
 import type {ClientHandler} from './types';
 import {ErrorBoundary} from 'react-error-boundary';
@@ -7,7 +13,7 @@ import {useServerResponse} from './framework/Hydration/rsc';
 import {ServerStateProvider} from './client';
 import {Router} from './foundation/Router/Router.client';
 
-const renderHydrogen: ClientHandler = async (ClientWrapper) => {
+const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
   const root = document.getElementById('root');
 
   if (!root) {
@@ -17,20 +23,28 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
     return;
   }
 
+  // default to StrictMode on, unless explicitly turned off
+  const RootComponent = config?.strictMode !== false ? StrictMode : Fragment;
+
   hydrateRoot(
     root,
-    <ErrorBoundary FallbackComponent={Error}>
-      <Suspense fallback={null}>
-        <Content clientWrapper={ClientWrapper} />
-      </Suspense>
-    </ErrorBoundary>
+    <RootComponent>
+      <ErrorBoundary FallbackComponent={Error}>
+        <Suspense fallback={null}>
+          <Content clientWrapper={ClientWrapper} />
+        </Suspense>
+      </ErrorBoundary>
+    </RootComponent>
   );
 };
 
 export default renderHydrogen;
 
 function Content({
-  clientWrapper: ClientWrapper = ({children}: any) => children,
+  clientWrapper: ClientWrapper = ({children}: {children: JSX.Element}) =>
+    children,
+}: {
+  clientWrapper: ElementType;
 }) {
   const [serverState, setServerState] = useState({
     pathname: window.location.pathname,

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -52,10 +52,12 @@ export type ServerHandlerConfig = {
 
 export type ClientHandlerConfig = {
   shopifyConfig: ShopifyConfig;
+  /** React's StrictMode is on by default for your client side app; if you want to turn it off (not recommended), you can pass `false` */
+  strictMode?: boolean;
 };
 
 export type ClientHandler = (
-  App: any,
+  App: React.ElementType,
   config: ClientHandlerConfig
 ) => Promise<void>;
 


### PR DESCRIPTION
### Description

Closes #438 

🎩 -ed and things seem to work well now that we've removed React Router v5 from the app. 

### Additional context

- Does this seem like the right way to allow turning off StrictMode?
- Is there a good spot to document this option...?
- Also improved the TS types for `renderHydrogen` while I was here

---

### Before submitting the PR, please make sure you do the following:

- [x] Run `yarn changeset add` to update the changelog, if needed
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
