### PR TITLE
[Hydrogen docs]: Add context about Strict Mode

### DIFF
--- a/.changeset/tidy-apricots-protect.md
+++ b/.changeset/tidy-apricots-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Hydrogen docs: Strict mode

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -100,6 +100,23 @@ export default renderHydrogen(ClientWrapper);
 
 {% endcodeblock %}
 
+#### Strict mode
+
+[Strict mode](https://reactjs.org/docs/strict-mode.html) is enabled by default for all Hydrogen apps in development. It includes [strict effects](https://github.com/reactwg/react-18/discussions/19), which mounts and unmounts components multiple times to catch potential issues with user or third-party code.
+
+If strict effects cause problems problems for your app, then you can turn off strict mode. Create a `src/entry-client.jsx` file in your project and set `strictMode` to `false`:
+
+{% codeblock file, filename: 'src/entry-client.jsx' %}
+
+```jsx
+renderHydrogen(ClientWrapper, {strictMode: false});
+```
+
+{% endcodeblock %}
+
+> Tip:
+> If you turn off strict mode, then we recommended that you still include the `StrictMode` component at as high of a level as possible in your React tree to catch errors.
+
 ### Change the server entry point
 
 If you need to change the server entry point, then make the following updates in the `package.json` file:

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -104,7 +104,7 @@ export default renderHydrogen(ClientWrapper);
 
 [Strict mode](https://reactjs.org/docs/strict-mode.html) is enabled by default for all Hydrogen apps in development. It includes [strict effects](https://github.com/reactwg/react-18/discussions/19), which mounts and unmounts components multiple times to catch potential issues with user or third-party code.
 
-If strict effects cause problems problems for your app, then you can turn off strict mode. Create a `src/entry-client.jsx` file in your project and set `strictMode` to `false`:
+If strict effects cause problems for your app, then you can turn off strict mode. Create a `src/entry-client.jsx` file in your project and set `strictMode` to `false`:
 
 {% codeblock file, filename: 'src/entry-client.jsx' %}
 
@@ -114,7 +114,7 @@ renderHydrogen(ClientWrapper, {strictMode: false});
 
 {% endcodeblock %}
 
-> Tip:
+> Caution:
 > If you turn off strict mode, then we recommended that you still include the `StrictMode` component at as high of a level as possible in your React tree to catch errors.
 
 ### Change the server entry point


### PR DESCRIPTION
## This PR: 
- Adds a new section in the Hydrogen framework docs about strict mode
- Fixes https://github.com/Shopify/hydrogen/issues/793
- Relates to https://github.com/Shopify/hydrogen/pull/763 and https://github.com/Shopify/shopify-dev/pull/17109

### Tophatted

<img width="839" alt="Screen Shot 2022-03-02 at 9 52 26 AM" src="https://user-images.githubusercontent.com/65373971/156420195-c6e5ba97-cc4e-4c50-bd20-746cbf610ab5.png">