### PR TITLE
Fix issue with `NotFound` component

### DIFF
--- a/.changeset/witty-games-clap.md
+++ b/.changeset/witty-games-clap.md
@@ -1,0 +1,5 @@
+---
+'create-hydrogen-app': patch
+---
+
+Fix usage of NotFound when it is not possible to modify the `response` object

--- a/examples/template-hydrogen-default/src/components/NotFound.server.jsx
+++ b/examples/template-hydrogen-default/src/components/NotFound.server.jsx
@@ -31,8 +31,10 @@ function NotFoundHero() {
 }
 
 export default function NotFound({country = {isoCode: 'US'}, response}) {
-  response.doNotStream();
-  response.writeHead({status: 404, statusText: 'Not found'});
+  if (response) {
+    response.doNotStream();
+    response.writeHead({status: 404, statusText: 'Not found'});
+  }
 
   const {data} = useShopQuery({
     query: QUERY,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #867

We assumed that `<NotFound>` was only being used as a routing fallback, but we're actually using it in a number of places, including as a fallback for products that cannot be found after querying the SFAPI.

It's important to note that, since we have to suspend to query the SFAPI and get the not found response, we can no longer issue a `404` status, because streaming has started by that point. #streamingproblems

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
