### PR TITLE
RawHtml with dompurify

### DIFF
--- a/.changeset/chilled-numbers-turn.md
+++ b/.changeset/chilled-numbers-turn.md
@@ -1,0 +1,32 @@
+---
+'template-hydrogen-default': minor
+'@shopify/hydrogen': minor
+---
+
+`RawHtml` offically supports `DOMPurify` string sanitize with a new optional prop `dompurifyConfig`.
+By default, `DOMpurify` will have config to forbid `style` tags: `{FORBID_TAGS: ['style']}`.
+You can override this with `dompurifyConfig`.
+See [DOMPurify](https://github.com/cure53/DOMPurify#can-i-configure-dompurify) for more configuration options.
+
+Usage:
+
+```
+import {RawHtml} from '@shopify/hydrogen/client';
+
+<RawHtml string={collection.descriptionHtml} className="text-lg" dompurifyConfig={{
+  FORBID_TAGS: ['style', 'br']
+}}/>
+```
+
+To upgrade, make sure to change the import path to `@shopify/hydrogen/client`
+
+```diff
+- import {RawHtml} from '@shopify/hydrogen';
++ import {RawHtml} from '@shopify/hydrogen/client';
+```
+
+**Note:** We converted `RawHtml` to a client only component because `DOMPurify` cannot sanitize
+a string without a `DOM` object. `jsDOM` was the recommended library for running in node. However,
+this library will bloat the vendor bundle by 4MB and it does not work in a worker enviroment. By
+having `RawHtml` as a client componet, the string sanitization is happening in the client browser
+where there will always be a `DOM` object available.

--- a/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
@@ -3,9 +3,9 @@ import {
   ProductProviderFragment,
   useShopQuery,
   flattenConnection,
-  RawHtml,
   Seo,
 } from '@shopify/hydrogen';
+import {RawHtml} from '@shopify/hydrogen/client';
 import gql from 'graphql-tag';
 
 import LoadMoreProducts from '../../components/LoadMoreProducts.client';

--- a/examples/template-hydrogen-default/src/routes/pages/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/pages/[handle].server.jsx
@@ -1,4 +1,5 @@
-import {useShopQuery, RawHtml, Seo} from '@shopify/hydrogen';
+import {useShopQuery, Seo} from '@shopify/hydrogen';
+import {RawHtml} from '@shopify/hydrogen/client';
 import gql from 'graphql-tag';
 
 import Layout from '../../components/Layout.server';

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -98,15 +98,16 @@
     }
   },
   "dependencies": {
+    "@types/dompurify": "^2.3.3",
     "@vitejs/plugin-react": "^1.1.1",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.1",
     "connect": "^3.7.0",
+    "dompurify": "^2.3.6",
     "es-module-lexer": "^0.9.0",
     "fast-glob": "^3.2.5",
     "graphql": "^16.0.1",
     "history": "^5.2.0",
-    "isomorphic-dompurify": "^0.13.0",
     "kolorist": "^1.5.1",
     "magic-string": "^0.25.7",
     "node-fetch": "^2.6.7",

--- a/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
+++ b/packages/hydrogen/src/components/Metafield/Metafield.client.tsx
@@ -2,7 +2,7 @@ import React, {ElementType} from 'react';
 import {Props} from '../types';
 import {useShop} from '../../foundation';
 import {getMeasurementAsString} from '../../utilities';
-import {RawHtml} from '../RawHtml';
+import {RawHtml} from '../RawHtml/RawHtml.client';
 import {ParsedMetafield, Measurement, Rating} from '../../types';
 import {MetafieldFragment as Fragment} from '../../graphql/graphql-constants';
 import {Image} from '../Image';

--- a/packages/hydrogen/src/components/ProductDescription/ProductDescription.client.tsx
+++ b/packages/hydrogen/src/components/ProductDescription/ProductDescription.client.tsx
@@ -1,5 +1,5 @@
 import React, {ElementType} from 'react';
-import {RawHtml} from '../RawHtml';
+import {RawHtml} from '../RawHtml/RawHtml.client';
 import {useProduct} from '../ProductProvider';
 import {Props} from '../types';
 

--- a/packages/hydrogen/src/components/ProductDescription/tests/ProductDescription.test.tsx
+++ b/packages/hydrogen/src/components/ProductDescription/tests/ProductDescription.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {getProduct} from '../../../utilities/tests/product';
 import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {ProductProvider} from '../../ProductProvider';
-import {RawHtml} from '../../RawHtml';
+import {RawHtml} from '../../RawHtml/RawHtml.client';
 import {ProductDescription} from '../ProductDescription.client';
 
 describe('<ProductDescription/>', () => {

--- a/packages/hydrogen/src/components/RawHtml/README.md
+++ b/packages/hydrogen/src/components/RawHtml/README.md
@@ -10,7 +10,7 @@ To keep the text unsanitized, set the `unsanitized` prop to `true`.
 ## Example code
 
 ```tsx
-import {RawHtml} from '@shopify/hydrogen';
+import {RawHtml} from '@shopify/hydrogen/client';
 
 export function MyComponent() {
   return <RawHtml string="<p>Hello world</p>" />;

--- a/packages/hydrogen/src/components/RawHtml/RawHtml.client.tsx
+++ b/packages/hydrogen/src/components/RawHtml/RawHtml.client.tsx
@@ -1,20 +1,20 @@
 import React, {ElementType} from 'react';
 import {Props} from '../types';
+import DOMPurify from 'dompurify';
 
-// TODO: Revisit with Worker runtime
-// import * as DOMPurify from 'isomorphic-dompurify';
-
-// const DOMPURIFY_CONFIG = {
-//   FORBID_ATTR: ['style'],
-// };
+const DOMPURIFY_CONFIG = {
+  FORBID_ATTR: ['style'],
+};
 
 export interface RawHtmlProps<TTag> {
   /** An HTML string. */
   string: string;
-  /** Whether the HTML string should be sanitized with `isomorphic-dompurify`. */
+  /** Whether the HTML string should be sanitized with `DOMPurify`. */
   unsanitized?: boolean;
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
   as?: TTag;
+  /** A config object for DOMPurify. Defaults to `{ FORBID_ATTR: ['style'] }` */
+  dompurifyConfig?: any;
 }
 
 /**
@@ -22,21 +22,25 @@ export interface RawHtmlProps<TTag> {
  * displaying rich text-like descriptions associated with a product.
  *
  * The string passed to `RawHtml` is sanitized with
- * [isomorphic-dompurify](https://github.com/kkomelin/isomorphic-dompurify) by default.
+ * [DOMPurify](https://github.com/cure53/DOMPurify) by default.
  * To keep the text unsanitized, set the `unsanitized` prop to `true`.
  */
 export function RawHtml<TTag extends ElementType>(
   props: Props<TTag> & RawHtmlProps<TTag>
 ) {
-  const {string, unsanitized, as, ...passthroughProps} = props;
+  const {string, unsanitized, as, dompurifyConfig, ...passthroughProps} = props;
   const Wrapper = as ?? 'div';
+
   const sanitizedString = React.useMemo(() => {
-    if (unsanitized || true) {
+    if (unsanitized) {
       return string;
     }
 
     // TODO: Re-enable when we find a way to support Worker runtime
-    // return DOMPurify.sanitize(text, DOMPURIFY_CONFIG);
+    return DOMPurify.sanitize(
+      string,
+      dompurifyConfig || DOMPURIFY_CONFIG
+    ).toString();
   }, [string, !!unsanitized]);
 
   return (

--- a/packages/hydrogen/src/components/RawHtml/RawHtml.client.tsx
+++ b/packages/hydrogen/src/components/RawHtml/RawHtml.client.tsx
@@ -1,4 +1,4 @@
-import React, {ElementType} from 'react';
+import React, {ElementType, useEffect, useState} from 'react';
 import {Props} from '../types';
 import DOMPurify from 'dompurify';
 
@@ -32,18 +32,20 @@ export function RawHtml<TTag extends ElementType>(
 ) {
   const {string, unsanitized, as, dompurifyConfig, ...passthroughProps} = props;
   const Wrapper = as ?? 'div';
+  const [sanitizedString, setSanitizedString] = useState('');
 
-  const sanitizedString = React.useMemo(() => {
-    if (unsanitized) {
-      return string;
+  useEffect(() => {
+    if (!unsanitized) {
+      setSanitizedString(
+        DOMPurify.sanitize(
+          string,
+          dompurifyConfig || DOMPURIFY_CONFIG
+        ).toString()
+      );
+    } else {
+      setSanitizedString(string);
     }
-
-    // TODO: Re-enable when we find a way to support Worker runtime
-    return DOMPurify.sanitize(
-      string,
-      dompurifyConfig || DOMPURIFY_CONFIG
-    ).toString();
-  }, [string, !!unsanitized]);
+  }, [string, unsanitized]);
 
   return (
     <Wrapper

--- a/packages/hydrogen/src/components/RawHtml/RawHtml.client.tsx
+++ b/packages/hydrogen/src/components/RawHtml/RawHtml.client.tsx
@@ -2,7 +2,9 @@ import React, {ElementType} from 'react';
 import {Props} from '../types';
 import DOMPurify from 'dompurify';
 
-const DOMPURIFY_CONFIG = {
+import type {Config as DOMPurifyConfig} from 'dompurify';
+
+const DOMPURIFY_CONFIG: DOMPurifyConfig = {
   FORBID_ATTR: ['style'],
 };
 
@@ -14,7 +16,7 @@ export interface RawHtmlProps<TTag> {
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
   as?: TTag;
   /** A config object for DOMPurify. Defaults to `{ FORBID_ATTR: ['style'] }` */
-  dompurifyConfig?: any;
+  dompurifyConfig?: DOMPurifyConfig;
 }
 
 /**

--- a/packages/hydrogen/src/components/RawHtml/examples/raw-html.example.tsx
+++ b/packages/hydrogen/src/components/RawHtml/examples/raw-html.example.tsx
@@ -1,4 +1,4 @@
-import {RawHtml} from '@shopify/hydrogen';
+import {RawHtml} from '@shopify/hydrogen/client';
 
 export function MyComponent() {
   return <RawHtml string="<p>Hello world</p>" />;

--- a/packages/hydrogen/src/components/RawHtml/index.ts
+++ b/packages/hydrogen/src/components/RawHtml/index.ts
@@ -1,1 +1,1 @@
-export {RawHtml, RawHtmlProps} from './RawHtml';
+export {RawHtml, RawHtmlProps} from './RawHtml.client';

--- a/packages/hydrogen/src/components/RawHtml/tests/RawHtml.test.tsx
+++ b/packages/hydrogen/src/components/RawHtml/tests/RawHtml.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {RawHtml} from '../RawHtml';
+import {RawHtml} from '../RawHtml.client';
 import {Link} from '../../Link/index';
 
 describe('<RawHtml />', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,10 +2182,10 @@
   resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
   integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
 
-"@types/dompurify@^2.1.0":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.3.1.tgz#2934adcd31c4e6b02676f9c22f9756e5091c04dd"
-  integrity sha512-YJth9qa0V/E6/XPH1Jq4BC8uCMmO8V1fKWn8PCvuZcAhMn7q0ez9LW6naQT04UZzjFfAPhyRMZmI2a2rbMlEFA==
+"@types/dompurify@^2.3.3":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.3.3.tgz#c24c92f698f77ed9cc9d9fa7888f90cf2bfaa23f"
+  integrity sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==
   dependencies:
     "@types/trusted-types" "*"
 
@@ -4367,10 +4367,10 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-dompurify@^2.2.7:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.4.tgz#1cf5cf0105ccb4debdf6db162525bd41e6ddacc6"
-  integrity sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ==
+dompurify@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.6.tgz#2e019d7d7617aacac07cbbe3d88ae3ad354cf875"
+  integrity sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg==
 
 domutils@^1.5.1:
   version "1.7.0"
@@ -6759,15 +6759,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-dompurify@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-dompurify/-/isomorphic-dompurify-0.13.0.tgz#a4dde357e8531018a85ebb2dd56c4794b6739ba3"
-  integrity sha512-j2/kt/PGbxvfeEm1uiRLlttZkQdn3hFe1rMr/wm3qFnMXSIw0Nmqu79k+TIoSj+KOwO98Sz9TbuNHU7ejv7IZA==
-  dependencies:
-    "@types/dompurify" "^2.1.0"
-    dompurify "^2.2.7"
-    jsdom "^16.5.2"
-
 isomorphic-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
@@ -7241,7 +7232,7 @@ js-yaml@^4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^16.4.0, jsdom@^16.5.2:
+jsdom@^16.4.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710"
   integrity sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==


### PR DESCRIPTION
Fix: https://github.com/Shopify/hydrogen/issues/58

### Description

We disabled `DOMPurify` for dev preview and now we are bringing the support back.

Added a new optional prop:

* `dompurifyConfig`- A config object for DOMPurify. Defaults to `{ FORBID_ATTR: ['style'] }`

### Breaking Change

`RawHtml` is now a client only component. Make sure to update the path reference.

```diff
- import {RawHtml} from '@shopify/hydrogen';
+ import {RawHtml} from '@shopify/hydrogen/client';
```


### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
