### PR TITLE
Improve logging for useShopQuery errors

### DIFF
--- a/.changeset/plenty-squids-clap.md
+++ b/.changeset/plenty-squids-clap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improve logging for useShopQuery errors

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -126,7 +126,7 @@ function createShopRequest(body: string, locale?: string) {
 
 function createErrorMessage(fetchError: Response | Error) {
   if (fetchError instanceof Response) {
-    `Failed to fetch the Storefront API. ${
+    `An error occurred while fetching from the Storefront API. ${
       // 403s to the SF API (almost?) always mean that your Shopify credentials are bad/wrong
       fetchError.status === 403
         ? `You may have a bad value in 'shopify.config.js'`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We've seen numerous reports of this error in development and production:

```
Error: Failed to fetch the Storefront API. undefined
```

Which like, super sucks as an error. 

What's actually happening is that we were assuming all `fetchError`s returned from `useQuery` were `Response` objects. However, these can be regular errors thrown due to issues with reading from cache, constructing requests, etc.

This PR adds a check to get a better formatted error message. It also logs out the original error instead of just the formatted error string.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
