### PR TITLE
Fix changeset publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,6 +34,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: yarn run version
+          publish: yarn changeset tag
           commit: '[ci] release'
           title: '[ci] release'
         env:


### PR DESCRIPTION
Runs [changeset tag](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#tag) on publish, which is the "git-only" alternative to `changeset publish`. This script is required to be specified for the publish behavior to happen at all.

What happens after this is that the log output is collected by the Changesets GH Action, the tags are pushed back to the Git repo, and GitHub Releases are created.

Fixes #784 