### PR TITLE
Avoid accessing undefined global __flight

### DIFF
--- a/.changeset/healthy-pets-unite.md
+++ b/.changeset/healthy-pets-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Avoid accessing undefined global \_\_flight as a side effect of another unknown error.

--- a/packages/hydrogen/src/framework/Hydration/rsc.ts
+++ b/packages/hydrogen/src/framework/Hydration/rsc.ts
@@ -17,7 +17,7 @@ declare global {
 
 let rscReader: ReadableStream | null;
 
-if (__flight && __flight.length > 0) {
+if (globalThis.__flight && __flight.length > 0) {
   const contentLoaded = new Promise((resolve) =>
     document.addEventListener('DOMContentLoaded', resolve)
   );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If an error occurs during SSR/RSC, the global `__flight` variable might not be populated. As a result, the browser throws `Reference Error: __flight is not defined`, which might be masking the original error.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
