### PR TITLE
Apply React patches before minifying the worker bundle

### DIFF
--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -76,33 +76,28 @@ export default () => {
     }),
 
     // TODO: Remove when react-dom/fizz is fixed
-    generateBundle: process.env.WORKER
-      ? (options, bundle) => {
-          // There's only one key in bundle, normally `worker.js`
-          const [bundleKey] = Object.keys(bundle);
-          const workerBundle = bundle[bundleKey];
-          // It's always a chunk, this is just for TypeScript
-          if (workerBundle.type === 'chunk') {
-            // React fizz and flight try to access an undefined value.
-            // This puts a guard before accessing it.
-            workerBundle.code = workerBundle.code.replace(
-              /\((\w+)\.locked\)/gm,
-              '($1 && $1.locked)'
-            );
+    renderChunk: process.env.WORKER
+      ? (code, chunk, opts) => {
+          if (!chunk.isEntry) return null;
 
-            // `renderToReadableStream` is bugged in React.
-            // This adds a workaround until these issues are fixed:
-            // https://github.com/facebook/react/issues/22772
-            // https://github.com/facebook/react/issues/23113
-            workerBundle.code = workerBundle.code.replace(
-              /var \w+\s*=\s*(\w+)\.completedRootSegment;/g,
-              'if($1.status===5)return\n$1.status=5;\n$&'
-            );
-            workerBundle.code = workerBundle.code.replace(
-              /(\w+)\.allPendingTasks\s*={2,3}\s*0\s*\&\&\s*\w+\.pingedTasks\.length/g,
-              '$1.status=0;\n$&'
-            );
-          }
+          // React fizz and flight try to access an undefined value.
+          // This puts a guard before accessing it.
+          code = code.replace(/\((\w+)\.locked\)/gm, '($1 && $1.locked)');
+
+          // `renderToReadableStream` is bugged in React.
+          // This adds a workaround until these issues are fixed:
+          // https://github.com/facebook/react/issues/22772
+          // https://github.com/facebook/react/issues/23113
+          code = code.replace(
+            /var \w+\s*=\s*(\w+)\.completedRootSegment;/g,
+            'if($1.status===5)return\n$1.status=5;\n$&'
+          );
+          code = code.replace(
+            /(\w+)\.allPendingTasks\s*={2,3}\s*0\s*\&\&\s*\w+\.pingedTasks\.length/g,
+            '$1.status=0;\n$&'
+          );
+
+          return code;
         }
       : undefined,
   } as Plugin;

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -90,11 +90,11 @@ export default () => {
           // https://github.com/facebook/react/issues/23113
           code = code.replace(
             /var \w+\s*=\s*(\w+)\.completedRootSegment;/g,
-            'if($1.status===5)return\n$1.status=5;\n$&'
+            'if($1.status===5)return;$1.status=5;\n$&'
           );
           code = code.replace(
-            /(\w+)\.allPendingTasks\s*={2,3}\s*0\s*\&\&\s*\w+\.pingedTasks\.length/g,
-            '$1.status=0;\n$&'
+            /{([^{]*?(\w+)\.pingedTasks\.length)/g,
+            '{$2.status=0;\n$1'
           );
 
           return code;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We can't currently deploy to workers because our logic to patch React experimental doesn't work anymore after adding minification (it throws errors like `cannot read "locked" of undefined`).
This PR fixes the issue by applying React patches before minifying the bundle.

-- Edit: Also had to modify the regular expressions because the code in `renderChunk` is pre-minified 🤯 

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
