### PR TITLE
feat: fallback the selectedVariantId to the first available variant

### DIFF
--- a/.changeset/funny-cycles-trade.md
+++ b/.changeset/funny-cycles-trade.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-In cases where the initialVariantId is missing on the <ProductProvider />`, the`selectedVariantId`in the returned`object`from the useProduct()` hook will now use the first available variant or the first variant (if non are available).
+In cases where the `initialVariantId` is missing on the `<ProductProvider />`, the `selectedVariantId` in the returned `object` from `useProduct()` will now use the first available variant _or_ the first variant (if non are available).

--- a/.changeset/funny-cycles-trade.md
+++ b/.changeset/funny-cycles-trade.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+In cases where the initialVariantId is missing on the <ProductProvider />`, the`selectedVariantId`in the returned`object`from the useProduct()` hook will now use the first available variant or the first variant (if non are available).

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -40,12 +40,7 @@ export function AddToCartButton<TTag extends React.ElementType = 'button'>(
   } = props;
   const {status, id, cartCreate, linesAdd} = useCart();
   const product = useProduct();
-  const variantId =
-    explicitVariantId ??
-    product?.selectedVariant?.id ??
-    product?.variants?.find((variant) => variant.availableForSale)?.id ??
-    product?.variants?.[0]?.id ??
-    '';
+  const variantId = explicitVariantId ?? product?.selectedVariant?.id ?? '';
   const disabled =
     explicitVariantId === null ||
     variantId === '' ||

--- a/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
@@ -4,7 +4,6 @@ import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {mountWithCartProvider} from '../../CartProvider/tests/utilities';
 
 import {ProductProvider} from '../../ProductProvider';
-import {CART} from '../../CartProvider/tests/fixtures';
 import {AddToCartButton} from '../AddToCartButton.client';
 import {getProduct, getVariant} from '../../../utilities/tests/product';
 

--- a/packages/hydrogen/src/hooks/useProductOptions/tests/useProductOptions.test.tsx
+++ b/packages/hydrogen/src/hooks/useProductOptions/tests/useProductOptions.test.tsx
@@ -8,308 +8,314 @@ import {
 } from './fixtures';
 import {flattenConnection} from '../../../utilities';
 
-it('returns a structured list of options and values', async () => {
-  function Component() {
-    const {options} = useProductOptions({variants: VARIANTS});
+describe('useProductOptions', () => {
+  it('returns a structured list of options and values', async () => {
+    function Component() {
+      const {options} = useProductOptions({variants: VARIANTS});
 
-    return <div>{JSON.stringify(options)}</div>;
-  }
+      return <div>{JSON.stringify(options)}</div>;
+    }
 
-  const wrapper = await mount(<Component />);
+    const wrapper = await mount(<Component />);
 
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify([
-      {
-        name: 'Color',
-        values: ['Black', 'White'],
-      },
-      {
-        name: 'Size',
-        values: ['Small', 'Large'],
-      },
-    ]),
-  });
-});
-
-it('provides setSelectedOption callback', async () => {
-  function Component() {
-    const {options, setSelectedOption, selectedOptions} = useProductOptions({
-      variants: VARIANTS,
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify([
+        {
+          name: 'Color',
+          values: ['Black', 'White'],
+        },
+        {
+          name: 'Size',
+          values: ['Small', 'Large'],
+        },
+      ]),
     });
-
-    return (
-      <>
-        <ul>
-          {options.map((option) => (
-            <li key={option.name}>
-              <ul>
-                {option.values.map((value) => (
-                  <li key={value}>
-                    <button
-                      onClick={() => setSelectedOption(option.name, value)}
-                    >
-                      {value}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ul>
-        <div>{JSON.stringify(selectedOptions)}</div>
-      </>
-    );
-  }
-
-  const wrapper = await mount(<Component />);
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify({}),
   });
 
-  await wrapper.find('button', {children: 'Black'})!.trigger('onClick');
+  it('provides setSelectedOption callback', async () => {
+    function Component() {
+      const {options, setSelectedOption, selectedOptions} = useProductOptions({
+        variants: VARIANTS,
+      });
 
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify({Color: 'Black'}),
-  });
-});
-
-it('computes selected variant based on options', async () => {
-  function Component() {
-    const {options, setSelectedOption, selectedVariant} = useProductOptions({
-      variants: VARIANTS,
-    });
-
-    return (
-      <>
-        <ul>
-          {options.map((option) => (
-            <li key={option.name}>
-              <ul>
-                {option.values.map((value) => (
-                  <li key={value}>
-                    <button
-                      onClick={() => setSelectedOption(option.name, value)}
-                    >
-                      {value}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ul>
-        <div>{JSON.stringify(selectedVariant)}</div>
-      </>
-    );
-  }
-
-  const wrapper = await mount(<Component />);
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: undefined,
-  });
-
-  await wrapper.find('button', {children: 'Black'})!.trigger('onClick');
-  await wrapper.find('button', {children: 'Large'})!.trigger('onClick');
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify(VARIANTS.edges[1].node),
-  });
-});
-
-it('computes selected options based on initial selected variant', async () => {
-  function Component() {
-    const {selectedOptions} = useProductOptions({
-      variants: VARIANTS,
-      initialVariantId: VARIANTS.edges[0].node.id,
-    });
-
-    return <div>{JSON.stringify(selectedOptions)}</div>;
-  }
-
-  const wrapper = await mount(<Component />);
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify({Color: 'Black', Size: 'Small'}),
-  });
-});
-
-it('provides list of variants', async () => {
-  function Component() {
-    const {variants} = useProductOptions({
-      variants: VARIANTS,
-    });
-
-    return <div>{JSON.stringify(variants)}</div>;
-  }
-
-  const wrapper = await mount(<Component />);
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify(flattenConnection(VARIANTS)),
-  });
-});
-
-it('provides setSelectedVariant callback', async () => {
-  function Component() {
-    const {variants, selectedVariant, setSelectedVariant} = useProductOptions({
-      variants: VARIANTS,
-    });
-
-    return (
-      <>
-        <label htmlFor="variant">Variant</label>
-        <select
-          name="variant"
-          id="variant"
-          value={selectedVariant?.id}
-          onChange={(e) =>
-            setSelectedVariant(variants.find((v) => v.id === e.target.value)!)
-          }
-        >
-          {variants.map((variant) => (
-            <option key={variant.id} value={variant.id}>
-              {variant.title}
-            </option>
-          ))}
-        </select>
-        <div>{JSON.stringify(selectedVariant)}</div>
-      </>
-    );
-  }
-
-  const wrapper = await mount(<Component />);
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: undefined,
-  });
-
-  await wrapper
-    .find('select', {name: 'variant'})!
-    .trigger('onChange', {target: {value: VARIANTS.edges[1].node.id}});
-
-  expect(wrapper).toContainReactComponent('div', {
-    children: JSON.stringify(VARIANTS.edges[1].node),
-  });
-});
-
-it('provides out of stock helper', async () => {
-  function Component() {
-    const {options, setSelectedOption, isOptionInStock} = useProductOptions({
-      variants: VARIANTS,
-    });
-
-    return (
-      <>
-        <ul>
-          {options.map((option) => (
-            <li key={option.name}>
-              <ul>
-                {option.values.map((value) => (
-                  <li key={value}>
-                    <button
-                      onClick={() => setSelectedOption(option.name, value)}
-                    >
-                      {`${value}${
-                        !isOptionInStock(option.name, value)
-                          ? ' (out of stock)'
-                          : ''
-                      }`}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ul>
-      </>
-    );
-  }
-  const wrapper = await mount(<Component />);
-
-  expect(wrapper).toContainReactComponentTimes('button', 1, {
-    children: 'White',
-  });
-  expect(wrapper).toContainReactComponentTimes('button', 0, {
-    children: 'White (out of stock)',
-  });
-
-  await wrapper.find('button', {children: 'Large'})!.trigger('onClick');
-
-  expect(wrapper).toContainReactComponentTimes('button', 1, {
-    children: 'White (out of stock)',
-  });
-});
-
-it('supports selecting a selling plan', async () => {
-  function Component() {
-    const {
-      setSelectedSellingPlan,
-      selectedSellingPlan,
-      selectedSellingPlanAllocation,
-      sellingPlanGroups,
-    } = useProductOptions({
-      variants: VARIANTS_WITH_SELLING_PLANS,
-      sellingPlanGroups: SELLING_PLAN_GROUPS_CONNECTION,
-      initialVariantId: VARIANTS_WITH_SELLING_PLANS.edges[0].node.id,
-    });
-
-    const selectSellingPlanMarkup = selectedSellingPlan ? (
-      <div id="selectedSellingPlan">{JSON.stringify(selectedSellingPlan)}</div>
-    ) : null;
-    const selectedSellingPlanAllocationMarkup =
-      selectedSellingPlanAllocation ? (
-        <div id="selectedSellingPlanAllocation">
-          {JSON.stringify(selectedSellingPlanAllocation)}
-        </div>
-      ) : null;
-
-    return (
-      <>
-        {(sellingPlanGroups ?? []).map((sellingPlanGroup) => {
-          return (
-            <div key={sellingPlanGroup.name}>
-              <h2>{sellingPlanGroup.name}</h2>
-              <ul>
-                {sellingPlanGroup.sellingPlans.map((sellingPlan) => {
-                  return (
-                    <li key={sellingPlan.id}>
+      return (
+        <>
+          <ul>
+            {options.map((option) => (
+              <li key={option.name}>
+                <ul>
+                  {option.values.map((value) => (
+                    <li key={value}>
                       <button
-                        onClick={() => setSelectedSellingPlan(sellingPlan)}
+                        onClick={() => setSelectedOption(option.name, value)}
                       >
-                        {sellingPlan.name}
+                        {value}
                       </button>
                     </li>
-                  );
-                })}
-              </ul>
-            </div>
-          );
-        })}
-        {selectSellingPlanMarkup}
-        {selectedSellingPlanAllocationMarkup}
-      </>
-    );
-  }
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+          <div>{JSON.stringify(selectedOptions)}</div>
+        </>
+      );
+    }
 
-  const wrapper = await mount(<Component />);
+    const wrapper = await mount(<Component />);
 
-  expect(wrapper).toContainReactComponentTimes('div', 0, {
-    id: 'selectedSellingPlan',
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify({Color: 'Black', Size: 'Small'}),
+    });
+
+    await wrapper.find('button', {children: 'White'})!.trigger('onClick');
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify({Color: 'White', Size: 'Small'}),
+    });
   });
-  expect(wrapper).toContainReactComponentTimes('div', 0, {
-    id: 'selectedSellingPlanAllocation',
+
+  it('computes selected variant based on options', async () => {
+    function Component() {
+      const {options, setSelectedOption, selectedVariant} = useProductOptions({
+        variants: VARIANTS,
+      });
+
+      return (
+        <>
+          <ul>
+            {options.map((option) => (
+              <li key={option.name}>
+                <ul>
+                  {option.values.map((value) => (
+                    <li key={value}>
+                      <button
+                        onClick={() => setSelectedOption(option.name, value)}
+                      >
+                        {value}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+          <div>{JSON.stringify(selectedVariant)}</div>
+        </>
+      );
+    }
+
+    const wrapper = await mount(<Component />);
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify(VARIANTS.edges[0].node),
+    });
+
+    await wrapper.find('button', {children: 'Black'})!.trigger('onClick');
+    await wrapper.find('button', {children: 'Large'})!.trigger('onClick');
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify(VARIANTS.edges[1].node),
+    });
   });
 
-  await wrapper
-    .find('button', {children: 'Deliver every week'})!
-    .trigger('onClick');
+  it('computes selected options based on initial selected variant', async () => {
+    function Component() {
+      const {selectedOptions} = useProductOptions({
+        variants: VARIANTS,
+        initialVariantId: VARIANTS.edges[0].node.id,
+      });
 
-  expect(wrapper).toContainReactComponentTimes('div', 1, {
-    id: 'selectedSellingPlan',
+      return <div>{JSON.stringify(selectedOptions)}</div>;
+    }
+
+    const wrapper = await mount(<Component />);
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify({Color: 'Black', Size: 'Small'}),
+    });
   });
-  expect(wrapper).toContainReactComponentTimes('div', 1, {
-    id: 'selectedSellingPlanAllocation',
+
+  it('provides list of variants', async () => {
+    function Component() {
+      const {variants} = useProductOptions({
+        variants: VARIANTS,
+      });
+
+      return <div>{JSON.stringify(variants)}</div>;
+    }
+
+    const wrapper = await mount(<Component />);
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify(flattenConnection(VARIANTS)),
+    });
+  });
+
+  it('provides setSelectedVariant callback', async () => {
+    function Component() {
+      const {variants, selectedVariant, setSelectedVariant} = useProductOptions(
+        {
+          variants: VARIANTS,
+        }
+      );
+
+      return (
+        <>
+          <label htmlFor="variant">Variant</label>
+          <select
+            name="variant"
+            id="variant"
+            value={selectedVariant?.id}
+            onChange={(e) =>
+              setSelectedVariant(variants.find((v) => v.id === e.target.value)!)
+            }
+          >
+            {variants.map((variant) => (
+              <option key={variant.id} value={variant.id}>
+                {variant.title}
+              </option>
+            ))}
+          </select>
+          <div>{JSON.stringify(selectedVariant)}</div>
+        </>
+      );
+    }
+
+    const wrapper = await mount(<Component />);
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify(VARIANTS.edges[0].node),
+    });
+
+    await wrapper
+      .find('select', {name: 'variant'})!
+      .trigger('onChange', {target: {value: VARIANTS.edges[1].node.id}});
+
+    expect(wrapper).toContainReactComponent('div', {
+      children: JSON.stringify(VARIANTS.edges[1].node),
+    });
+  });
+
+  it('provides out of stock helper', async () => {
+    function Component() {
+      const {options, setSelectedOption, isOptionInStock} = useProductOptions({
+        variants: VARIANTS,
+      });
+
+      return (
+        <>
+          <ul>
+            {options.map((option) => (
+              <li key={option.name}>
+                <ul>
+                  {option.values.map((value) => (
+                    <li key={value}>
+                      <button
+                        onClick={() => setSelectedOption(option.name, value)}
+                      >
+                        {`${value}${
+                          !isOptionInStock(option.name, value)
+                            ? ' (out of stock)'
+                            : ''
+                        }`}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </>
+      );
+    }
+    const wrapper = await mount(<Component />);
+
+    expect(wrapper).toContainReactComponentTimes('button', 1, {
+      children: 'White',
+    });
+    expect(wrapper).toContainReactComponentTimes('button', 0, {
+      children: 'White (out of stock)',
+    });
+
+    await wrapper.find('button', {children: 'Large'})!.trigger('onClick');
+
+    expect(wrapper).toContainReactComponentTimes('button', 1, {
+      children: 'White (out of stock)',
+    });
+  });
+
+  it('supports selecting a selling plan', async () => {
+    function Component() {
+      const {
+        setSelectedSellingPlan,
+        selectedSellingPlan,
+        selectedSellingPlanAllocation,
+        sellingPlanGroups,
+      } = useProductOptions({
+        variants: VARIANTS_WITH_SELLING_PLANS,
+        sellingPlanGroups: SELLING_PLAN_GROUPS_CONNECTION,
+        initialVariantId: VARIANTS_WITH_SELLING_PLANS.edges[0].node.id,
+      });
+
+      const selectSellingPlanMarkup = selectedSellingPlan ? (
+        <div id="selectedSellingPlan">
+          {JSON.stringify(selectedSellingPlan)}
+        </div>
+      ) : null;
+      const selectedSellingPlanAllocationMarkup =
+        selectedSellingPlanAllocation ? (
+          <div id="selectedSellingPlanAllocation">
+            {JSON.stringify(selectedSellingPlanAllocation)}
+          </div>
+        ) : null;
+
+      return (
+        <>
+          {(sellingPlanGroups ?? []).map((sellingPlanGroup) => {
+            return (
+              <div key={sellingPlanGroup.name}>
+                <h2>{sellingPlanGroup.name}</h2>
+                <ul>
+                  {sellingPlanGroup.sellingPlans.map((sellingPlan) => {
+                    return (
+                      <li key={sellingPlan.id}>
+                        <button
+                          onClick={() => setSelectedSellingPlan(sellingPlan)}
+                        >
+                          {sellingPlan.name}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })}
+          {selectSellingPlanMarkup}
+          {selectedSellingPlanAllocationMarkup}
+        </>
+      );
+    }
+
+    const wrapper = await mount(<Component />);
+
+    expect(wrapper).toContainReactComponentTimes('div', 0, {
+      id: 'selectedSellingPlan',
+    });
+    expect(wrapper).toContainReactComponentTimes('div', 0, {
+      id: 'selectedSellingPlanAllocation',
+    });
+
+    await wrapper
+      .find('button', {children: 'Deliver every week'})!
+      .trigger('onClick');
+
+    expect(wrapper).toContainReactComponentTimes('div', 1, {
+      id: 'selectedSellingPlan',
+    });
+    expect(wrapper).toContainReactComponentTimes('div', 1, {
+      id: 'selectedSellingPlanAllocation',
+    });
   });
 });

--- a/packages/hydrogen/src/hooks/useProductOptions/useProductOptions.ts
+++ b/packages/hydrogen/src/hooks/useProductOptions/useProductOptions.ts
@@ -18,7 +18,7 @@ import {GraphQLConnection} from '../../types';
 export function useProductOptions({
   variants: variantsConnection,
   sellingPlanGroups: sellingPlanGroupsConnection,
-  initialVariantId,
+  initialVariantId: explicitVariantId,
 }: {
   /** The product's `VariantConnection`. */
   variants?: GraphQLConnection<Variant>;
@@ -36,17 +36,19 @@ export function useProductOptions({
   // All the options available for a product, based on all the variants
   const options = useMemo(() => getOptions(variants), [variants]);
 
+  const initialVariantId =
+    explicitVariantId === null
+      ? (explicitVariantId as null)
+      : variants.find((variant) => variant.id === explicitVariantId) ||
+        variants.find((variant) => variant.availableForSale) ||
+        variants[0];
   /**
    * Track the selectedVariant within the hook. If `initialVariantId`
    * is passed, use that as an initial value.
    */
   const [selectedVariant, setSelectedVariant] = useState<
     Variant | undefined | null
-  >(
-    initialVariantId == null
-      ? (initialVariantId as null | undefined)
-      : variants.find((variant) => variant.id === initialVariantId)
-  );
+  >(initialVariantId);
 
   /**
    * Track the selectedOptions within the hook. If a `initialVariantId`
@@ -68,11 +70,7 @@ export function useProductOptions({
    * values.
    */
   useEffect(() => {
-    const selectedVariant =
-      initialVariantId == null
-        ? (initialVariantId as null | undefined)
-        : variants.find((variant) => variant.id === initialVariantId);
-    setSelectedVariant(selectedVariant);
+    setSelectedVariant(initialVariantId);
 
     const selectedOptions = selectedVariant?.selectedOptions
       ? selectedVariant.selectedOptions.reduce((memo, optionSet) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
Closes https://github.com/Shopify/hydrogen/issues/548

### Description

This PR implements the resolving of the [`selectedVariantId` defined here](https://github.com/Shopify/hydrogen/issues/548#issuecomment-1029179479). I had previously implemented this for the `AddToCartButton.client.jsx` component only and I've moved that functionality to the `useProduct` hook.

### Before submitting the PR, please make sure you do the following:

- [ ] Run `yarn changeset add` to update the changelog, if needed
- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository for your change, if needed
