### PR TITLE
Deploy to Cloudflare Workers on push to `main`

### DIFF
--- a/.github/deployments/cloudflare/worker.js
+++ b/.github/deployments/cloudflare/worker.js
@@ -1,0 +1,50 @@
+// If the request path matches any of your assets, then use the `getAssetFromKV`
+// function from `@cloudflare/kv-asset-handler` to serve it. Otherwise, call the
+// `handleRequest` function, which is imported from your `App.server.jsx` file,
+// to return a Hydrogen response.
+import {getAssetFromKV} from '@cloudflare/kv-asset-handler';
+import handleRequest from './src/App.server';
+import indexTemplate from './dist/client/index.html?raw';
+
+function isAsset(url) {
+  // Update this RE to fit your assets
+  return /\.(png|jpe?g|gif|css|js|svg|ico|map)$/i.test(url.pathname);
+}
+
+async function handleAsset(url, event) {
+  const response = await getAssetFromKV(event, {});
+
+  // Custom cache-control for assets
+  if (response.status < 400) {
+    const filename = url.pathname.split('/').pop();
+
+    const maxAge =
+      filename.split('.').length > 2
+        ? 31536000 // hashed asset, will never be updated
+        : 86400; // favicon and other public assets
+
+    response.headers.append('cache-control', `public, max-age=${maxAge}`);
+  }
+
+  return response;
+}
+
+async function handleEvent(event) {
+  try {
+    const url = new URL(event.request.url);
+
+    if (isAsset(url)) {
+      return await handleAsset(url, event);
+    }
+
+    return await handleRequest(event.request, {
+      indexTemplate,
+      cache: caches.default,
+      context: event,
+    });
+  } catch (error) {
+    return new Response(error.message || error.toString(), {status: 500});
+  }
+}
+
+addEventListener('fetch', (event) => event.respondWith(handleEvent(event)));

--- a/.github/deployments/cloudflare/wrangler.toml
+++ b/.github/deployments/cloudflare/wrangler.toml
@@ -1,0 +1,16 @@
+name = "template-default"
+type = "javascript"
+account_id = ""
+workers_dev = true
+route = ""
+zone_id = ""
+compatibility_date = "2022-01-28"
+compatibility_flags = ["streams_enable_constructors"]
+
+[site]
+bucket = "dist/client"
+entry-point = "dist/worker"
+
+[build]
+upload.format = "service-worker"
+command = "echo 'Already built; skipping'"

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -5,7 +5,7 @@ name: Deployments
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: ['v1.x-2022-07']
 
 concurrency:
   group: deployments-${{ github.head_ref }}

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -1,0 +1,54 @@
+# This Action is responsible for deploying the default Hydrogen template to various runtimes as a CI step.
+# This helps us detect when we've made a change that is potentially incompatible on an environment.
+name: Deployments
+
+on:
+  workflow_dispatch:
+  push:
+    # TODO: Add this back when ready to merge
+    # branches: [main]
+
+concurrency:
+  group: changeset-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy_cloudflare:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'main' && github.repository_owner == 'shopify' }}
+    name: Deploy to Cloudflare Workers
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install the packages
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Build Hydrogen
+        run: yarn workspace @shopify/hydrogen build
+
+      - name: Make updates for Cloudflare Workers runtime
+        working-directory: ./examples/template-hydrogen-default
+        run: |
+          cp ../../.github/deployments/cloudflare/* .
+          yarn add @cloudflare/kv-asset-handler
+
+      - name: Build for workers
+        working-directory: ./examples/template-hydrogen-default
+        run: |
+          yarn build:client
+          yarn cross-env WORKER=true vite build --outDir dist/worker --ssr worker
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@1.3.0
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.DEPLOYMENT_CF_ACCOUNT_ID }}
+        with:
+          apiToken: ${{ secrets.DEPLOYMENT_CF_API_TOKEN }}
+          workingDirectory: ./examples/template-hydrogen-default

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deploy_cloudflare:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'shopify' }}
+    if: ${{ github.repository_owner == 'shopify' }}
     name: Deploy to Cloudflare Workers
     steps:
       - name: Check out the code

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -5,8 +5,7 @@ name: Deployments
 on:
   workflow_dispatch:
   push:
-    # TODO: Add this back when ready to merge
-    # branches: [main]
+    branches: [main]
 
 concurrency:
   group: deployments-${{ github.head_ref }}
@@ -15,8 +14,7 @@ concurrency:
 jobs:
   deploy_cloudflare:
     runs-on: ubuntu-latest
-    # TODO: Add this back when ready to merge
-    # if: ${{ github.ref_name == 'main' && github.repository_owner == 'shopify' }}
+    if: github.repository_owner == 'shopify' }}
     name: Deploy to Cloudflare Workers
     steps:
       - name: Check out the code

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -15,7 +15,8 @@ concurrency:
 jobs:
   deploy_cloudflare:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'main' && github.repository_owner == 'shopify' }}
+    # TODO: Add this back when ready to merge
+    # if: ${{ github.ref_name == 'main' && github.repository_owner == 'shopify' }}
     name: Deploy to Cloudflare Workers
     steps:
       - name: Check out the code

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -9,7 +9,7 @@ on:
     # branches: [main]
 
 concurrency:
-  group: changeset-${{ github.head_ref }}
+  group: deployments-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/packages/hydrogen/src/foundation/ShopifyProvider/index.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/index.ts
@@ -1,2 +1,1 @@
-export {ShopifyProvider} from './ShopifyProvider.server';
 export {ShopifyContext} from './ShopifyProvider.client';

--- a/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/tests/ShopifyProvider.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {ShopifyProvider, ShopifyContext} from '..';
+import {ShopifyContext} from '../ShopifyProvider.client';
+import {ShopifyProvider} from '../ShopifyProvider.server';
 import {DEFAULT_LOCALE} from '../../constants';
 import {SHOPIFY_CONFIG} from './fixtures';
 

--- a/packages/hydrogen/src/foundation/index.tsx
+++ b/packages/hydrogen/src/foundation/index.tsx
@@ -1,4 +1,3 @@
 export * from './ServerStateProvider';
 export {useShop} from './useShop';
-export {ShopifyProvider} from './ShopifyProvider';
 export {useUrl} from './useUrl';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -19,6 +19,7 @@ export {useParams} from './foundation/Router/useParams';
 
 // This is exported here because it contains a Server Component
 export {LocalizationProvider} from './components/LocalizationProvider/LocalizationProvider.server';
+export {ShopifyProvider} from './foundation/ShopifyProvider/ShopifyProvider.server';
 
 // Exported here because users shouldn't be making `useShopQuery` calls from the client
 export * from './hooks/useShopQuery';

--- a/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
+++ b/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
@@ -4,7 +4,7 @@ import {BrowserHistory} from 'history';
 import {DEFAULT_LOCALE} from '../../foundation/constants';
 
 import {ShopifyConfig} from '../../types';
-import {ShopifyProvider} from '../../foundation/ShopifyProvider';
+import {ShopifyProvider} from '../../foundation/ShopifyProvider/ShopifyProvider.server';
 import {Router} from '../../foundation/Router/Router';
 import {ServerState, ServerStateProvider} from '../../foundation';
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #836 

This PR adds a new `deployments.yaml` GH Action which will house a suite of deployments to various hosting platforms.

We're starting with Cloudflare Workers, because it's closest to Oxygen.

Eventually, we should add Fly.io for Docker/Node, Vercel, etc.

### Additional context

😎  https://template-default.hydrogen-devs.workers.dev/