### PR TITLE
Prevent exporting server components with client components

### DIFF
--- a/packages/hydrogen/src/foundation/ShopifyProvider/index.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/index.ts
@@ -1,2 +1,1 @@
-export {ShopifyProvider} from './ShopifyProvider.server';
 export {ShopifyContext} from './ShopifyProvider.client';

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {ShopifyProvider, ShopifyContext} from '..';
+import {ShopifyContext} from '../ShopifyProvider.client';
+import {ShopifyProvider} from '../ShopifyProvider.server';
 import {DEFAULT_LOCALE} from '../../constants';
 import {SHOPIFY_CONFIG} from './fixtures';
 

--- a/packages/hydrogen/src/foundation/index.tsx
+++ b/packages/hydrogen/src/foundation/index.tsx
@@ -1,4 +1,3 @@
 export * from './ServerStateProvider';
 export {useShop} from './useShop';
-export {ShopifyProvider} from './ShopifyProvider';
 export {useUrl} from './useUrl';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -19,6 +19,7 @@ export {useParams} from './foundation/Router/useParams';
 
 // This is exported here because it contains a Server Component
 export {LocalizationProvider} from './components/LocalizationProvider/LocalizationProvider.server';
+export {ShopifyProvider} from './foundation/ShopifyProvider/ShopifyProvider.server';
 
 // Exported here because users shouldn't be making `useShopQuery` calls from the client
 export * from './hooks/useShopQuery';

--- a/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
+++ b/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
@@ -4,7 +4,7 @@ import {BrowserHistory} from 'history';
 import {DEFAULT_LOCALE} from '../../foundation/constants';
 
 import {ShopifyConfig} from '../../types';
-import {ShopifyProvider} from '../../foundation/ShopifyProvider';
+import {ShopifyProvider} from '../../foundation/ShopifyProvider/ShopifyProvider.server';
 import {Router} from '../../foundation/Router/Router';
 import {ServerState, ServerStateProvider} from '../../foundation';
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Sometimes (but not always), we will see this when attempting to build a Hydrogen app:

```
[vite-plugin-react-server-components] Cannot import ./ShopifyProvider.server from "/home/runner/work/hydrogen/hydrogen/packages/hydrogen/src/foundation/ShopifyProvider/index.ts". By react-server convention, .server.js files can only be imported from other .server.js files. That way nobody accidentally sends these to the client by indirectly importing it.
error during build:
```

I'm not sure why we don't always see it. Perhaps has to do with how the source is built. Regardless, this PR ensures we are more careful about exporting a server component explicitly rather than from a shared component. This also prevents server-only logic from leaking into the client via `useShop()` etc.