### PR TITLE
DO NOT MERGE: Adding simple load test for debugging 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "update-docs-on-version": "ts-node --project ./tsconfig.json ./scripts/update-docs-on-version.ts",
     "generate-docs": "ts-node --project ./tsconfig.json ./scripts/generate-docs.ts",
     "generate-docs:debug": "node --inspect-brk ./node_modules/.bin/ts-node --project ./tsconfig.json ./scripts/generate-docs.ts",
-    "tophat": "node ./scripts/tophat"
+    "tophat": "node ./scripts/tophat",
+    "load-test": "k6 run ./scripts/load-test.js"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.3",

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -1,0 +1,23 @@
+import {check} from 'k6';
+import http from 'k6/http';
+
+export const options = {
+  vus: 10,
+  duration: '10s',
+};
+
+export default function () {
+  const res = http.get(
+    'https://hydrogen-11.shopify-oxygen-platform.workers.dev/'
+  );
+
+  check(res, {
+    'Error connecting to data source': (r) => {
+      const hitError = r.body.includes(
+        'Error: The fetch attempt failed; there was an issue connecting to the data source.'
+      );
+
+      return hitError;
+    },
+  });
+}


### PR DESCRIPTION
This PR is just for debugging and not meant to merge. It adds a simple load testing script using [k6](https://k6.io/).

To run it, pull down this branch and run `yarn load-test`.