### PR TITLE
Use html and body attributes present in index.html

### DIFF
--- a/.changeset/rotten-wasps-share.md
+++ b/.changeset/rotten-wasps-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Attributes from `<html>` and `<body>` elements in `index.html` are now included in the SSR response.

--- a/examples/template-hydrogen-default/index.html
+++ b/examples/template-hydrogen-default/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -15,7 +15,7 @@ import type {
   ImportGlobEagerOutput,
   ServerHandlerConfig,
 } from './types';
-import {Html} from './framework/Hydration/Html';
+import {Html, applyHtmlHead} from './framework/Hydration/Html';
 import {ServerComponentResponse} from './framework/Hydration/ServerComponentResponse.server';
 import {ServerComponentRequest} from './framework/Hydration/ServerComponentRequest.server';
 import {getCacheControlHeader} from './framework/cache';
@@ -32,7 +32,6 @@ import {
 } from './utilities/apiRoutes';
 import {ServerStateProvider} from './foundation/ServerStateProvider';
 import {isBotUA} from './utilities/bot-ua';
-import type {HelmetData as HeadData} from 'react-helmet-async';
 import {setContext, setCache, RuntimeContext} from './framework/runtime';
 import {setConfig} from './framework/config';
 import {
@@ -214,23 +213,15 @@ async function render(
   }
 
   headers['Content-type'] = HTML_CONTENT_TYPE;
-  const {bodyAttributes, htmlAttributes, ...head} = extractHeadElements(
-    request.ctx.head
-  );
 
-  html = html
-    .replace(
-      /<head>(.*?)<\/head>/s,
-      generateHeadTag(head as Record<string, any>)
-    )
-    .replace('<html', htmlAttributes ? `<html ${htmlAttributes}` : '$&')
-    .replace('<body', bodyAttributes ? `<body ${bodyAttributes}` : '$&')
-    .replace(
+  html = applyHtmlHead(html, request.ctx.head, template);
+
+  if (flight) {
+    html = html.replace(
       '</body>',
-      flight
-        ? `${flightContainer({init: true, nonce, chunk: flight})}</body>`
-        : '$&'
+      `${flightContainer({init: true, nonce, chunk: flight})}</body>`
     );
+  }
 
   postRequestTasks('ssr', status, request, componentResponse);
 
@@ -673,22 +664,6 @@ function PreloadQueries({
   return children;
 }
 
-function extractHeadElements({context: {helmet}}: HeadData) {
-  return helmet
-    ? {
-        base: helmet.base.toString(),
-        bodyAttributes: helmet.bodyAttributes.toString(),
-        htmlAttributes: helmet.htmlAttributes.toString(),
-        link: helmet.link.toString(),
-        meta: helmet.meta.toString(),
-        noscript: helmet.noscript.toString(),
-        script: helmet.script.toString(),
-        style: helmet.style.toString(),
-        title: helmet.title.toString(),
-      }
-    : {};
-}
-
 async function renderToBufferedString(
   ReactApp: JSX.Element,
   {log, nonce}: {log: Logger; nonce?: string}
@@ -828,33 +803,6 @@ function writeHeadToServerResponse(
 function isRedirect(response: {status?: number; statusCode?: number}) {
   const status = response.status ?? response.statusCode ?? 0;
   return status >= 300 && status < 400;
-}
-
-/**
- * Generate the contents of the `head` tag, and update the existing `<title>` tag
- * if one exists, and if a title is passed.
- */
-function generateHeadTag({title, ...rest}: Record<string, string>) {
-  const headProps = ['base', 'meta', 'style', 'noscript', 'script', 'link'];
-
-  const otherHeadProps = headProps
-    .map((prop) => rest[prop])
-    .filter(Boolean)
-    .join('\n');
-
-  return (_outerHtml: string, innerHtml: string) => {
-    let headHtml = otherHeadProps + innerHtml;
-
-    if (title) {
-      if (headHtml.includes('<title>')) {
-        headHtml = headHtml.replace(/(<title>(?:.|\n)*?<\/title>)/, title);
-      } else {
-        headHtml += title;
-      }
-    }
-
-    return `<head>${headHtml}</head>`;
-  };
 }
 
 async function createNodeWriter() {

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -274,10 +274,7 @@ async function stream(
       log,
       routes,
     },
-    {
-      template: noScriptTemplate,
-      htmlAttrs: {lang: 'en'},
-    }
+    {template: noScriptTemplate}
   );
 
   const rscToScriptTagReadable = new ReadableStream({

--- a/packages/hydrogen/src/framework/Hydration/Html.tsx
+++ b/packages/hydrogen/src/framework/Hydration/Html.tsx
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 import React, {ReactNode} from 'react';
+import type {HelmetData as HeadData} from 'react-helmet-async';
 
 type HtmlOptions = {
   children: ReactNode;
@@ -8,15 +9,23 @@ type HtmlOptions = {
   bodyAttrs?: Record<string, string>;
 };
 
+const HTML_ATTR_SEP_RE = /(?<!\=)"\s+/gim;
+const getHtmlAttrs = (template: string) =>
+  template.match(/<html\s+([^>]+?)\s*>/s)?.[1] || '';
+const getBodyAttrs = (template: string) =>
+  template.match(/<body\s+([^>]+?)\s*>/s)?.[1] || '';
+
 const REACT_ATTR_MAP = Object.create(null) as Record<string, string>;
 REACT_ATTR_MAP.class = 'className';
 REACT_ATTR_MAP.style = 'data-style'; // Ignore string styles, it breaks React
 
-function attrsToProps(stringAttrs: string) {
+function attrsToProps(attrs: string) {
+  attrs = attrs?.trim();
+
   // Assume all attributes are surrounded by double quotes.
-  return stringAttrs
+  return attrs
     ? Object.fromEntries(
-        stringAttrs.split(/(?<!\=)"\s+/gim).map((attr) => {
+        attrs.split(HTML_ATTR_SEP_RE).map((attr) => {
           const [key, value] = attr.replace(/"/g, '').split(/=(.+)/);
           return [REACT_ATTR_MAP[key.toLowerCase()] || key, value];
         })
@@ -24,9 +33,16 @@ function attrsToProps(stringAttrs: string) {
     : {};
 }
 
+function propsToAttrs(props: Record<string, string>) {
+  return Object.entries(props)
+    .map(
+      ([key, value]) =>
+        `${key === REACT_ATTR_MAP.class ? 'class' : key}="${value}"`
+    )
+    .join(' ');
+}
+
 export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
-  const [, existingHtmlAttrs] = template.match(/<html\s+([^>]+?)\s*>/s) || [];
-  const [, existingBodyAttrs] = template.match(/<body\s+([^>]+?)\s*>/s) || [];
   let head = template.match(/<head>(.+?)<\/head>/s)![1] || '';
 
   // @ts-ignore
@@ -40,11 +56,77 @@ export function Html({children, template, htmlAttrs, bodyAttrs}: HtmlOptions) {
   }
 
   return (
-    <html {...attrsToProps(existingHtmlAttrs)} {...htmlAttrs}>
+    <html {...attrsToProps(getHtmlAttrs(template))} {...htmlAttrs}>
       <head dangerouslySetInnerHTML={{__html: head}} />
-      <body {...attrsToProps(existingBodyAttrs)} {...bodyAttrs}>
+      <body {...attrsToProps(getBodyAttrs(template))} {...bodyAttrs}>
         <div id="root">{children}</div>
       </body>
     </html>
   );
+}
+
+export function applyHtmlHead(html: string, head: HeadData, template: string) {
+  const {bodyAttrs, htmlAttrs, ...headTags} = extractHeadElements(
+    head,
+    template
+  );
+
+  return html
+    .replace(
+      /<head>(.*?)<\/head>/s,
+      generateHeadTag(headTags as Record<string, any>)
+    )
+    .replace(/<html[^>]*?>/s, htmlAttrs ? `<html ${htmlAttrs}>` : '$&')
+    .replace(/<body[^>]*?>/s, bodyAttrs ? `<body ${bodyAttrs}>` : '$&');
+}
+
+function extractHeadElements({context: {helmet}}: HeadData, template: string) {
+  // There might be existing attributes in the template that are
+  // duplicated in the helmet. Transform them to props and back
+  // to string attributes to remove duplicates.
+  const htmlUniqueProps = attrsToProps(
+    `${getHtmlAttrs(template)} ${helmet.htmlAttributes}`
+  );
+  const bodyUniqueProps = attrsToProps(
+    `${getBodyAttrs(template)} ${helmet.bodyAttributes}`
+  );
+
+  return {
+    htmlAttrs: propsToAttrs(htmlUniqueProps),
+    bodyAttrs: propsToAttrs(bodyUniqueProps),
+    base: helmet.base.toString(),
+    link: helmet.link.toString(),
+    meta: helmet.meta.toString(),
+    noscript: helmet.noscript.toString(),
+    script: helmet.script.toString(),
+    style: helmet.style.toString(),
+    title: helmet.title.toString(),
+  };
+}
+
+/**
+ * Generate the contents of the `head` tag, and update the existing `<title>` tag
+ * if one exists, and if a title is passed.
+ */
+function generateHeadTag({title, ...rest}: Record<string, string>) {
+  const headProps = ['base', 'meta', 'style', 'noscript', 'script', 'link'];
+
+  const otherHeadProps = headProps
+    .map((prop) => rest[prop])
+    .filter(Boolean)
+    .join('\n');
+
+  return (_outerHtml: string, innerHtml: string) => {
+    let headHtml = otherHeadProps + innerHtml;
+
+    if (title) {
+      if (headHtml.includes('<title>')) {
+        headHtml = headHtml.replace(/(<title>(?:.|\n)*?<\/title>)/, title);
+      } else {
+        headHtml += title;
+      }
+    }
+
+    return `<head>${headHtml}</head>`;
+  };
 }

--- a/packages/playground/server-components/index.html
+++ b/packages/playground/server-components/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hydrogen App</title>
   </head>
-  <body>
+  <body data-my-attr=" some spaces here " class="pb-1" style="color: red">
     <div id="root"></div>
     <script type="module" src="/@shopify/hydrogen/entry-client"></script>
   </body>

--- a/packages/playground/server-components/src/routes/env.server.jsx
+++ b/packages/playground/server-components/src/routes/env.server.jsx
@@ -1,0 +1,18 @@
+import ClientEnv from '../components/ClientEnv.client';
+
+export default function Env() {
+  return (
+    <>
+      <h1>Env</h1>
+
+      <div className="secrets-server">
+        <div>PUBLIC_VARIABLE:{import.meta.env.PUBLIC_VARIABLE || ''}|</div>
+        <div>PRIVATE_VARIABLE:{Oxygen.env.PRIVATE_VARIABLE || ''}|</div>
+      </div>
+
+      <div className="secrets-client">
+        <ClientEnv />
+      </div>
+    </>
+  );
+}

--- a/packages/playground/server-components/src/routes/index.server.jsx
+++ b/packages/playground/server-components/src/routes/index.server.jsx
@@ -1,5 +1,4 @@
 import {Link} from '@shopify/hydrogen';
-import ClientEnv from '../components/ClientEnv.client';
 
 export function api() {
   return new Response('some api response');
@@ -11,15 +10,6 @@ export default function Index() {
       <h1>Home</h1>
 
       <div>Quotes should not make it crash: ` ' "</div>
-
-      <div className="secrets-server">
-        <div>PUBLIC_VARIABLE:{import.meta.env.PUBLIC_VARIABLE || ''}|</div>
-        <div>PRIVATE_VARIABLE:{Oxygen.env.PRIVATE_VARIABLE || ''}|</div>
-      </div>
-
-      <div className="secrets-client">
-        <ClientEnv />
-      </div>
 
       <Link className="btn" to="/about">
         About

--- a/packages/playground/server-components/src/routes/seo.server.jsx
+++ b/packages/playground/server-components/src/routes/seo.server.jsx
@@ -13,7 +13,7 @@ export default function Index() {
       <Head>
         <html lang="ja" />
         <meta property="og:url" content="example.com" />
-        <body data-test={true} />
+        <body data-test={true} className="pb-2" />
       </Head>
 
       <Suspense fallback={null}>

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -15,13 +15,6 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
     await page.goto(getServerUrl());
 
     expect(await page.textContent('h1')).toContain('Home');
-    const secretsServer = await page.textContent('.secrets-server');
-    expect(secretsServer).toContain('PUBLIC_VARIABLE:42-public|');
-    expect(secretsServer).toContain('PRIVATE_VARIABLE:42-private|');
-    const secretsClient = await page.textContent('.secrets-client');
-    expect(secretsClient).toContain('PUBLIC_VARIABLE:42-public|');
-    expect(secretsClient).toContain('PRIVATE_VARIABLE:|'); // Missing private var in client bundle
-
     await page.click('.btn');
 
     expect(await page.textContent('body')).toContain('About');
@@ -44,6 +37,18 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
     await page.goto(getServerUrl() + '/redirected');
     expect(await page.url()).toContain('/about');
     expect(await page.textContent('h1')).toContain('About');
+  });
+
+  it('has access to environment variables', async () => {
+    await page.goto(getServerUrl() + '/env');
+    expect(await page.textContent('h1')).toContain('Env');
+
+    const secretsServer = await page.textContent('.secrets-server');
+    expect(secretsServer).toContain('PUBLIC_VARIABLE:42-public|');
+    expect(secretsServer).toContain('PRIVATE_VARIABLE:42-private|');
+    const secretsClient = await page.textContent('.secrets-client');
+    expect(secretsClient).toContain('PUBLIC_VARIABLE:42-public|');
+    expect(secretsClient).toContain('PRIVATE_VARIABLE:|'); // Missing private var in client bundle
   });
 
   it('should support API route on a server component for POST methods', async () => {

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -278,8 +278,11 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
     const response = await fetch(getServerUrl() + '/seo?_bot');
     const body = await response.text();
 
-    expect(body).toContain('<html lang="ja"');
-    expect(body).toContain('<body data-test="true"');
+    expect(body).toContain('<html lang="ja">');
+    // Overwrites "class" and appends "data-test"
+    expect(body).toContain(
+      '<body data-my-attr=" some spaces here " class="pb-2" data-style="color: red" data-test="true">'
+    );
     expect(body).toMatch(
       /<meta\s+.*?property="og:url"\s+content="example.com"\s*\/>/
     );

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -15,6 +15,13 @@ export default async function testCases({getServerUrl, isBuild}: TestOptions) {
     await page.goto(getServerUrl());
 
     expect(await page.textContent('h1')).toContain('Home');
+
+    expect(await page.getAttribute('body', 'class')).toEqual('pb-1');
+    expect(await page.getAttribute('body', 'style')).toEqual(null); // Style is ignored
+    expect(await page.getAttribute('body', 'data-my-attr')).toEqual(
+      ' some spaces here '
+    );
+
     await page.click('.btn');
 
     expect(await page.textContent('body')).toContain('About');


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #750 

This extracts `<html>` and `<body>` attributes from `index.html` and adds it to the SSR response. It also allows overwriting these attributes with anything passed to `<Head>` component.

Some logic for generating HTML for bots has been moved to `Html.tsx` to make `entry-server` a bit lighter.

Related: #511 --  RTL attribute can be added to `index.html`. Should we close that issue?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
