### PR TITLE
Force terminal colors in tests for Vite CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test-e2e": "jest --config jest-e2e.config.ts",
-    "test:vite-ci": "jest && jest --config jest-e2e.config.ts",
+    "test:vite-ci": "cross-env FORCE_COLOR=true jest && jest --config jest-e2e.config.ts",
     "version": "changeset version && node -p \"'export const LIB_VERSION = \\'' + require('./packages/hydrogen/package.json').version + '\\';'\" > packages/hydrogen/src/version.ts",
     "hydrogen": "./packages/cli/bin/hydrogen",
     "h2": "./packages/cli/bin/hydrogen",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Tests fail when running in Vite CI because terminal colors are disabled by default, and that makes some of our Jest snapshot tests fail. [More info here](https://github.com/vitejs/vite-ecosystem-ci/pull/42)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
