### PR TITLE
fix: the server only logs the timing for a stream rendered page once

### DIFF
--- a/.changeset/small-crabs-roll.md
+++ b/.changeset/small-crabs-roll.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix server the server to only log once for the full time it takes to stream render a page

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -450,8 +450,6 @@ async function stream(
 
         writeHeadToServerResponse(response, componentResponse, log, didError);
 
-        logServerResponse('str', request, response.statusCode);
-
         if (isRedirect(response)) {
           // Return redirects early without further rendering/streaming
           return response.end();


### PR DESCRIPTION
### Description
Right now the server logs twice for every stream render:

![image](https://user-images.githubusercontent.com/1566869/157145348-8ed8cad9-e281-4303-b67f-86fc50dd89d4.png)

This fixes it to only log once, with the overall time it took to render.

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
