### PR TITLE
[Hydrogen docs]: Revisions to framework content and global hooks descriptions 

### DIFF
--- a/.alexignore
+++ b/.alexignore
@@ -3,3 +3,4 @@ packages/hydrogen/src/docs/hooks.md
 packages/hydrogen/src/docs/components.md
 packages/hydrogen/src/docs/hydrogen-reference.md
 packages/hydrogen/src/framework/docs/css-support.md
+packages/hydrogen/src/foundation/useQuery/README.md

--- a/.changeset/brown-clocks-speak.md
+++ b/.changeset/brown-clocks-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Hydrogen docs: Framework and global hooks content updates

--- a/packages/hydrogen/src/docs/hooks.md
+++ b/packages/hydrogen/src/docs/hooks.md
@@ -37,23 +37,23 @@ Global hooks are used to fetch data from server components.
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useserverstate">useServerState</a></td>
-    <td>Manage a server state when using Hydrogen as a React Server Component framework.</td>
+    <td><a href="/custom-storefronts/hydrogen/framework/server-state">Manages the server state</a> when using Hydrogen as a React Server Component framework.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useshop">useShop</a></td>
-    <td>Access values within <code>shopify.config.js</code>.</td>
+    <td>Accesses values within <code>shopify.config.js</code>.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useshopquery">useShopQuery</a></td>
-    <td>Make server-only GraphQL queries to the <a href="/api/storefront">Storefront API</a>.</td>
+    <td>Makes server-only GraphQL queries to the <a href="/api/storefront">Storefront API</a>.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/usequery">useQuery</a></td>
-    <td>A wrapper around <code>useQuery</code> from <code>react-query</code>. It supports Suspense calls on the server and on the client.</td>
+    <td>Executes an asynchronous operation like <code>fetch</code> in a way that supports <a href="https://reactjs.org/docs/concurrent-mode-suspense.html">Suspense</a>.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useurl">useUrl</a></td>
-    <td>Retrieve the current URL in a server or client component.</td>
+    <td>Retrieves the current URL in a server or client component.</td>
   </tr>
 </table>
 

--- a/packages/hydrogen/src/docs/hydrogen-reference.md
+++ b/packages/hydrogen/src/docs/hydrogen-reference.md
@@ -85,23 +85,23 @@ Global components wrap around your entire app. Hydrogen includes the [ShopifyPro
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useserverstate">useServerState</a></td>
-    <td>Manage a server state when using Hydrogen as a React Server Component framework.</td>
+    <td><a href="/custom-storefronts/hydrogen/framework/server-state">Manages the server state</a> when using Hydrogen as a React Server Component framework.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useshop">useShop</a></td>
-    <td>Access values within <code>shopify.config.js</code>.</td>
+    <td>Accesses values within <code>shopify.config.js</code>.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useshopquery">useShopQuery</a></td>
-    <td>Make server-only GraphQL queries to the <a href="/api/storefront">Storefront API</a>.</td>
+    <td>Makes server-only GraphQL queries to the <a href="/api/storefront">Storefront API</a>.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/usequery">useQuery</a></td>
-    <td>A wrapper around <code>useQuery</code> from <code>react-query</code>. It supports Suspense calls on the server and on the client.</td>
+    <td>Executes an asynchronous operation like <code>fetch</code> in a way that supports <a href="https://reactjs.org/docs/concurrent-mode-suspense.html">Suspense</a>.</td>
   </tr>
   <tr>
     <td><a href="/api/hydrogen/hooks/global/useurl">useUrl</a></td>
-    <td>Retrieve the current URL in a server or client component.</td>
+    <td>Retrieves the current URL in a server or client component.</td>
   </tr>
 </table>
 

--- a/packages/hydrogen/src/foundation/useQuery/README.md
+++ b/packages/hydrogen/src/foundation/useQuery/README.md
@@ -1,8 +1,6 @@
 <!-- This file is generated from source code in the Shopify/hydrogen repo. Edit the files in /packages/hydrogen/src/foundation/useQuery and run 'yarn generate-docs' at the root of this repo. For more information, refer to https://github.com/Shopify/shopify-dev/blob/main/content/internal/operations/hydrogen-reference-docs.md. -->
 
-The `useQuery` hook is a wrapper around Suspense calls and
-global runtime's Cache if it exists.
-It supports Suspense calls on the server and on the client.
+The `useQuery` hook executes an asynchronous operation like `fetch` in a way that supports [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html). It's based on [react-query](https://react-query.tanstack.com/reference/useQuery). You can use this hook to call any third-party APIs.
 
 ## Example code
 

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -27,9 +27,10 @@ export interface HydrogenUseQueryOptions {
 }
 
 /**
- * The `useQuery` hook is a wrapper around Suspense calls and
- * global runtime's Cache if it exists.
- * It supports Suspense calls on the server and on the client.
+ * The `useQuery` hook executes an asynchronous operation like `fetch` in a way that
+ * supports [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html). It's based
+ * on [react-query](https://react-query.tanstack.com/reference/useQuery). You can use this
+ * hook to call any third-party APIs.
  */
 export function useQuery<T>(
   /** A string or array to uniquely identify the current query. */


### PR DESCRIPTION
## This PR: 
- Revises the framework content in the Hydrogen docs to improve usability and information design
- Fixes the parallelism of descriptions in the global hooks docs
- Relates to https://github.com/Shopify/shopify-dev/pull/16934