### PR TITLE
Remove unnecessary Prop type

### DIFF
--- a/.changeset/quick-jeans-visit.md
+++ b/.changeset/quick-jeans-visit.md
@@ -1,0 +1,19 @@
+---
+'@shopify/hydrogen': patch
+---
+
+`@shopify/hydrogen` will no longer export the following types
+
+- MediaFileProps
+- VideoProps
+- ImageProps
+- ExternalVideoProps
+- RawHtmlProps
+- AddToCartButtonProps
+- ModelViewerProps
+- MoneyProps
+- BuyNowButtonProps
+- BuyNowButtonPropsWeControl
+- ShopPayButtonProps
+
+Any Component props type should be typed instead with `React.ComponentProps<typeof MyComponent>`.

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -1,9 +1,8 @@
 import React, {ReactNode, useEffect, useState} from 'react';
 import {useCart} from '../CartProvider';
 import {useProduct} from '../ProductProvider';
-import {Props} from '../types';
 
-export interface AddToCartButtonProps {
+interface AddToCartButtonProps {
   /** An array of cart line attributes that belong to the item being added to the cart. */
   attributes?: {
     key: string;
@@ -25,8 +24,9 @@ type PropsWeControl = 'onClick';
  * The `AddToCartButton` component renders a button that adds an item to the cart when pressed.
  * It must be a descendent of the `CartProvider` component.
  */
-export function AddToCartButton<TTag extends React.ElementType = 'button'>(
-  props: Props<TTag, PropsWeControl> & AddToCartButtonProps
+export function AddToCartButton(
+  props: Omit<JSX.IntrinsicElements['button'], PropsWeControl> &
+    AddToCartButtonProps
 ) {
   const [addingItem, setAddingItem] = useState<boolean>(false);
   const {
@@ -34,7 +34,6 @@ export function AddToCartButton<TTag extends React.ElementType = 'button'>(
     quantity = 1,
     attributes,
     children,
-    onAdd,
     accessibleAddingToCartLabel,
     ...passthroughProps
   } = props;

--- a/packages/hydrogen/src/components/AddToCartButton/index.ts
+++ b/packages/hydrogen/src/components/AddToCartButton/index.ts
@@ -1,1 +1,1 @@
-export {AddToCartButton, AddToCartButtonProps} from './AddToCartButton.client';
+export {AddToCartButton} from './AddToCartButton.client';

--- a/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
+++ b/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
@@ -1,9 +1,8 @@
-import React, {useEffect, ElementType, useState, useCallback} from 'react';
+import React, {useEffect, useState, useCallback} from 'react';
 import type {ReactNode} from 'react';
 import {useInstantCheckout} from '../CartProvider';
-import {Props} from '../types';
 
-export interface BuyNowButtonProps {
+interface BuyNowButtonProps {
   /** The item quantity. Defaults to 1. */
   quantity?: number;
   /** The ID of the variant. */
@@ -17,11 +16,12 @@ export interface BuyNowButtonProps {
   children: ReactNode;
 }
 
-export type BuyNowButtonPropsWeControl = 'onClick';
+type PropsWeControl = 'onClick';
 
 /** The `BuyNowButton` component renders a button that adds an item to the cart and redirects the customer to checkout. */
-export function BuyNowButton<TTag extends ElementType = 'button'>(
-  props: Props<TTag, BuyNowButtonPropsWeControl> & BuyNowButtonProps
+export function BuyNowButton(
+  props: Omit<JSX.IntrinsicElements['button'], PropsWeControl> &
+    BuyNowButtonProps
 ) {
   const {createInstantCheckout, checkoutUrl} = useInstantCheckout();
   const [loading, setLoading] = useState<boolean>(false);

--- a/packages/hydrogen/src/components/BuyNowButton/index.ts
+++ b/packages/hydrogen/src/components/BuyNowButton/index.ts
@@ -1,5 +1,1 @@
-export {
-  BuyNowButton,
-  BuyNowButtonProps,
-  BuyNowButtonPropsWeControl,
-} from './BuyNowButton.client';
+export {BuyNowButton} from './BuyNowButton.client';

--- a/packages/hydrogen/src/components/CartCheckoutButton/CartCheckoutButton.client.tsx
+++ b/packages/hydrogen/src/components/CartCheckoutButton/CartCheckoutButton.client.tsx
@@ -1,6 +1,5 @@
 import React, {ReactNode, useEffect, useState} from 'react';
 import {useCart} from '../CartProvider';
-import {Props} from '../types';
 
 type PropsWeControl = 'onClick';
 
@@ -8,8 +7,8 @@ type PropsWeControl = 'onClick';
  * The `CartCheckoutButton` component renders a button that redirects to the checkout URL for the cart.
  * It must be a descendent of a `CartProvider` component.
  */
-export function CartCheckoutButton<TTag extends React.ElementType = 'a'>(
-  props: Props<TTag, PropsWeControl> & {
+export function CartCheckoutButton(
+  props: Omit<JSX.IntrinsicElements['button'], PropsWeControl> & {
     /** A `ReactNode` element. */
     children: ReactNode;
   }

--- a/packages/hydrogen/src/components/CartEstimatedCost/CartEstimatedCost.client.tsx
+++ b/packages/hydrogen/src/components/CartEstimatedCost/CartEstimatedCost.client.tsx
@@ -1,7 +1,6 @@
-import React, {ElementType} from 'react';
+import React from 'react';
 import {useCart} from '../CartProvider';
 import {Money} from '../Money';
-import {Props} from '../types';
 
 export interface CartEstimatedCostProps {
   /** A string type that defines the type of cost needed. Valid values: `total`, `subtotal`, `tax`, or `duty`. */
@@ -15,8 +14,9 @@ export interface CartEstimatedCostProps {
  * cost associated with the `amountType` prop. If no `amountType` prop is specified, then it defaults to `totalAmount`.
  * If `children` is a function, then it will pass down the render props provided by the parent component.
  */
-export function CartEstimatedCost<TTag extends ElementType>(
-  props: Props<TTag> & CartEstimatedCostProps
+export function CartEstimatedCost<TTag extends keyof JSX.IntrinsicElements>(
+  props: Omit<React.ComponentProps<typeof Money>, 'data'> &
+    CartEstimatedCostProps
 ) {
   const {estimatedCost} = useCart();
   const {amountType = 'total', children, ...passthroughProps} = props;
@@ -37,7 +37,7 @@ export function CartEstimatedCost<TTag extends ElementType>(
   }
 
   return (
-    <Money {...passthroughProps} data={amount}>
+    <Money<TTag> {...passthroughProps} data={amount}>
       {children}
     </Money>
   );

--- a/packages/hydrogen/src/components/CartLineImage/CartLineImage.client.tsx
+++ b/packages/hydrogen/src/components/CartLineImage/CartLineImage.client.tsx
@@ -1,15 +1,18 @@
-import React, {ElementType} from 'react';
+import React from 'react';
 import {useCartLine} from '../CartLineProvider';
 import {Image} from '../Image';
-import {Props} from '../types';
 import {ImageSizeOptions} from '../../utilities';
+
+type PropsWeControl = 'data' | 'options';
 
 /**
  * The `CartLineImage` component renders an `Image` component for the cart line merchandise's image.
  * It must be a descendent of a `CartLineProvider` component.
  */
-export function CartLineImage<TTag extends ElementType = 'img'>(
-  props: Props<TTag> & {options?: ImageSizeOptions}
+export function CartLineImage(
+  props: Omit<React.ComponentProps<typeof Image>, PropsWeControl> & {
+    options?: ImageSizeOptions;
+  }
 ) {
   const cartLine = useCartLine();
 

--- a/packages/hydrogen/src/components/CartLinePrice/CartLinePrice.client.tsx
+++ b/packages/hydrogen/src/components/CartLinePrice/CartLinePrice.client.tsx
@@ -1,10 +1,8 @@
-import React, {ElementType} from 'react';
+import React from 'react';
 import {useCartLine} from '../CartLineProvider';
-import {Money, MoneyProps} from '../Money';
-import {Props} from '../types';
+import {Money} from '../Money';
 
-export interface CartLinePriceProps<TTag>
-  extends Omit<MoneyProps<TTag>, 'data'> {
+interface CartLinePriceProps {
   /** The type of price. Valid values:`regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
 }
@@ -13,8 +11,8 @@ export interface CartLinePriceProps<TTag>
  * The `CartLinePrice` component renders a `Money` component for the cart line merchandise's price or
  * compare at price. It must be a descendent of a `CartLineProvider` component.
  */
-export function CartLinePrice<TTag extends ElementType>(
-  props: Props<TTag> & CartLinePriceProps<TTag>
+export function CartLinePrice<TTag extends keyof JSX.IntrinsicElements>(
+  props: Omit<React.ComponentProps<typeof Money>, 'data'> & CartLinePriceProps
 ) {
   const cartLine = useCartLine();
   const {priceType = 'regular', ...passthroughProps} = props;
@@ -29,7 +27,7 @@ export function CartLinePrice<TTag extends ElementType>(
   }
 
   return (
-    <Money
+    <Money<TTag>
       {...passthroughProps}
       data={{
         amount: `${parseFloat(price.amount) * cartLine.quantity}`,

--- a/packages/hydrogen/src/components/CartLineProductTitle/CartLineProductTitle.client.tsx
+++ b/packages/hydrogen/src/components/CartLineProductTitle/CartLineProductTitle.client.tsx
@@ -1,13 +1,14 @@
-import React, {ElementType} from 'react';
-import {Props} from '../types';
+import React from 'react';
 import {useCartLine} from '../CartLineProvider';
 
 /**
  * The `CartLineProductTitle` component renders a `span` element (or the type of HTML element specified by
  * the `as` prop) with the cart line merchandise's title. It must be a descendent of a `CartLineProvider` component.
  */
-export function CartLineProductTitle<TTag extends ElementType>(
-  props: Props<TTag> & {
+export function CartLineProductTitle<
+  TTag extends keyof JSX.IntrinsicElements = 'span'
+>(
+  props: JSX.IntrinsicElements[TTag] & {
     /** An HTML tag to be rendered as the base element wrapper. The default is `span`.  */
     as?: TTag;
   }

--- a/packages/hydrogen/src/components/CartLineQuantity/CartLineQuantity.client.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantity/CartLineQuantity.client.tsx
@@ -1,13 +1,14 @@
-import React, {ElementType} from 'react';
-import {Props} from '../types';
+import React from 'react';
 import {useCartLine} from '../CartLineProvider';
 
 /**
  * The `CartLineQuantity` component renders a `span` element (or the type of HTML element
  * specified by the `as` prop) with the cart line's quantity. It must be a descendent of a `CartLineProvider` component.
  */
-export function CartLineQuantity<TTag extends ElementType>(
-  props: Props<TTag> & {
+export function CartLineQuantity<
+  TTag extends keyof JSX.IntrinsicElements = 'span'
+>(
+  props: JSX.IntrinsicElements[TTag] & {
     /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
     as?: TTag;
   }

--- a/packages/hydrogen/src/components/CartShopPayButton/CartShopPayButton.client.tsx
+++ b/packages/hydrogen/src/components/CartShopPayButton/CartShopPayButton.client.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import {useCart} from '../CartProvider';
-import {ShopPayButton, ShopPayButtonProps} from '../ShopPayButton';
+import {ShopPayButton} from '../ShopPayButton';
 
 /**
  * The `CartShopPayButton` component renders a `ShopPayButton` for the items in the cart.
@@ -9,7 +9,7 @@ import {ShopPayButton, ShopPayButtonProps} from '../ShopPayButton';
 export function CartShopPayButton({
   /** A string of classes to apply to the `div` that wraps the `shop-pay-button` web component. */
   className,
-}: Omit<ShopPayButtonProps, 'variantIds'>) {
+}: Omit<React.ComponentProps<typeof ShopPayButton>, 'variantIds'>) {
   const {lines} = useCart();
 
   const idsAndQuantities = useMemo(() => {

--- a/packages/hydrogen/src/components/ExternalVideo/ExternalVideo.tsx
+++ b/packages/hydrogen/src/components/ExternalVideo/ExternalVideo.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
+import React from 'react';
 import {YouTube, Vimeo, useEmbeddedVideoUrl} from '../../utilities';
-import {Props} from '../types';
 import {ExternalVideoFragment as Fragment} from '../../graphql/graphql-constants';
 import type {ExternalVideoFragmentFragment} from './ExternalVideoFragment';
 
-export interface ExternalVideoProps {
+interface ExternalVideoProps {
   /** An object with the keys `host`, `embedUrl`, and `id`. Refer to the Storefront API's
    * [`ExternalVideo` type](/api/storefront/reference/products/externalvideo).
    */
@@ -22,8 +21,9 @@ type PropsWeControl = 'src';
  * The `ExternalVideo` component renders an embedded video for the Storefront
  * API's [`ExternalVideo` object](/api/storefront/reference/products/externalvideo).
  */
-export function ExternalVideo<TTag extends React.ElementType = 'iframe'>(
-  props: Props<TTag, PropsWeControl> & ExternalVideoProps
+export function ExternalVideo(
+  props: Omit<JSX.IntrinsicElements['iframe'], PropsWeControl> &
+    ExternalVideoProps
 ) {
   const {
     data,

--- a/packages/hydrogen/src/components/ExternalVideo/index.ts
+++ b/packages/hydrogen/src/components/ExternalVideo/index.ts
@@ -1,5 +1,1 @@
-export {
-  ExternalVideo,
-  ExternalVideoProps,
-  ExternalVideoFragment,
-} from './ExternalVideo';
+export {ExternalVideo, ExternalVideoFragment} from './ExternalVideo';

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -20,7 +20,7 @@ export interface BaseImageProps {
   loaderOptions?: ImageLoaderOptions['options'];
 }
 
-export interface MediaImageProps extends BaseImageProps {
+interface MediaImageProps extends BaseImageProps {
   /** An object with the keys `url`, `altText`, `id`, `width` and `height`. Refer to the
    * Storefront API's [`Image` object](/api/storefront/reference/common-objects/image).
    */
@@ -29,7 +29,7 @@ export interface MediaImageProps extends BaseImageProps {
   options?: ImageSizeOptions;
 }
 
-export interface ExternalImageProps extends BaseImageProps {
+interface ExternalImageProps extends BaseImageProps {
   /** A URL string. This string can be an absolute path or a relative path depending on the `loader`. */
   src: string;
   /** The integer value for the width of the image. This is a required prop when `src` is present. */
@@ -38,7 +38,7 @@ export interface ExternalImageProps extends BaseImageProps {
   height: number;
 }
 
-export type ImageProps = MediaImageProps | ExternalImageProps;
+type ImageProps = MediaImageProps | ExternalImageProps;
 
 type PropsWeControl = 'src' | 'width' | 'height';
 

--- a/packages/hydrogen/src/components/Image/index.ts
+++ b/packages/hydrogen/src/components/Image/index.ts
@@ -1,1 +1,1 @@
-export {Image, ImageProps, ImageFragment, MediaImageProps} from './Image';
+export {Image, ImageFragment} from './Image';

--- a/packages/hydrogen/src/components/LocalizationProvider/LocalizationProvider.server.tsx
+++ b/packages/hydrogen/src/components/LocalizationProvider/LocalizationProvider.server.tsx
@@ -1,11 +1,10 @@
-import React, {ReactNode, ElementType} from 'react';
+import React, {ReactNode} from 'react';
 import LocalizationClientProvider from './LocalizationClientProvider.client';
 import {useShopQuery} from '../../hooks/useShopQuery';
 import {LocalizationQuery} from './LocalizationQuery';
 import {Localization} from '../../graphql/graphql-constants';
 import {CacheDays} from '../../framework/CachingStrategy';
 import {PreloadOptions} from '../../types';
-import {Props} from '../types';
 
 export interface LocalizationProviderProps {
   /** A `ReactNode` element. */
@@ -26,9 +25,7 @@ export interface LocalizationProviderProps {
  * The `isoCode` of the `country` can be used in the Storefront API's
  * `@inContext` directive as the `country` value.
  */
-export function LocalizationProvider<TTag extends ElementType>(
-  props: Props<TTag> & LocalizationProviderProps
-) {
+export function LocalizationProvider(props: LocalizationProviderProps) {
   const {
     data: {localization},
   } = useShopQuery<LocalizationQuery>({

--- a/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
+++ b/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import {Image, MediaImageProps} from '../Image';
-import {Video, VideoProps} from '../Video';
-import {ExternalVideo, ExternalVideoProps} from '../ExternalVideo';
+import React from 'react';
+import {Image} from '../Image';
+import {Video} from '../Video';
+import {ExternalVideo} from '../ExternalVideo';
 import {ModelViewer} from '../ModelViewer';
 import {MediaFileFragment as Fragment} from '../../graphql/graphql-constants';
 // import {Media as MediaType} from '../../graphql/types/types';
@@ -17,7 +17,9 @@ export interface MediaFileProps {
   /** A [Media object](/api/storefront/reference/products/media). */
   data: MediaFileFragmentFragment;
   /** The options for the `Image`, `Video`, `ExternalVideo`, or `ModelViewer` components. */
-  options?: VideoProps['options'] | ExternalVideoProps['options'];
+  options?:
+    | React.ComponentProps<typeof Video>['options']
+    | React.ComponentProps<typeof ExternalVideo>['options'];
 }
 
 /**
@@ -44,7 +46,7 @@ export function MediaFile({
         <Image
           {...passthroughProps}
           data={dataImage}
-          options={options as MediaImageProps['options']}
+          options={options as React.ComponentProps<typeof Image>['options']}
         />
       );
     }
@@ -53,7 +55,7 @@ export function MediaFile({
         <Video
           {...passthroughProps}
           data={data as MediaFileFragment_Video_Fragment}
-          options={options as VideoProps['options']}
+          options={options as React.ComponentProps<typeof Video>['options']}
         />
       );
     case 'EXTERNAL_VIDEO':
@@ -61,7 +63,9 @@ export function MediaFile({
         <ExternalVideo
           {...passthroughProps}
           data={data as MediaFileFragment_ExternalVideo_Fragment}
-          options={options as ExternalVideoProps['options']}
+          options={
+            options as React.ComponentProps<typeof ExternalVideo>['options']
+          }
         />
       );
     case 'MODEL_3D':

--- a/packages/hydrogen/src/components/Metafield/components/StarRating/StarRating.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/StarRating.tsx
@@ -1,5 +1,4 @@
-import React, {useMemo, ElementType} from 'react';
-import {Props} from '../../../types';
+import React, {useMemo} from 'react';
 import {Rating} from '../../../../types';
 
 export const STAR_EMPTY = '☆';
@@ -11,8 +10,8 @@ export interface StarRatingProps<TTag> {
   as?: TTag;
 }
 
-export function StarRating<TTag extends ElementType>(
-  props: Props<TTag> & StarRatingProps<TTag>
+export function StarRating<TTag extends keyof JSX.IntrinsicElements = 'div'>(
+  props: JSX.IntrinsicElements[TTag] & StarRatingProps<TTag>
 ) {
   const {as, rating, ...passthroughProps} = props;
 

--- a/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
+++ b/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
@@ -10,7 +10,7 @@ import {Model3DFragment as Fragment} from '../../graphql/graphql-constants';
 import {Props} from '../types';
 import type {Model3DFragmentFragment} from './Model3D';
 
-export interface ModelViewerProps {
+interface ModelViewerProps {
   /** Any ReactNode elements. */
   children?: ReactNode;
   /** An object with the same fields as the [GraphQL fragment](#graphql-fragment). */

--- a/packages/hydrogen/src/components/ModelViewer/index.ts
+++ b/packages/hydrogen/src/components/ModelViewer/index.ts
@@ -1,1 +1,1 @@
-export {ModelViewer, ModelViewerProps} from './ModelViewer.client';
+export {ModelViewer} from './ModelViewer.client';

--- a/packages/hydrogen/src/components/Money/Money.client.tsx
+++ b/packages/hydrogen/src/components/Money/Money.client.tsx
@@ -1,10 +1,9 @@
-import React, {ElementType} from 'react';
+import React from 'react';
 import {useMoney} from '../../hooks';
-import {Props} from '../types';
 import type {MoneyFragmentFragment} from './MoneyFragment';
 import {MoneyFragment as Fragment} from '../../graphql/graphql-constants';
 
-export interface MoneyProps<TTag> {
+interface MoneyProps<TTag> {
   /** An HTML tag to be rendered as the base element wrapper. The default is `div`. */
   as?: TTag;
   /** A [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2). */
@@ -16,8 +15,8 @@ export interface MoneyProps<TTag> {
  * [`MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) according to the
  * `defaultLocale` in the `shopify.config.js` file.
  */
-export function Money<TTag extends ElementType>(
-  props: Props<TTag> & MoneyProps<TTag>
+export function Money<TTag extends keyof JSX.IntrinsicElements = 'div'>(
+  props: JSX.IntrinsicElements[TTag] & MoneyProps<TTag>
 ) {
   const {data, as, ...passthroughProps} = props;
   const moneyObject = useMoney(data);

--- a/packages/hydrogen/src/components/Money/index.tsx
+++ b/packages/hydrogen/src/components/Money/index.tsx
@@ -1,1 +1,1 @@
-export {Money, MoneyProps, MoneyFragment} from './Money.client';
+export {Money, MoneyFragment} from './Money.client';

--- a/packages/hydrogen/src/components/ProductDescription/ProductDescription.client.tsx
+++ b/packages/hydrogen/src/components/ProductDescription/ProductDescription.client.tsx
@@ -1,15 +1,14 @@
-import React, {ElementType} from 'react';
+import React from 'react';
 import {RawHtml} from '../RawHtml';
 import {useProduct} from '../ProductProvider';
-import {Props} from '../types';
 
 /**
  * The `ProductDescription` component renders a `RawHtml` component with
  * the product's [`descriptionHtml`](/api/storefront/reference/products/product).
  * It must be a descendent of the `ProductProvider` component.
  */
-export function ProductDescription<TTag extends ElementType = 'div'>(
-  props: Props<TTag>
+export function ProductDescription(
+  props: Omit<React.ComponentProps<typeof RawHtml>, 'string'>
 ) {
   const product = useProduct();
 

--- a/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
+++ b/packages/hydrogen/src/components/ProductPrice/ProductPrice.client.tsx
@@ -1,12 +1,10 @@
-import React, {ElementType} from 'react';
+import React from 'react';
 import {MoneyV2, UnitPriceMeasurement} from '../../graphql/types/types';
-import {Money, MoneyProps} from '../Money';
+import {Money} from '../Money';
 import {useProduct} from '../ProductProvider';
-import {Props} from '../types';
 import {UnitPrice} from '../UnitPrice';
 
-export interface ProductPriceProps<TTag>
-  extends Omit<MoneyProps<TTag>, 'data'> {
+export interface ProductPriceProps {
   /** The type of price. Valid values: `regular` (default) or `compareAt`. */
   priceType?: 'regular' | 'compareAt';
   /** The type of value. Valid values: `min` (default), `max` or `unit`. */
@@ -19,8 +17,12 @@ export interface ProductPriceProps<TTag>
  * The `ProductPrice` component renders a `Money` component with the product
  * [`priceRange`](/api/storefront/reference/products/productpricerange)'s `maxVariantPrice` or `minVariantPrice`, for either the regular price or compare at price range. It must be a descendent of the `ProductProvider` component.
  */
-export function ProductPrice<TTag extends ElementType>(
-  props: Props<TTag> & ProductPriceProps<TTag>
+export function ProductPrice<TTag extends keyof JSX.IntrinsicElements>(
+  props: (
+    | Omit<React.ComponentProps<typeof UnitPrice>, 'data' | 'measurement'>
+    | Omit<React.ComponentProps<typeof Money>, 'data'>
+  ) &
+    ProductPriceProps
 ) {
   const product = useProduct();
   const {
@@ -72,9 +74,13 @@ export function ProductPrice<TTag extends ElementType>(
 
   if (measurement) {
     return (
-      <UnitPrice {...passthroughProps} data={price} measurement={measurement} />
+      <UnitPrice<TTag>
+        {...passthroughProps}
+        data={price}
+        measurement={measurement}
+      />
     );
   }
 
-  return <Money {...passthroughProps} data={price} />;
+  return <Money<TTag> {...passthroughProps} data={price} />;
 }

--- a/packages/hydrogen/src/components/RawHtml/RawHtml.tsx
+++ b/packages/hydrogen/src/components/RawHtml/RawHtml.tsx
@@ -1,5 +1,4 @@
-import React, {ElementType} from 'react';
-import {Props} from '../types';
+import React from 'react';
 
 // TODO: Revisit with Worker runtime
 // import * as DOMPurify from 'isomorphic-dompurify';
@@ -25,8 +24,8 @@ export interface RawHtmlProps<TTag> {
  * [isomorphic-dompurify](https://github.com/kkomelin/isomorphic-dompurify) by default.
  * To keep the text unsanitized, set the `unsanitized` prop to `true`.
  */
-export function RawHtml<TTag extends ElementType>(
-  props: Props<TTag> & RawHtmlProps<TTag>
+export function RawHtml<TTag extends keyof JSX.IntrinsicElements = 'div'>(
+  props: JSX.IntrinsicElements[TTag] & RawHtmlProps<TTag>
 ) {
   const {string, unsanitized, as, ...passthroughProps} = props;
   const Wrapper = as ?? 'div';

--- a/packages/hydrogen/src/components/RawHtml/index.ts
+++ b/packages/hydrogen/src/components/RawHtml/index.ts
@@ -1,1 +1,1 @@
-export {RawHtml, RawHtmlProps} from './RawHtml';
+export {RawHtml} from './RawHtml';

--- a/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
+++ b/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
@@ -3,7 +3,7 @@ import {useShop} from '../../foundation/useShop';
 import {useLoadScript} from '../../hooks/useLoadScript/useLoadScript';
 
 // By using 'never' in the "or" cases below, it makes these props "exclusive" and means that you cannot pass both of them; you must pass either one OR the other.
-export type ShopPayButtonProps = {
+type ShopPayButtonProps = {
   /** A string of classes to apply to the `div` that wraps the Shop Pay button. */
   className?: string;
 } & (

--- a/packages/hydrogen/src/components/ShopPayButton/index.ts
+++ b/packages/hydrogen/src/components/ShopPayButton/index.ts
@@ -1,1 +1,1 @@
-export {ShopPayButton, ShopPayButtonProps} from './ShopPayButton.client';
+export {ShopPayButton} from './ShopPayButton.client';

--- a/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPrice.client.tsx
@@ -1,5 +1,4 @@
-import React, {ElementType} from 'react';
-import {Props} from '../types';
+import React from 'react';
 import {Money} from '../Money';
 import {UnitPriceFragment as Fragment} from '../../graphql/graphql-constants';
 import type {UnitPriceFragmentFragment} from './UnitPriceFragment';
@@ -17,8 +16,8 @@ export interface UnitPriceProps<TTag> {
  * The `UnitPrice` component renders a string with a [UnitPrice](/themes/pricing-payments/unit-pricing) as the
  * [Storefront API's `MoneyV2` object](/api/storefront/reference/common-objects/moneyv2) with a reference unit from the [Storefront API's `UnitPriceMeasurement` object](/api/storefront/reference/products/unitpricemeasurement).
  */
-export function UnitPrice<TTag extends ElementType>(
-  props: Props<TTag> & UnitPriceProps<TTag>
+export function UnitPrice<TTag extends keyof JSX.IntrinsicElements = 'div'>(
+  props: JSX.IntrinsicElements[TTag] & UnitPriceProps<TTag>
 ) {
   const {data, measurement, as, ...passthroughProps} = props;
 

--- a/packages/hydrogen/src/components/Video/Video.tsx
+++ b/packages/hydrogen/src/components/Video/Video.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
-import {Props} from '../types';
+import React from 'react';
 import {ImageSizeOptions, useImageUrl} from '../../utilities';
 import {VideoFragment as Fragment} from '../../graphql/graphql-constants';
 import type {VideoFragmentFragment} from './VideoFragment';
 
-export interface VideoProps {
+interface VideoProps {
   /** An object corresponding to the [GraphQL fragment](#graphql-fragment). */
   data: VideoFragmentFragment;
   /** An object of image size options for the video's `previewImage`. */
@@ -14,9 +13,7 @@ export interface VideoProps {
 /**
  * The `Video` component renders a `video` for the Storefront API's [`Video` object](/api/storefront/reference/products/video).
  */
-export function Video<TTag extends React.ElementType = 'video'>(
-  props: Props<TTag> & VideoProps
-) {
+export function Video(props: JSX.IntrinsicElements['video'] & VideoProps) {
   const {
     data,
     options,

--- a/packages/hydrogen/src/components/Video/index.ts
+++ b/packages/hydrogen/src/components/Video/index.ts
@@ -1,2 +1,1 @@
-export type {VideoProps} from './Video';
 export {Video, VideoFragment} from './Video';

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -1,19 +1,11 @@
 export {Link} from './Link';
-export type {MediaFileProps} from './MediaFile';
 export {MediaFile, MediaFileFragment} from './MediaFile';
-export type {VideoProps} from './Video';
 export {Video} from './Video';
-export type {ImageProps} from './Image';
 export {Image} from './Image';
-export type {ExternalVideoProps} from './ExternalVideo';
 export {ExternalVideo} from './ExternalVideo';
-export type {RawHtmlProps} from './RawHtml';
 export {RawHtml} from './RawHtml';
-export type {AddToCartButtonProps} from './AddToCartButton';
 export {AddToCartButton} from './AddToCartButton';
-export type {ModelViewerProps} from './ModelViewer';
 export {ModelViewer} from './ModelViewer';
-export type {MoneyProps} from './Money';
 export {Money} from './Money';
 export {Metafield} from './Metafield';
 export type {MetafieldType, MetafieldFragmentFragment} from './Metafield';
@@ -44,12 +36,7 @@ export {ProductDescription} from './ProductDescription';
 export {ProductTitle} from './ProductTitle';
 export {ProductPrice} from './ProductPrice';
 export {ProductMetafield} from './ProductMetafield';
-export type {
-  BuyNowButtonProps,
-  BuyNowButtonPropsWeControl,
-} from './BuyNowButton';
 export {BuyNowButton} from './BuyNowButton';
-export type {ShopPayButtonProps} from './ShopPayButton';
 export {ShopPayButton} from './ShopPayButton';
 export {useAvailableCountries} from '../hooks/useAvailableCountries';
 export {useCountry} from '../hooks/useCountry';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Remove the exporting of `xProps` types from the hydrogen package
- Update `ElementType` to use `JSX.IntrinsicElements` instead for better type checking

### Additional context

When using `ElementType` as generic in the component, any attribute come up with type `any`

<img width="500" alt="element type - fail" src="https://user-images.githubusercontent.com/1610169/156842948-80d0ab59-1ec7-43eb-bbbb-3ec5b861cd7e.png">

But if we type with `JSX.IntrinsicElements`, now the attribute would be typed correct

<img width="629" alt="element type - pass" src="https://user-images.githubusercontent.com/1610169/156842946-4584c15c-dcc5-4c93-b9da-babc2f08c590.png">

### Dynamic element type

When typing a component using one of the prop as element, we can use the pattern below for a strict type checking 

```tsx
interface MoneyProps<TTag> {
  as?: TTag;
}

export function MyComponent<TTag extends keyof JSX.IntrinsicElements = 'div'>(
  props: JSX.IntrinsicElements[TTag] & MoneyProps<TTag>) {

  const Wrapper = as ?? 'div';

  return <Wrapper {...passthroughProps}>{...}</Wrapper>;

}
```

With `div` element as default, passing attribute `defaultChecked` with boolean value will pass type checking
<img width="940" alt="dynamic element type (default) - pass" src="https://user-images.githubusercontent.com/1610169/156843761-6f00f3a1-5f95-4a4b-838b-96c3ecd307b2.png">

With `div` element as default, passing attribute `poster` will fail type checking
<img width="762" alt="dynamic element type - fail" src="https://user-images.githubusercontent.com/1610169/156843136-170a6893-826b-46fb-9b22-57b32906e7df.png">

With `video` pass in as prop, which means we are using it as TTag generic type. Passing attribute `poster` will pass type checking

<img width="486" alt="dynamic element type - pass" src="https://user-images.githubusercontent.com/1610169/156843917-e69bb63c-031c-48a6-b49c-878c7c2ae6aa.png">


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
