### PR TITLE
Support non-PascalCase filenames for client components

### DIFF
--- a/.changeset/shaggy-bees-promise.md
+++ b/.changeset/shaggy-bees-promise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Support non-PascalCase filenames for client components.

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
@@ -17,10 +17,10 @@ import {createElement} from 'react';
 // to load them later when consuming the response in SSR.
 globalThis.__COMPONENT_INDEX = {};
 
-function isReactComponent(component, name) {
+function isReactComponent(component, name, isNamed) {
   if (!component) return false;
   return (
-    (typeof component === 'function' && /^[A-Z]/.test(name)) ||
+    (typeof component === 'function' && (!isNamed || /^[A-Z]/.test(name))) ||
     typeof component.render === 'function' ||
     component.$$typeof === Symbol.for('react.element')
   );
@@ -34,7 +34,7 @@ function wrapInClientProxy(_ref) {
     named = _ref.named,
     component = _ref.component;
 
-  if (!isReactComponent(component, name)) {
+  if (!isReactComponent(component, name, named)) {
     // This is not a React component, do not wrap it.
     return component;
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #802 

We were using the filename to decide if the default export is a React component or not. This is a temporary fix until we have a new iteration of Vite<>RSC.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
