### PR TITLE
Minify SSR build output

### DIFF
--- a/.changeset/moody-waves-wash.md
+++ b/.changeset/moody-waves-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Minify server build output

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -14,6 +14,7 @@ export default () => {
       },
 
       build: {
+        minify: 'esbuild',
         sourcemap: true,
         /**
          * By default, SSR dedupe logic gets bundled which runs `require('module')`.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR enables minification for SSR build outputs. Minifying server code is not something you'd typically worry about, thus the default to `false`.

However, in v8 Worker runtimes, larger file size incurs penalties on code execution and boot time. It also means you're approaching a limitation for certain runtimes (like Cloudflare Workers and Vercel).

**Before:**

```
dist/server/index.js   1266.85 KiB
dist/worker/index.js   780.85 KiB
```

**After:**

```
dist/server/index.js   577.44 KiB
dist/worker/index.js   459.24 KiB
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
