### PR TITLE
Fix cart dialog not opening on click

### DIFF
--- a/.changeset/wet-onions-poke.md
+++ b/.changeset/wet-onions-poke.md
@@ -1,0 +1,5 @@
+---
+'template-hydrogen-default': patch
+---
+
+Update @headlessui/react version to fix Cart dialog not opening.

--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -33,7 +33,7 @@
     "vite": "^2.8.0"
   },
   "dependencies": {
-    "@headlessui/react": "^1.4.1",
+    "@headlessui/react": "^1.5.0",
     "@shopify/hydrogen": "^0.11.1",
     "body-parser": "^1.19.1",
     "compression": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,10 +1614,10 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
-"@headlessui/react@^1.4.1":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.4.2.tgz#87e264f190dbebbf8dfdd900530da973dad24576"
-  integrity sha512-N8tv7kLhg9qGKBkVdtg572BvKvWhmiudmeEpOCyNwzOsZHCXBtl8AazGikIfUS+vBoub20Fse3BjawXDVPPdug==
+"@headlessui/react@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The cart dialog won't open when clicked in `main` branch (in development only). Apparently, it was a [known bug](https://github.com/tailwindlabs/headlessui/issues/479) in `@headlessui/react` and is fixed in the latest version. -- I've no idea what we have changed in `main` branch to trigger this bug, though.

I wanted to fix the scroll when clicking the cart, but that's also an [issue](https://github.com/tailwindlabs/headlessui/pull/850) in the same component.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
