### PR TITLE
fix linesAdd to create cart when it does not exist

### DIFF
--- a/.changeset/afraid-meals-fly.md
+++ b/.changeset/afraid-meals-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Update `linesAdd` to create cart if cart does not exist.

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -38,7 +38,7 @@ export function AddToCartButton<TTag extends React.ElementType = 'button'>(
     accessibleAddingToCartLabel,
     ...passthroughProps
   } = props;
-  const {status, id, cartCreate, linesAdd} = useCart();
+  const {status, linesAdd} = useCart();
   const product = useProduct();
   const variantId = explicitVariantId ?? product?.selectedVariant?.id ?? '';
   const disabled =
@@ -61,25 +61,13 @@ export function AddToCartButton<TTag extends React.ElementType = 'button'>(
         disabled={disabled}
         onClick={() => {
           setAddingItem(true);
-          if (!id) {
-            cartCreate({
-              lines: [
-                {
-                  quantity: quantity,
-                  merchandiseId: variantId,
-                  attributes: attributes,
-                },
-              ],
-            });
-          } else {
-            linesAdd([
-              {
-                quantity: quantity,
-                merchandiseId: variantId,
-                attributes: attributes,
-              },
-            ]);
-          }
+          linesAdd([
+            {
+              quantity: quantity,
+              merchandiseId: variantId,
+              attributes: attributes,
+            },
+          ]);
         }}
       >
         {children}

--- a/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
@@ -61,233 +61,80 @@ describe('AddToCartButton', () => {
       });
     });
 
-    describe('and a Cart Id is present', () => {
-      it('calls linesAdd with the variantId', () => {
-        const mockLinesAdd = jest.fn();
-        const id = '123';
-        const component = mountWithCartProvider(
-          <AddToCartButton variantId={id}>Add to cart</AddToCartButton>,
-          {linesAdd: mockLinesAdd, cart: {id: '456'}}
-        );
-        component.find('button')?.trigger('onClick');
+    it('calls linesAdd with the variantId', () => {
+      const mockLinesAdd = jest.fn();
+      const id = '123';
+      const component = mountWithCartProvider(
+        <AddToCartButton variantId={id}>Add to cart</AddToCartButton>,
+        {linesAdd: mockLinesAdd, cart: {id: '456'}}
+      );
+      component.find('button')?.trigger('onClick');
 
-        expect(mockLinesAdd).toHaveBeenCalledTimes(1);
-        expect(mockLinesAdd).toHaveBeenCalledWith([
-          expect.objectContaining({
-            merchandiseId: id,
-          }),
-        ]);
-      });
-    });
-
-    describe('and a Cart Id is not present', () => {
-      it('calls createCart with the variantId', () => {
-        const mockCreateCart = jest.fn();
-        const id = '123';
-        const component = mountWithCartProvider(
-          <AddToCartButton variantId={id}>Add to cart</AddToCartButton>,
-          {cartCreate: mockCreateCart}
-        );
-        component.find('button')?.trigger('onClick');
-
-        expect(mockCreateCart).toHaveBeenCalledTimes(1);
-        expect(mockCreateCart).toHaveBeenCalledWith({
-          lines: [
-            expect.objectContaining({
-              merchandiseId: id,
-            }),
-          ],
-        });
-      });
+      expect(mockLinesAdd).toHaveBeenCalledTimes(1);
+      expect(mockLinesAdd).toHaveBeenCalledWith([
+        expect.objectContaining({
+          merchandiseId: id,
+        }),
+      ]);
     });
   });
 
   describe('when inside a ProductProvider', () => {
     describe('and an initialVariantId is present', () => {
-      describe('and a Cart ID is present', () => {
-        it('calls linesAdd with the initialVariantId', () => {
-          const mockLinesAdd = jest.fn();
-          const product = getProduct();
-          const selectedVariant = product.variants.edges[0].node;
+      it('calls linesAdd with the initialVariantId', () => {
+        const mockLinesAdd = jest.fn();
+        const product = getProduct();
+        const selectedVariant = product.variants.edges[0].node;
 
-          const component = mountWithCartProvider(
-            <ProductProvider
-              data={product}
-              initialVariantId={selectedVariant.id}
-            >
-              <AddToCartButton>Add to cart</AddToCartButton>
-            </ProductProvider>,
-            {linesAdd: mockLinesAdd, cart: {id: '456'}}
-          );
+        const component = mountWithCartProvider(
+          <ProductProvider data={product} initialVariantId={selectedVariant.id}>
+            <AddToCartButton>Add to cart</AddToCartButton>
+          </ProductProvider>,
+          {linesAdd: mockLinesAdd, cart: {id: '456'}}
+        );
 
-          component.find('button')?.trigger('onClick');
+        component.find('button')?.trigger('onClick');
 
-          expect(mockLinesAdd).toHaveBeenCalledTimes(1);
-          expect(mockLinesAdd).toHaveBeenCalledWith([
-            expect.objectContaining({
-              merchandiseId: selectedVariant.id,
-            }),
-          ]);
-        });
-      });
-
-      describe('and a Cart Id is not present', () => {
-        it('calls createCart with the initialVariantId', () => {
-          const mockCreateCart = jest.fn();
-          const product = getProduct();
-          const selectedVariant = product.variants.edges[0].node;
-
-          const component = mountWithCartProvider(
-            <ProductProvider
-              data={product}
-              initialVariantId={selectedVariant.id}
-            >
-              <AddToCartButton>Add to cart</AddToCartButton>
-            </ProductProvider>,
-            {cartCreate: mockCreateCart}
-          );
-
-          component.find('button')?.trigger('onClick');
-
-          expect(mockCreateCart).toHaveBeenCalledTimes(1);
-          expect(mockCreateCart).toHaveBeenCalledWith({
-            lines: [
-              expect.objectContaining({
-                merchandiseId: selectedVariant.id,
-              }),
-            ],
-          });
-        });
+        expect(mockLinesAdd).toHaveBeenCalledTimes(1);
+        expect(mockLinesAdd).toHaveBeenCalledWith([
+          expect.objectContaining({
+            merchandiseId: selectedVariant.id,
+          }),
+        ]);
       });
     });
 
     describe('and the initialVariantId is omitted', () => {
-      describe('and a Cart Id is present', () => {
-        it('calls linesAdd with the first available variant', () => {
-          const mockLinesAdd = jest.fn();
-          const product = getProduct({
-            variants: {
-              edges: [
-                {
-                  node: getVariant({
-                    availableForSale: true,
-                    id: 'some variant id',
-                  }) as any,
-                },
-              ],
-            },
-          });
-
-          const component = mountWithCartProvider(
-            <ProductProvider data={product}>
-              <AddToCartButton>Add to cart</AddToCartButton>
-            </ProductProvider>,
-            {linesAdd: mockLinesAdd, cart: {id: '456'}}
-          );
-
-          component.find('button')?.trigger('onClick');
-
-          expect(mockLinesAdd).toHaveBeenCalledTimes(1);
-          expect(mockLinesAdd).toHaveBeenCalledWith([
-            expect.objectContaining({
-              merchandiseId: 'some variant id',
-            }),
-          ]);
-        });
-      });
-
-      describe('and a Cart ID is not present', () => {
-        it('calls createCart with the first available variant', () => {
-          const mockCreateCart = jest.fn();
-          const product = getProduct({
-            variants: {
-              edges: [
-                {
-                  node: getVariant({
-                    availableForSale: false,
-                    id: 'some-unavailable-variant-id',
-                  }) as any,
-                },
-                {
-                  node: getVariant({
-                    availableForSale: true,
-                    id: 'an-available-variant-id',
-                  }) as any,
-                },
-                {
-                  node: getVariant({
-                    availableForSale: false,
-                    id: 'another-unavailable-variant-id',
-                  }) as any,
-                },
-                {
-                  node: getVariant({
-                    availableForSale: true,
-                    id: 'another-available-variant-id',
-                  }) as any,
-                },
-              ],
-            },
-          });
-
-          const component = mountWithCartProvider(
-            <ProductProvider data={product}>
-              <AddToCartButton>Add to cart</AddToCartButton>
-            </ProductProvider>,
-            {cartCreate: mockCreateCart}
-          );
-
-          component.find('button')?.trigger('onClick');
-
-          expect(mockCreateCart).toHaveBeenCalledTimes(1);
-          expect(mockCreateCart).toHaveBeenCalledWith({
-            lines: [
-              expect.objectContaining({
-                merchandiseId: 'an-available-variant-id',
-              }),
+      it('calls linesAdd with the first available variant', () => {
+        const mockLinesAdd = jest.fn();
+        const product = getProduct({
+          variants: {
+            edges: [
+              {
+                node: getVariant({
+                  availableForSale: true,
+                  id: 'some variant id',
+                }) as any,
+              },
             ],
-          });
+          },
         });
 
-        it('calls createCart with the first variant when non are available', () => {
-          const mockCreateCart = jest.fn();
-          const product = getProduct({
-            variants: {
-              edges: [
-                {
-                  node: getVariant({
-                    availableForSale: false,
-                    id: 'some-unavailable-variant-id',
-                  }) as any,
-                },
-                {
-                  node: getVariant({
-                    availableForSale: false,
-                    id: 'another-unavailable-variant-id',
-                  }) as any,
-                },
-              ],
-            },
-          });
+        const component = mountWithCartProvider(
+          <ProductProvider data={product}>
+            <AddToCartButton>Add to cart</AddToCartButton>
+          </ProductProvider>,
+          {linesAdd: mockLinesAdd, cart: {id: '456'}}
+        );
 
-          const component = mountWithCartProvider(
-            <ProductProvider data={product}>
-              <AddToCartButton>Add to cart</AddToCartButton>
-            </ProductProvider>,
-            {cartCreate: mockCreateCart, cart: null}
-          );
+        component.find('button')?.trigger('onClick');
 
-          component.find('button')?.trigger('onClick');
-
-          expect(mockCreateCart).toHaveBeenCalledTimes(1);
-          expect(mockCreateCart).toHaveBeenCalledWith({
-            lines: [
-              expect.objectContaining({
-                merchandiseId: 'some-unavailable-variant-id',
-              }),
-            ],
-          });
-        });
+        expect(mockLinesAdd).toHaveBeenCalledTimes(1);
+        expect(mockLinesAdd).toHaveBeenCalledWith([
+          expect.objectContaining({
+            merchandiseId: 'some variant id',
+          }),
+        ]);
       });
     });
 

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -644,7 +644,11 @@ export function CartProvider({
           : 0,
       cartCreate,
       linesAdd(lines: CartLineInput[]) {
-        addLineItem(lines, state);
+        if ('cart' in state && state.cart.id) {
+          addLineItem(lines, state);
+        } else {
+          cartCreate({lines});
+        }
       },
       linesRemove(lines: string[]) {
         removeLineItem(lines, state);

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProvider.client.test.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProvider.client.test.tsx
@@ -1,39 +1,124 @@
-import * as React from 'react';
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {flattenConnection} from '../../../utilities';
 import {CartContext} from '../context';
-import {mountWithCartProvider} from './utilities';
 import {CART_WITH_LINES} from './fixtures';
 import type {CartLineInput} from '../../../graphql/types/types';
-const useCartFetch = jest.fn();
+
+import {CartProvider} from '../CartProvider.client';
+
+const fetchCartMock = jest.fn(() => ({data: {}}));
+
 jest.mock('../hooks', () => {
   return {
-    useCartFetch: useCartFetch,
+    useCartFetch: () => fetchCartMock,
   };
 });
 
-describe(`CartProvider.client`, () => {
-  describe(`totalQuantity`, () => {
-    let TotalQuantity = () => (
-      <CartContext.Consumer>
-        {(cartContext) => {
-          return <div>{cartContext?.totalQuantity}</div>;
-        }}
-      </CartContext.Consumer>
-    );
+describe('<CartProvider />', () => {
+  beforeEach(() => {
+    fetchCartMock.mockReset();
+    fetchCartMock.mockReturnValue({data: {}});
+  });
 
-    beforeEach(() => {
-      useCartFetch.mockReset();
+  describe('prop `data` does not exist', () => {
+    it('renders CartContext.Provider with default cart data and status=uninitialized', () => {
+      const wrapper = mount(<CartProvider>test</CartProvider>);
+
+      expect(wrapper).toContainReactComponent(CartContext.Provider, {
+        value: expect.objectContaining({
+          lines: [],
+          attributes: [],
+        }),
+      });
     });
 
-    it(`should start with 1`, () => {
-      const mount = mountWithCartProvider(<TotalQuantity />);
-      expect(mount).toContainReactText(`1`);
+    it('renders CartContext.Provider with status=uninitialized', () => {
+      const wrapper = mount(<CartProvider>test</CartProvider>);
+
+      expect(wrapper).toContainReactComponent(CartContext.Provider, {
+        value: expect.objectContaining({
+          status: 'uninitialized',
+          error: undefined,
+        }),
+      });
+    });
+  });
+
+  describe('prop `data` exist', () => {
+    it('renders CartContext.Provider with cart data and flatten lines', () => {
+      const wrapper = mount(
+        <CartProvider data={CART_WITH_LINES}>test</CartProvider>
+      );
+
+      expect(wrapper).toContainReactComponent(CartContext.Provider, {
+        value: expect.objectContaining({
+          ...CART_WITH_LINES,
+          lines: flattenConnection(CART_WITH_LINES.lines),
+        }),
+      });
     });
 
-    xit(`should add 1 line when a new line is added with quantity of 1, for a total of 2`, () => {
+    it('renders CartContext.Provider with status=idle follows by status=updating', () => {
+      const cartContextMock = jest.fn();
+      mount(
+        <CartProvider data={CART_WITH_LINES}>
+          <CartContext.Consumer>
+            {(cartContext) => {
+              cartContextMock(cartContext);
+              return null;
+            }}
+          </CartContext.Consumer>
+        </CartProvider>
+      );
+
+      expect(cartContextMock.mock.calls).toHaveLength(2);
+
+      expect(cartContextMock.mock.calls[0][0]).toMatchObject(
+        expect.objectContaining({
+          status: 'idle',
+          error: undefined,
+        })
+      );
+
+      expect(cartContextMock.mock.calls[1][0]).toMatchObject(
+        expect.objectContaining({
+          status: 'updating',
+        })
+      );
+    });
+  });
+
+  describe('totalQuantity', () => {
+    it('defaults to 0 when cart is empty', () => {
+      const wrapper = mount(<CartProvider>test</CartProvider>);
+
+      expect(wrapper).toContainReactComponent(CartContext.Provider, {
+        value: expect.objectContaining({
+          totalQuantity: 0,
+        }),
+      });
+    });
+
+    it('starts with the line numbers in the cart', () => {
+      const wrapper = mount(
+        <CartProvider data={CART_WITH_LINES}>test</CartProvider>
+      );
+
+      expect(wrapper).toContainReactComponent(CartContext.Provider, {
+        value: expect.objectContaining({
+          totalQuantity: CART_WITH_LINES.lines.edges.length,
+        }),
+      });
+    });
+
+    it.skip('increase by 1 when a new line is added', () => {
       const newLine: CartLineInput = {
         merchandiseId: '123',
       };
-      useCartFetch.mockReturnValue({
+
+      fetchCartMock.mockReturnValue({
         data: {
           cartLinesAdd: {
             cart: {
@@ -44,12 +129,11 @@ describe(`CartProvider.client`, () => {
         },
       });
 
-      TotalQuantity = () => (
-        <CartContext.Consumer>
-          {(cartContext) => {
-            return (
-              <div>
-                <span id="quantity">{cartContext?.totalQuantity}</span>
+      const wrapper = mount(
+        <CartProvider data={CART_WITH_LINES}>
+          <CartContext.Consumer>
+            {(cartContext) => {
+              return (
                 <button
                   onClick={() => {
                     cartContext?.linesAdd([newLine]);
@@ -57,15 +141,120 @@ describe(`CartProvider.client`, () => {
                 >
                   Add
                 </button>
-              </div>
-            );
-          }}
-        </CartContext.Consumer>
+              );
+            }}
+          </CartContext.Consumer>
+        </CartProvider>
       );
 
-      const mount = mountWithCartProvider(<TotalQuantity />);
-      mount.act(() => mount.find('button')?.trigger('onClick'));
-      expect(mount.find('span')).toContainReactText(`2`);
+      wrapper.find('button')?.trigger('onClick');
+
+      expect(wrapper).toContainReactComponent(CartContext.Provider, {
+        value: expect.objectContaining({
+          totalQuantity: CART_WITH_LINES.lines.edges.length + 1,
+        }),
+      });
+    });
+  });
+
+  describe('linesAdd()', () => {
+    it('calls CartCreateMutation with lines if cart id does not exist', () => {
+      const linesMock: CartLineInput[] = [
+        {
+          merchandiseId: '123',
+        },
+      ];
+
+      const wrapper = mount(
+        <CartProvider>
+          <CartContext.Consumer>
+            {(cartContext) => {
+              return (
+                <button
+                  onClick={() => {
+                    cartContext?.linesAdd(linesMock);
+                  }}
+                >
+                  Add
+                </button>
+              );
+            }}
+          </CartContext.Consumer>
+        </CartProvider>
+      );
+
+      expect(
+        wrapper.find(CartContext.Provider)?.prop('value')
+      ).not.toHaveProperty('id');
+
+      wrapper.find('button')?.trigger('onClick');
+
+      expect(fetchCartMock).toHaveBeenLastCalledWith({
+        query: expect.stringContaining('mutation CartCreate'),
+        variables: {
+          input: {lines: linesMock},
+          numCartLines: undefined,
+          country: undefined,
+        },
+      });
+    });
+
+    it.skip('calls CartLineAddMutation with lines if cart id exist', () => {
+      Object.defineProperties(window, {
+        localStorage: {
+          value: {
+            getItem: jest.fn().mockReturnValue('abc'),
+            removeItem: jest.fn(),
+          },
+        },
+      });
+
+      fetchCartMock.mockReturnValue({
+        data: {
+          cartLinesAdd: {
+            cart: CART_WITH_LINES,
+          },
+        },
+      });
+
+      const linesMock: CartLineInput[] = [
+        {
+          merchandiseId: '123',
+        },
+      ];
+
+      const wrapper = mount(
+        <CartProvider>
+          <CartContext.Consumer>
+            {(cartContext) => {
+              return (
+                <button
+                  onClick={() => {
+                    cartContext?.linesAdd(linesMock);
+                  }}
+                >
+                  Add
+                </button>
+              );
+            }}
+          </CartContext.Consumer>
+        </CartProvider>
+      );
+
+      expect(wrapper.find(CartContext.Provider)?.prop('value')).toHaveProperty(
+        'id'
+      );
+
+      wrapper.find('button')?.trigger('onClick');
+
+      expect(fetchCartMock).toHaveBeenLastCalledWith({
+        query: expect.stringContaining('mutation CartLineAdd'),
+        variables: {
+          input: {lines: linesMock},
+          numCartLines: undefined,
+          country: undefined,
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/Shopify/hydrogen/issues/723

### Additional context

A few more test were also added to test with data & without data scenario when using `CartProvider`

Two test were skip here, one were skip because previously but I also had to skip another test I added.

This is because we are using `@shopify/react-testing` which only support React <= v17, and we are using `react-dom@0.0.0-experimental-529dc3ce8-20220124` that has a different internal and the test utility falls whenever it encounter state update that end up updating the dom.

Not for this PR to resolve, I log an issue [here](https://github.com/Shopify/hydrogen/issues/800).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
