### PR TITLE
Add e2e for headers and customBody

### DIFF
--- a/packages/playground/server-components/src/routes/custom-body.server.jsx
+++ b/packages/playground/server-components/src/routes/custom-body.server.jsx
@@ -1,0 +1,5 @@
+export default function CustomBody({response}) {
+  response.doNotStream();
+  response.headers.set('content-type', 'text/plain');
+  return response.send('User-agent: *\nDisallow: /admin\n');
+}

--- a/packages/playground/server-components/src/routes/headers.server.jsx
+++ b/packages/playground/server-components/src/routes/headers.server.jsx
@@ -1,0 +1,17 @@
+export default function Headers({response}) {
+  response.writeHead({
+    status: 201,
+    statusText: 'hey',
+    headers: {'Accept-Encoding': 'deflate'},
+  });
+
+  response.headers.set('Set-Cookie', 'hello=world');
+  response.headers.append('Set-Cookie', 'hello2=world2');
+  response.headers.append('Accept-Encoding', 'gzip');
+
+  return (
+    <div>
+      <h1>Headers</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Looks like we were not testing response headers and customBody.

cc @scottdixon 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
