### PR TITLE
Improve the default error boundary template for production

### DIFF
--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -65,12 +65,39 @@ function Content({
 }
 
 function Error({error}: {error: Error}) {
+  if (import.meta.env.DEV) {
+    return (
+      <div style={{padding: '1em'}}>
+        <h1 style={{fontSize: '2em', marginBottom: '1em', fontWeight: 'bold'}}>
+          Error
+        </h1>
+
+        <pre style={{whiteSpace: 'pre-wrap'}}>{error.stack}</pre>
+      </div>
+    );
+  }
+
   return (
-    <div style={{padding: '1em'}}>
+    <div
+      style={{
+        padding: '2em',
+        textAlign: 'center',
+      }}
+    >
       <h1 style={{fontSize: '2em', marginBottom: '1em', fontWeight: 'bold'}}>
-        Error
+        Something's wrong here...
       </h1>
-      <pre style={{whiteSpace: 'pre-wrap'}}>{error.stack}</pre>
+
+      <div style={{fontSize: '1.1em'}}>
+        <p>We found an error while loading this page.</p>
+        <p>
+          Please, refresh or go back to the{' '}
+          <a href="/" style={{textDecoration: 'underline'}}>
+            home page
+          </a>
+          .
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When an error occurs (like SFAPI error), we are currently showing the error stack in production, which is not very good UX.
I think we should:

- Add a minimal error message in the outer-most error boundary (inside Hydrogen itself) like the one provided in this PR (perhaps improving the wording). -- Assuming Tailwind is not loaded here.
- Add at least 1 more error boundary within `App.server.jsx` with a better style that aligns with the starter template.
- Add docs about error boundaries or even add more examples within the starter template where it makes sense so we show errors localized in the UI.

Thoughts? @jplhomer @vlucas 

<img width="616" alt="image" src="https://user-images.githubusercontent.com/1634092/156769378-9304c611-748f-4c0d-a358-28b87238ddb1.png">


<img width="616" alt="image" src="https://user-images.githubusercontent.com/1634092/156769284-6973208b-fcb1-4358-97fe-bcbe8bc26735.png">


---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
