### PR TITLE
ProductProvider example query fix

### DIFF
--- a/.changeset/stale-experts-leave.md
+++ b/.changeset/stale-experts-leave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Hydrogen docs: Update ProductProvider example query

--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -150,6 +150,7 @@ const QUERY = gql`
     $numProductVariantSellingPlanAllocations: Int!
     $numProductSellingPlanGroups: Int!
     $numProductSellingPlans: Int!
+    $includeReferenceMetafieldDetails: Boolean!
   ) {
     product: product(handle: $handle) {
       id

--- a/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
@@ -108,6 +108,7 @@ const QUERY = gql`
     $numProductVariantSellingPlanAllocations: Int!
     $numProductSellingPlanGroups: Int!
     $numProductSellingPlans: Int!
+    $includeReferenceMetafieldDetails: Boolean!
   ) {
     product: product(handle: $handle) {
       id


### PR DESCRIPTION
👋 Hey @mcvinci!

This adds `includeReferenceMetafieldDetails` to the ProductProvider example query arguments.

- Relates to https://github.com/Shopify/shopify-dev/pull/17445

![image](https://user-images.githubusercontent.com/59898611/157380140-530b2129-7039-4074-8b58-af58c2d85f00.png)

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
