### PR TITLE
Move away from fragments; use a local API function for cart

### DIFF
--- a/examples/template-hydrogen-default/src/routes/cart.server.js
+++ b/examples/template-hydrogen-default/src/routes/cart.server.js
@@ -1,0 +1,123 @@
+import gql from 'graphql-tag';
+
+export async function api(request, {queryShop}) {
+  const {action, variables} = await request.json();
+
+  if (!action) {
+    throw new Error('You must provide an action');
+  }
+
+  switch (action) {
+    case 'getCart':
+      return await getCart(variables, queryShop);
+
+    // ...
+  }
+}
+
+async function getCart(variables, queryShop) {
+  return await queryShop({
+    query: CART_QUERY,
+    variables,
+  });
+}
+
+const CART_QUERY = gql`
+  query CartQuery(
+    $id: ID!
+    $numCartLines: Int = 250
+    $country: CountryCode = ZZ
+  ) @inContext(country: $country) {
+    cart(id: $id) {
+      ...CartFragment
+    }
+  }
+
+  fragment CartFragment on Cart {
+    id
+    checkoutUrl
+    buyerIdentity {
+      countryCode
+      customer {
+        id
+        email
+        firstName
+        lastName
+        displayName
+      }
+      email
+      phone
+    }
+    lines(first: $numCartLines) {
+      edges {
+        node {
+          id
+          quantity
+          attributes {
+            key
+            value
+          }
+          merchandise {
+            ... on ProductVariant {
+              id
+              availableForSale
+              compareAtPriceV2 {
+                ...MoneyFragment
+              }
+              priceV2 {
+                ...MoneyFragment
+              }
+              requiresShipping
+              title
+              image {
+                ...ImageFragment
+              }
+              product {
+                handle
+                title
+              }
+              selectedOptions {
+                name
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+    estimatedCost {
+      subtotalAmount {
+        ...MoneyFragment
+      }
+      totalAmount {
+        ...MoneyFragment
+      }
+      totalDutyAmount {
+        ...MoneyFragment
+      }
+      totalTaxAmount {
+        ...MoneyFragment
+      }
+    }
+    note
+    attributes {
+      key
+      value
+    }
+    discountCodes {
+      code
+    }
+  }
+
+  fragment MoneyFragment on MoneyV2 {
+    currencyCode
+    amount
+  }
+  fragment ImageFragment on Image {
+    id
+    url
+    altText
+    width
+    height
+  }
+`;

--- a/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
@@ -1,9 +1,4 @@
 import {useShopQuery, flattenConnection, Seo} from '@shopify/hydrogen';
-import {
-  MediaFileFragment,
-  ProductProviderFragment,
-  CollectionSeoFragment,
-} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import LoadMoreProducts from '../../components/LoadMoreProducts.client';
@@ -96,7 +91,267 @@ const QUERY = gql`
     }
   }
 
-  ${CollectionSeoFragment}
-  ${MediaFileFragment}
-  ${ProductProviderFragment}
+  fragment CollectionSeoFragment on Collection {
+    title
+    description
+    seo {
+      ...SeoFragment
+    }
+    image {
+      ...ImageSeoFragment
+    }
+  }
+  fragment ImageSeoFragment on Image {
+    url
+    width
+    height
+    altText
+  }
+
+  fragment SeoFragment on SEO {
+    description
+    title
+  }
+
+  fragment ImageFragment on Image {
+    id
+    url
+    altText
+    width
+    height
+  }
+
+  fragment ProductProviderFragment on Product {
+    compareAtPriceRange {
+      maxVariantPrice {
+        ...MoneyFragment
+      }
+      minVariantPrice {
+        ...MoneyFragment
+      }
+    }
+    descriptionHtml
+    handle
+    id
+    media(first: $numProductMedia) {
+      edges {
+        node {
+          ...MediaFileFragment
+        }
+      }
+    }
+    metafields(first: $numProductMetafields) {
+      edges {
+        node {
+          ...MetafieldFragment
+        }
+      }
+    }
+    priceRange {
+      maxVariantPrice {
+        ...MoneyFragment
+      }
+      minVariantPrice {
+        ...MoneyFragment
+      }
+    }
+    title
+    variants(first: $numProductVariants) {
+      edges {
+        node {
+          ...VariantFragment
+        }
+      }
+    }
+    sellingPlanGroups(first: $numProductSellingPlanGroups) {
+      edges {
+        node {
+          ...SellingPlanGroupsFragment
+        }
+      }
+    }
+  }
+
+  fragment MediaFileFragment on Media {
+    ... on MediaImage {
+      mediaContentType
+      image {
+        ...ImageFragment
+      }
+    }
+    ... on Video {
+      mediaContentType
+      ...VideoFragment
+    }
+    ... on ExternalVideo {
+      mediaContentType
+      ...ExternalVideoFragment
+    }
+    ... on Model3d {
+      mediaContentType
+      ...Model3DFragment
+    }
+  }
+
+  fragment MetafieldFragment on Metafield {
+    id
+    type
+    namespace
+    key
+    value
+    createdAt
+    updatedAt
+    description
+    reference @include(if: $includeReferenceMetafieldDetails) {
+      __typename
+      ... on MediaImage {
+        id
+        mediaContentType
+        image {
+          ...ImageFragment
+        }
+      }
+    }
+  }
+
+  fragment VariantFragment on ProductVariant {
+    id
+    title
+    availableForSale
+    image {
+      ...ImageFragment
+    }
+    ...UnitPriceFragment
+    priceV2 {
+      ...MoneyFragment
+    }
+    compareAtPriceV2 {
+      ...MoneyFragment
+    }
+    selectedOptions {
+      name
+      value
+    }
+    metafields(first: $numProductVariantMetafields) {
+      edges {
+        node {
+          ...MetafieldFragment
+        }
+      }
+    }
+    sellingPlanAllocations(first: $numProductVariantSellingPlanAllocations) {
+      edges {
+        node {
+          priceAdjustments {
+            compareAtPrice {
+              ...MoneyFragment
+            }
+            perDeliveryPrice {
+              ...MoneyFragment
+            }
+            price {
+              ...MoneyFragment
+            }
+            unitPrice {
+              ...MoneyFragment
+            }
+          }
+          sellingPlan {
+            ...SellingPlanFragment
+          }
+        }
+      }
+    }
+  }
+
+  fragment SellingPlanGroupsFragment on SellingPlanGroup {
+    sellingPlans(first: $numProductSellingPlans) {
+      edges {
+        node {
+          ...SellingPlanFragment
+        }
+      }
+    }
+    appName
+    name
+    options {
+      name
+      values
+    }
+  }
+  fragment MoneyFragment on MoneyV2 {
+    currencyCode
+    amount
+  }
+
+  fragment VideoFragment on Video {
+    id
+    previewImage {
+      url
+    }
+    sources {
+      mimeType
+      url
+    }
+  }
+
+  fragment ExternalVideoFragment on ExternalVideo {
+    id
+    embedUrl
+    host
+  }
+
+  fragment Model3DFragment on Model3d {
+    id
+    alt
+    mediaContentType
+    previewImage {
+      url
+    }
+    sources {
+      url
+    }
+  }
+
+  fragment SellingPlanFragment on SellingPlan {
+    id
+    description
+    name
+    options {
+      name
+      value
+    }
+    priceAdjustments {
+      orderCount
+      adjustmentValue {
+        ... on SellingPlanFixedAmountPriceAdjustment {
+          adjustmentAmount {
+            ...MoneyFragment
+          }
+        }
+        ... on SellingPlanFixedPriceAdjustment {
+          price {
+            ...MoneyFragment
+          }
+        }
+        ... on SellingPlanPercentagePriceAdjustment {
+          adjustmentPercentage
+        }
+      }
+    }
+    recurringDeliveries
+  }
+
+  fragment UnitPriceFragment on ProductVariant {
+    unitPriceMeasurement {
+      measuredType
+      quantityUnit
+      quantityValue
+      referenceUnit
+      referenceValue
+    }
+    unitPrice {
+      ...MoneyFragment
+    }
+  }
 `;

--- a/examples/template-hydrogen-default/src/routes/index.server.jsx
+++ b/examples/template-hydrogen-default/src/routes/index.server.jsx
@@ -5,11 +5,7 @@ import {
   Seo,
   CacheDays,
 } from '@shopify/hydrogen';
-import {
-  ProductProviderFragment,
-  ImageFragment,
-  HomeSeoFragment,
-} from '@shopify/hydrogen/fragments';
+import {HomeSeoFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Layout from '../components/Layout.server';
@@ -234,6 +230,245 @@ const QUERY = gql`
     }
   }
 
-  ${ProductProviderFragment}
-  ${ImageFragment}
+  fragment ImageFragment on Image {
+    id
+    url
+    altText
+    width
+    height
+  }
+
+  fragment ProductProviderFragment on Product {
+    compareAtPriceRange {
+      maxVariantPrice {
+        ...MoneyFragment
+      }
+      minVariantPrice {
+        ...MoneyFragment
+      }
+    }
+    descriptionHtml
+    handle
+    id
+    media(first: $numProductMedia) {
+      edges {
+        node {
+          ...MediaFileFragment
+        }
+      }
+    }
+    metafields(first: $numProductMetafields) {
+      edges {
+        node {
+          ...MetafieldFragment
+        }
+      }
+    }
+    priceRange {
+      maxVariantPrice {
+        ...MoneyFragment
+      }
+      minVariantPrice {
+        ...MoneyFragment
+      }
+    }
+    title
+    variants(first: $numProductVariants) {
+      edges {
+        node {
+          ...VariantFragment
+        }
+      }
+    }
+    sellingPlanGroups(first: $numProductSellingPlanGroups) {
+      edges {
+        node {
+          ...SellingPlanGroupsFragment
+        }
+      }
+    }
+  }
+
+  fragment MediaFileFragment on Media {
+    ... on MediaImage {
+      mediaContentType
+      image {
+        ...ImageFragment
+      }
+    }
+    ... on Video {
+      mediaContentType
+      ...VideoFragment
+    }
+    ... on ExternalVideo {
+      mediaContentType
+      ...ExternalVideoFragment
+    }
+    ... on Model3d {
+      mediaContentType
+      ...Model3DFragment
+    }
+  }
+
+  fragment MetafieldFragment on Metafield {
+    id
+    type
+    namespace
+    key
+    value
+    createdAt
+    updatedAt
+    description
+    reference @include(if: $includeReferenceMetafieldDetails) {
+      __typename
+      ... on MediaImage {
+        id
+        mediaContentType
+        image {
+          ...ImageFragment
+        }
+      }
+    }
+  }
+
+  fragment VariantFragment on ProductVariant {
+    id
+    title
+    availableForSale
+    image {
+      ...ImageFragment
+    }
+    ...UnitPriceFragment
+    priceV2 {
+      ...MoneyFragment
+    }
+    compareAtPriceV2 {
+      ...MoneyFragment
+    }
+    selectedOptions {
+      name
+      value
+    }
+    metafields(first: $numProductVariantMetafields) {
+      edges {
+        node {
+          ...MetafieldFragment
+        }
+      }
+    }
+    sellingPlanAllocations(first: $numProductVariantSellingPlanAllocations) {
+      edges {
+        node {
+          priceAdjustments {
+            compareAtPrice {
+              ...MoneyFragment
+            }
+            perDeliveryPrice {
+              ...MoneyFragment
+            }
+            price {
+              ...MoneyFragment
+            }
+            unitPrice {
+              ...MoneyFragment
+            }
+          }
+          sellingPlan {
+            ...SellingPlanFragment
+          }
+        }
+      }
+    }
+  }
+
+  fragment SellingPlanGroupsFragment on SellingPlanGroup {
+    sellingPlans(first: $numProductSellingPlans) {
+      edges {
+        node {
+          ...SellingPlanFragment
+        }
+      }
+    }
+    appName
+    name
+    options {
+      name
+      values
+    }
+  }
+  fragment MoneyFragment on MoneyV2 {
+    currencyCode
+    amount
+  }
+
+  fragment VideoFragment on Video {
+    id
+    previewImage {
+      url
+    }
+    sources {
+      mimeType
+      url
+    }
+  }
+
+  fragment ExternalVideoFragment on ExternalVideo {
+    id
+    embedUrl
+    host
+  }
+
+  fragment Model3DFragment on Model3d {
+    id
+    alt
+    mediaContentType
+    previewImage {
+      url
+    }
+    sources {
+      url
+    }
+  }
+
+  fragment SellingPlanFragment on SellingPlan {
+    id
+    description
+    name
+    options {
+      name
+      value
+    }
+    priceAdjustments {
+      orderCount
+      adjustmentValue {
+        ... on SellingPlanFixedAmountPriceAdjustment {
+          adjustmentAmount {
+            ...MoneyFragment
+          }
+        }
+        ... on SellingPlanFixedPriceAdjustment {
+          price {
+            ...MoneyFragment
+          }
+        }
+        ... on SellingPlanPercentagePriceAdjustment {
+          adjustmentPercentage
+        }
+      }
+    }
+    recurringDeliveries
+  }
+
+  fragment UnitPriceFragment on ProductVariant {
+    unitPriceMeasurement {
+      measuredType
+      quantityUnit
+      quantityValue
+      referenceUnit
+      referenceValue
+    }
+    unitPrice {
+      ...MoneyFragment
+    }
+  }
 `;

--- a/examples/template-hydrogen-default/src/routes/pages/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/pages/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, Seo} from '@shopify/hydrogen';
-import {PageSeoFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Layout from '../../components/Layout.server';
@@ -29,12 +28,22 @@ export default function Page({params}) {
 
 const QUERY = gql`
   query PageDetails($handle: String!) {
-    pageByHandle(handle: $handle) {
+    page(handle: $handle) {
       title
       body
       ...PageSeoFragment
     }
   }
 
-  ${PageSeoFragment}
+  fragment PageSeoFragment on Page {
+    title
+    seo {
+      ...SeoFragment
+    }
+  }
+
+  fragment SeoFragment on SEO {
+    description
+    title
+  }
 `;

--- a/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
@@ -1,8 +1,4 @@
 import {useShopQuery, Seo} from '@shopify/hydrogen';
-import {
-  ProductProviderFragment,
-  ProductSeoFragment,
-} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';
@@ -56,6 +52,284 @@ const QUERY = gql`
     }
   }
 
-  ${ProductProviderFragment}
-  ${ProductSeoFragment}
+  fragment ImageFragment on Image {
+    id
+    url
+    altText
+    width
+    height
+  }
+
+  fragment ProductProviderFragment on Product {
+    compareAtPriceRange {
+      maxVariantPrice {
+        ...MoneyFragment
+      }
+      minVariantPrice {
+        ...MoneyFragment
+      }
+    }
+    descriptionHtml
+    handle
+    id
+    media(first: $numProductMedia) {
+      edges {
+        node {
+          ...MediaFileFragment
+        }
+      }
+    }
+    metafields(first: $numProductMetafields) {
+      edges {
+        node {
+          ...MetafieldFragment
+        }
+      }
+    }
+    priceRange {
+      maxVariantPrice {
+        ...MoneyFragment
+      }
+      minVariantPrice {
+        ...MoneyFragment
+      }
+    }
+    title
+    variants(first: $numProductVariants) {
+      edges {
+        node {
+          ...VariantFragment
+        }
+      }
+    }
+    sellingPlanGroups(first: $numProductSellingPlanGroups) {
+      edges {
+        node {
+          ...SellingPlanGroupsFragment
+        }
+      }
+    }
+  }
+
+  fragment MediaFileFragment on Media {
+    ... on MediaImage {
+      mediaContentType
+      image {
+        ...ImageFragment
+      }
+    }
+    ... on Video {
+      mediaContentType
+      ...VideoFragment
+    }
+    ... on ExternalVideo {
+      mediaContentType
+      ...ExternalVideoFragment
+    }
+    ... on Model3d {
+      mediaContentType
+      ...Model3DFragment
+    }
+  }
+
+  fragment MetafieldFragment on Metafield {
+    id
+    type
+    namespace
+    key
+    value
+    createdAt
+    updatedAt
+    description
+    reference @include(if: $includeReferenceMetafieldDetails) {
+      __typename
+      ... on MediaImage {
+        id
+        mediaContentType
+        image {
+          ...ImageFragment
+        }
+      }
+    }
+  }
+
+  fragment VariantFragment on ProductVariant {
+    id
+    title
+    availableForSale
+    image {
+      ...ImageFragment
+    }
+    ...UnitPriceFragment
+    priceV2 {
+      ...MoneyFragment
+    }
+    compareAtPriceV2 {
+      ...MoneyFragment
+    }
+    selectedOptions {
+      name
+      value
+    }
+    metafields(first: $numProductVariantMetafields) {
+      edges {
+        node {
+          ...MetafieldFragment
+        }
+      }
+    }
+    sellingPlanAllocations(first: $numProductVariantSellingPlanAllocations) {
+      edges {
+        node {
+          priceAdjustments {
+            compareAtPrice {
+              ...MoneyFragment
+            }
+            perDeliveryPrice {
+              ...MoneyFragment
+            }
+            price {
+              ...MoneyFragment
+            }
+            unitPrice {
+              ...MoneyFragment
+            }
+          }
+          sellingPlan {
+            ...SellingPlanFragment
+          }
+        }
+      }
+    }
+  }
+
+  fragment SellingPlanGroupsFragment on SellingPlanGroup {
+    sellingPlans(first: $numProductSellingPlans) {
+      edges {
+        node {
+          ...SellingPlanFragment
+        }
+      }
+    }
+    appName
+    name
+    options {
+      name
+      values
+    }
+  }
+  fragment MoneyFragment on MoneyV2 {
+    currencyCode
+    amount
+  }
+
+  fragment VideoFragment on Video {
+    id
+    previewImage {
+      url
+    }
+    sources {
+      mimeType
+      url
+    }
+  }
+
+  fragment ExternalVideoFragment on ExternalVideo {
+    id
+    embedUrl
+    host
+  }
+
+  fragment Model3DFragment on Model3d {
+    id
+    alt
+    mediaContentType
+    previewImage {
+      url
+    }
+    sources {
+      url
+    }
+  }
+
+  fragment SellingPlanFragment on SellingPlan {
+    id
+    description
+    name
+    options {
+      name
+      value
+    }
+    priceAdjustments {
+      orderCount
+      adjustmentValue {
+        ... on SellingPlanFixedAmountPriceAdjustment {
+          adjustmentAmount {
+            ...MoneyFragment
+          }
+        }
+        ... on SellingPlanFixedPriceAdjustment {
+          price {
+            ...MoneyFragment
+          }
+        }
+        ... on SellingPlanPercentagePriceAdjustment {
+          adjustmentPercentage
+        }
+      }
+    }
+    recurringDeliveries
+  }
+
+  fragment UnitPriceFragment on ProductVariant {
+    unitPriceMeasurement {
+      measuredType
+      quantityUnit
+      quantityValue
+      referenceUnit
+      referenceValue
+    }
+    unitPrice {
+      ...MoneyFragment
+    }
+  }
+
+  fragment ProductSeoFragment on Product {
+    title
+    description
+    seo {
+      ...SeoFragment
+    }
+    vendor
+    featuredImage {
+      ...ImageSeoFragment
+    }
+    variants(first: $numProductVariants) {
+      edges {
+        node {
+          image {
+            url
+          }
+          availableForSale
+          priceV2 {
+            amount
+            currencyCode
+          }
+          sku
+        }
+      }
+    }
+  }
+
+  fragment ImageSeoFragment on Image {
+    url
+    width
+    height
+    altText
+  }
+
+  fragment SeoFragment on SEO {
+    description
+    title
+  }
 `;


### PR DESCRIPTION
WIP to demonstrate what it looks like to remove our fragments from:

- Index
- Product
- Collections
- Pages

And how to migrate `<CartProvider>` away from embedding its own queries, to live in a local `/cart` API function instead in the developer's code.