### PR TITLE
fix: ignore promise exception when boomerang fails to load

### DIFF
--- a/.changeset/dirty-starfishes-compare.md
+++ b/.changeset/dirty-starfishes-compare.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Ignore when boomerang doesn't load. This often happens when a adblocker is present on the client.
+There is no longer an uncaught promise exception in the console.

--- a/packages/hydrogen/src/foundation/Boomerang/Boomerang.client.tsx
+++ b/packages/hydrogen/src/foundation/Boomerang/Boomerang.client.tsx
@@ -71,7 +71,10 @@ export function Boomerang({pageTemplate}: {pageTemplate: string | null}) {
         });
       }
     })();
-    loadScript(URL);
+    loadScript(URL).catch(() => {
+      // ignore if boomerang doesn't load
+      // most likely because of a ad blocker
+    });
   }, [storeDomain, pageTemplate]);
 
   return null;


### PR DESCRIPTION
### Description

Ignore when boomerang doesn't load. This often happens when a adblocker is present on the client.
There is no longer an uncaught promise exception in the console.

### Additional context

![image](https://user-images.githubusercontent.com/1566869/157146297-d438277e-e367-48fb-9f18-2d0d1d584c52.png)


### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
