### PR TITLE
Fix preloading queries in workers

### DIFF
--- a/.changeset/tricky-kangaroos-carry.md
+++ b/.changeset/tricky-kangaroos-carry.md
@@ -2,11 +2,11 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix preloading queries in workers to prevent waterfall requests. 
+Fix preloading queries in workers to prevent waterfall requests.
 
 **Breaking change**: `fetchBuilder` no longer accepts a `Request` argument. Instead, it now accepts a `url: string` and `options: FetchInit`:
 
 ```diff
 -fetchBuilder(new Request('https://my.endpoint.com', {headers: {foo: 'bar'}}));
 +fetchBuilder('https://my.endpoint.com', {headers: {foo: 'bar}});
-``
+```

--- a/.changeset/tricky-kangaroos-carry.md
+++ b/.changeset/tricky-kangaroos-carry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix preloading queries in workers to prevent waterfall requests.

--- a/.changeset/tricky-kangaroos-carry.md
+++ b/.changeset/tricky-kangaroos-carry.md
@@ -2,4 +2,11 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix preloading queries in workers to prevent waterfall requests.
+Fix preloading queries in workers to prevent waterfall requests. 
+
+**Breaking change**: `fetchBuilder` no longer accepts a `Request` argument. Instead, it now accepts a `url: string` and `options: FetchInit`:
+
+```diff
+-fetchBuilder(new Request('https://my.endpoint.com', {headers: {foo: 'bar'}}));
++fetchBuilder('https://my.endpoint.com', {headers: {foo: 'bar}});
+``

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -164,13 +164,6 @@ export function preloadRequestCacheData(
             },
             (error) => {
               result = {error};
-
-              collectQueryTimings(
-                request,
-                preloadQuery.key,
-                'expired',
-                getTime() - startApiTime
-              );
             }
           );
         }

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -95,19 +95,21 @@ export function useRequestCacheData<T>(
   const cacheKey = hashKey(key);
 
   if (!cache.has(cacheKey)) {
-    let data: RequestCacheResult<T>;
+    let result: RequestCacheResult<T>;
     let promise: Promise<RequestCacheResult<T> | void>;
 
     cache.set(cacheKey, () => {
-      if (data !== undefined) {
+      if (result !== undefined) {
         collectQueryTimings(request, key, 'rendered');
-        return data;
+        return result;
       }
+
       if (!promise) {
         const startApiTime = getTime();
         promise = fetcher().then(
-          (r) => {
-            data = {data: r};
+          (data) => {
+            result = {data};
+
             collectQueryTimings(
               request,
               key,
@@ -115,9 +117,10 @@ export function useRequestCacheData<T>(
               getTime() - startApiTime
             );
           },
-          (e) => (data = {error: e})
+          (error) => (result = {error})
         );
       }
+
       throw promise;
     });
   }
@@ -139,19 +142,19 @@ export function preloadRequestCacheData(
     collectQueryTimings(request, preloadQuery.key, 'preload');
 
     if (!cache.has(cacheKey)) {
-      let data: unknown;
+      let result: unknown;
       let promise: Promise<unknown>;
 
       cache.set(cacheKey, () => {
-        if (data !== undefined) {
+        if (result !== undefined) {
           collectQueryTimings(request, preloadQuery.key, 'rendered');
-          return data;
+          return result;
         }
         if (!promise) {
           const startApiTime = getTime();
           promise = preloadQuery.fetcher().then(
-            (r) => {
-              data = {data: r};
+            (data) => {
+              result = {data};
               collectQueryTimings(
                 request,
                 preloadQuery.key,
@@ -159,12 +162,9 @@ export function preloadRequestCacheData(
                 getTime() - startApiTime
               );
             },
-            (e) => {
-              // The preload query failed for some reason:
-              // On Cloudfare, this happens when a Cache item has expired at max-age
-              //
-              // We need to remove this entry from cache so that render cycle will retry on its own
-              cache.delete(cacheKey);
+            (error) => {
+              result = {error};
+
               collectQueryTimings(
                 request,
                 preloadQuery.key,

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -51,12 +51,12 @@ export function useShopQuery<T>({
   const log = getLoggerWithContext(serverRequest);
 
   const body = query ? graphqlRequestBody(query, variables) : '';
-  const {request, key} = createShopRequest(body, locale);
+  const {key, url, requestInit} = createShopRequest(body, locale);
 
   const {data, error: useQueryError} = useQuery<UseShopQueryResponse<T>>(
     key,
     query
-      ? fetchBuilder<UseShopQueryResponse<T>>(request)
+      ? fetchBuilder<UseShopQueryResponse<T>>(url, requestInit)
       : // If no query, avoid calling SFAPI & return nothing
         async () => ({data: undefined as unknown as T, errors: undefined}),
     {cache, preload}
@@ -108,19 +108,18 @@ function createShopRequest(body: string, locale?: string) {
     locale: defaultLocale,
   } = useShop();
 
-  const url = `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`;
-
   return {
-    request: new Request(url, {
+    key: [storeDomain, storefrontApiVersion, body, locale],
+    url: `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
+    requestInit: {
+      body,
       method: 'POST',
       headers: {
         'X-Shopify-Storefront-Access-Token': storefrontToken,
         'content-type': 'application/json',
         'Accept-Language': (locale as string) ?? defaultLocale,
       },
-      body,
-    }),
-    key: [storeDomain, storefrontApiVersion, body, locale],
+    },
   };
 }
 

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -133,20 +133,18 @@ function queryShopBuilder(shopifyConfig: ShopifyConfig) {
     const {storeDomain, storefrontApiVersion, storefrontToken, defaultLocale} =
       shopifyConfig;
 
-    const request = new Request(
+    const fetcher = fetchBuilder<T>(
       `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
       {
         method: 'POST',
+        body: graphqlRequestBody(query, variables),
         headers: {
           'X-Shopify-Storefront-Access-Token': storefrontToken,
           'Accept-Language': (locale as string) ?? defaultLocale,
           'Content-Type': 'application/json',
         },
-        body: graphqlRequestBody(query, variables),
       }
     );
-
-    const fetcher = fetchBuilder<T>(request);
 
     return await fetcher();
   };

--- a/packages/hydrogen/src/utilities/fetch.ts
+++ b/packages/hydrogen/src/utilities/fetch.ts
@@ -2,20 +2,25 @@ import {print} from 'graphql';
 import {LIB_VERSION} from '../version';
 import {ASTNode} from 'graphql';
 
-export function fetchBuilder<T>(request: Request) {
-  const defaultHeaders: Record<string, string> = {
-    'content-type': 'application/json',
-    'user-agent': `Hydrogen ${LIB_VERSION}`,
+const defaultHeaders = {
+  'content-type': 'application/json',
+  'user-agent': `Hydrogen ${LIB_VERSION}`,
+};
+
+type FetchInit = {
+  body?: string;
+  method?: string;
+  headers?: Record<string, string>;
+};
+
+export function fetchBuilder<T>(url: string, options: FetchInit = {}) {
+  const requestInit = {
+    ...options,
+    headers: {...defaultHeaders, ...options.headers},
   };
 
-  for (const [property, value] of Object.entries(defaultHeaders)) {
-    if (!request.headers.has(property)) {
-      request.headers.append(property, value);
-    }
-  }
-
   return async () => {
-    const response = await fetch(request.url, request);
+    const response = await fetch(url, requestInit);
 
     if (!response.ok) {
       throw response;

--- a/packages/hydrogen/src/utilities/log/log-query-timeline.ts
+++ b/packages/hydrogen/src/utilities/log/log-query-timeline.ts
@@ -8,12 +8,7 @@ import {getTime} from '../timing';
 
 import type {RenderType} from './log';
 
-export type TimingType =
-  | 'requested'
-  | 'resolved'
-  | 'rendered'
-  | 'preload'
-  | 'expired';
+export type TimingType = 'requested' | 'resolved' | 'rendered' | 'preload';
 
 export type QueryTiming = {
   name: string;
@@ -28,7 +23,6 @@ const TIMING_MAPPING = {
   rendered: 'Rendered',
   resolved: 'Resolved',
   preload: 'Preload',
-  expired: 'Expired',
 };
 
 export function collectQueryTimings(
@@ -84,7 +78,7 @@ export function logQueryTimings(
           )} ${loadColor(TIMING_MAPPING[query.timingType].padEnd(10))} ${
             query.name
           }${
-            query.timingType === 'resolved' || query.timingType === 'expired'
+            query.timingType === 'resolved'
               ? ` (Took ${duration?.toFixed(2)}ms)`
               : ''
           }`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #777

When preloading queries, our fetch logic was referencing a Request instance created in the original context instead of the current one. This is not allowed in CFW.
The changes in this PR makes the fetch logic reference plain objects/strings instead of Request instances.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
