### PR TITLE
Fix internal URL when it already includes origin

### DIFF
--- a/.changeset/fluffy-trees-fly.md
+++ b/.changeset/fluffy-trees-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix internal url usage in platforms like Vercel, which already provides protocol and host in `request.url`.

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
@@ -149,12 +149,13 @@ function saveToPreloadAllPreload(query: PreloadQueryEntry) {
  * URL pathname is. We want to use that if it's present, so we union type this to `any`.
  */
 function getUrlFromNodeRequest(request: any) {
+  const url: string = request.originalUrl ?? request.url;
+  if (url && !url.startsWith('/')) return url;
+
   // TODO: Find out how to determine https from `request` object without forwarded proto
   const secure = request.headers['x-forwarded-proto'] === 'https';
 
   return new URL(
-    `${secure ? 'https' : 'http'}://${
-      request.headers.host! + (request.originalUrl ?? request.url)
-    }`
+    `${secure ? 'https' : 'http'}://${request.headers.host! + url}`
   ).toString();
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We assume `request.url` only includes the url path (starting with `/`). However, platforms like Vercel already include `https://example.com/` prefix in `request.url`. Our current logic would duplicate it and end up using `https://example.com/https://example.com/`. See [workaround in Vercel deployment here](https://github.com/frandiox/hydrogen-vercel-edge/blob/0665b04e8b7132c4e9072770448119f70b1c9f20/edge-entry.js#L28)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Run `yarn changeset add` to update the changelog, if needed
- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
