### PR TITLE
Set the timeout to 30 minutes for GH Actions tests

### DIFF
--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]


### PR DESCRIPTION
The default is 360 minutes (6 hours). We don't need that in here.