### PR TITLE
Disable worker streaming until it is properly supported

### DIFF
--- a/.changeset/heavy-snails-approve.md
+++ b/.changeset/heavy-snails-approve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Disable worker streaming until it is properly supported.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -39,7 +39,6 @@ import {
   ssrRenderToReadableStream,
   rscRenderToReadableStream,
   createFromReadableStream,
-  supportsReadableStream,
   isStreamingSupported,
   bufferReadableStream,
 } from './streaming.server';
@@ -119,7 +118,7 @@ export const renderHydrogen = (
 
     const isStreamable =
       !isBotUA(url, request.headers.get('user-agent')) &&
-      (!!streamableResponse || supportsReadableStream());
+      (!!streamableResponse || (await isStreamingSupported()));
 
     const params = {
       App,

--- a/packages/hydrogen/src/streaming.server.ts
+++ b/packages/hydrogen/src/streaming.server.ts
@@ -39,15 +39,6 @@ export const ssrRenderToReadableStream = _ssrRenderToReadableStream as (
   options: StreamOptions
 ) => ReadableStream<Uint8Array>;
 
-export function supportsReadableStream() {
-  try {
-    new ReadableStream();
-    return true;
-  } catch (_) {
-    return false;
-  }
-}
-
 let cachedStreamingSupport: boolean;
 export async function isStreamingSupported() {
   if (cachedStreamingSupport === undefined) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/Shopify/hydrogen/issues/820

This disables streaming in workers until ReadableStream is properly supported.
I've been testing with Lighthouse and I couldn't notice any big difference between rendering and fake streaming, though. All the tests have a score around 96-100 with similar values.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
