### PR TITLE
Fix errors in CLI unit tests

### DIFF
--- a/packages/cli/src/commands/preview/tests/preview.test.ts
+++ b/packages/cli/src/commands/preview/tests/preview.test.ts
@@ -8,7 +8,7 @@ describe('preview', () => {
 
       expect(output).toContain('worker not found');
       expect(output).toContain(
-        'Run `yarn run build` to generate a worker build and try again.'
+        'build` to generate a worker build and try again.'
       );
     });
   });

--- a/packages/cli/src/tests/cli.test.ts
+++ b/packages/cli/src/tests/cli.test.ts
@@ -26,9 +26,7 @@ describe('CLI', () => {
       const result = await run('foo' as Command);
 
       expect(result.output.stdout).toStrictEqual(
-        expect.arrayContaining([
-          expect.stringMatching('Command module not found'),
-        ])
+        expect.arrayContaining([expect.stringMatching('Cannot find module')])
       );
     });
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Some CLI unit tests are logging wrong expected values like if they are failing but they are actually passing 🤯 
This fixes a couple of the issues.

<img width="849" alt="image" src="https://user-images.githubusercontent.com/1634092/156755689-5d345374-7cd3-4963-bd3b-8cf5fe6192ef.png">


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
