### PR TITLE
Update migration guide for product images

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -145,7 +145,7 @@ The following aliases have been removed. Use each component's original name:
 - `Product.SelectedVariant.BuyNowButton`: Use [`SelectedVariantBuyNowButton`](https://shopify.dev/api/hydrogen/components/product-variant/selectedvariantbuynowbutton) instead.
 - `Product.SelectedVariant.ShopPayButton`: Use [`SelectedVariantShopPayButton`](https://shopify.dev/api/hydrogen/components/product-variant/selectedvariantshoppaybutton) instead.
 - `Product.SelectedVariant.Price`: Use [`SelectedVariantPrice`](https://shopify.dev/api/hydrogen/components/product-variant/selectedvariantprice) instead.
-- `Product.SelectedVariant.Image` Use [`SelectedVariantImage`](https://shopify.dev/api/hydrogen/components/product-variant/selectedvariantimage) instead.
+- `Product.SelectedVariant.Image` Use [`Image`](https://shopify.dev/api/hydrogen/components/primitive/image) instead.
 - `Product.SelectedVariant.UnitPrice`: Use [`SelectedVariantUnitPrice`](https://shopify.dev/api/hydrogen/components/product-variant/selectedvariantunitprice) instead.
 - `Product.SelectedVariant.Metafield`: Use [`SelectedVariantMetafield`](https://shopify.dev/api/hydrogen/components/product-variant/selectedvariantmetafield) instead.
 - `Cart`: Use [`CartProvider`](https://shopify.dev/api/hydrogen/components/cart/cartprovider) instead.
@@ -167,7 +167,7 @@ The following aliases have been removed. Use each component's original name:
 -   <Product.Image/>
 - </Product>
 + <ProductProvider>
-+  <ProductImage/>
++  <Image data={product.selectedVariant.image} />
 + </ProductProvider>
 ```
 


### PR DESCRIPTION
### Description

Updates migration guide to use `<Image data={product.selectedVariant.image} />` in favour of `<ProductImage />` and `<SelectedVariantImage />`

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
