### PR TITLE
Exploration: store preload queries in remote cache

### DIFF
--- a/.changeset/tricky-kangaroos-carry.md
+++ b/.changeset/tricky-kangaroos-carry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix preloading queries in workers to prevent waterfall requests.

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -95,19 +95,21 @@ export function useRequestCacheData<T>(
   const cacheKey = hashKey(key);
 
   if (!cache.has(cacheKey)) {
-    let data: RequestCacheResult<T>;
+    let result: RequestCacheResult<T>;
     let promise: Promise<RequestCacheResult<T> | void>;
 
     cache.set(cacheKey, () => {
-      if (data !== undefined) {
+      if (result !== undefined) {
         collectQueryTimings(request, key, 'rendered');
-        return data;
+        return result;
       }
+
       if (!promise) {
         const startApiTime = getTime();
         promise = fetcher().then(
-          (r) => {
-            data = {data: r};
+          (data) => {
+            result = {data};
+
             collectQueryTimings(
               request,
               key,
@@ -115,9 +117,10 @@ export function useRequestCacheData<T>(
               getTime() - startApiTime
             );
           },
-          (e) => (data = {error: e})
+          (error) => (result = {error})
         );
       }
+
       throw promise;
     });
   }
@@ -139,19 +142,19 @@ export function preloadRequestCacheData(
     collectQueryTimings(request, preloadQuery.key, 'preload');
 
     if (!cache.has(cacheKey)) {
-      let data: unknown;
+      let result: unknown;
       let promise: Promise<unknown>;
 
       cache.set(cacheKey, () => {
-        if (data !== undefined) {
+        if (result !== undefined) {
           collectQueryTimings(request, preloadQuery.key, 'rendered');
-          return data;
+          return result;
         }
         if (!promise) {
           const startApiTime = getTime();
           promise = preloadQuery.fetcher().then(
-            (r) => {
-              data = {data: r};
+            (data) => {
+              result = {data};
               collectQueryTimings(
                 request,
                 preloadQuery.key,
@@ -159,12 +162,9 @@ export function preloadRequestCacheData(
                 getTime() - startApiTime
               );
             },
-            (e) => {
-              // The preload query failed for some reason:
-              // On Cloudfare, this happens when a Cache item has expired at max-age
-              //
-              // We need to remove this entry from cache so that render cycle will retry on its own
-              cache.delete(cacheKey);
+            (error) => {
+              result = {error};
+
               collectQueryTimings(
                 request,
                 preloadQuery.key,

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -13,6 +13,7 @@ import {
 } from '../../framework/cache';
 import {runDelayedFunction} from '../../framework/runtime';
 import {useRequestCacheData, useServerRequest} from '../ServerRequestProvider';
+import type {FetchInit} from '../../utilities/fetch';
 
 export interface HydrogenUseQueryOptions {
   /** The [caching strategy](/custom-storefronts/hydrogen/framework/cache#caching-strategies) to help you
@@ -24,6 +25,10 @@ export interface HydrogenUseQueryOptions {
    * to preload the query for all requests.
    */
   preload?: PreloadOptions;
+  asyncPreload?: {
+    url: string;
+    fetchInit: FetchInit;
+  };
 }
 
 /**
@@ -55,6 +60,8 @@ export function useQuery<T>(
       preload: queryOptions?.preload,
       key: withCacheIdKey,
       fetcher,
+      url: queryOptions?.asyncPreload?.url,
+      fetchInit: queryOptions?.asyncPreload?.fetchInit,
     });
   }
 

--- a/packages/hydrogen/src/framework/cache.ts
+++ b/packages/hydrogen/src/framework/cache.ts
@@ -41,9 +41,9 @@ function getKeyUrl(key: string) {
  * containing the `JSON.parse` version of the response as well
  * as the response itself so it can be checked for staleness.
  */
-export async function getItemFromCache(
+export async function getItemFromCache<T = any>(
   key: QueryKey
-): Promise<undefined | [any, Response]> {
+): Promise<undefined | [T, Response]> {
   const cache = getCache();
   if (!cache) {
     return;

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -51,12 +51,12 @@ export function useShopQuery<T>({
   const log = getLoggerWithContext(serverRequest);
 
   const body = query ? graphqlRequestBody(query, variables) : '';
-  const {request, key} = createShopRequest(body, locale);
+  const {key, url, requestInit} = createShopRequest(body, locale);
 
   const {data, error: useQueryError} = useQuery<UseShopQueryResponse<T>>(
     key,
     query
-      ? fetchBuilder<UseShopQueryResponse<T>>(request)
+      ? fetchBuilder<UseShopQueryResponse<T>>(url, requestInit)
       : // If no query, avoid calling SFAPI & return nothing
         async () => ({data: undefined as unknown as T, errors: undefined}),
     {cache, preload}
@@ -108,19 +108,18 @@ function createShopRequest(body: string, locale?: string) {
     locale: defaultLocale,
   } = useShop();
 
-  const url = `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`;
-
   return {
-    request: new Request(url, {
+    key: [storeDomain, storefrontApiVersion, body, locale],
+    url: `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
+    requestInit: {
+      body,
       method: 'POST',
       headers: {
         'X-Shopify-Storefront-Access-Token': storefrontToken,
         'content-type': 'application/json',
         'Accept-Language': (locale as string) ?? defaultLocale,
       },
-      body,
-    }),
-    key: [storeDomain, storefrontApiVersion, body, locale],
+    },
   };
 }
 

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -59,7 +59,7 @@ export function useShopQuery<T>({
       ? fetchBuilder<UseShopQueryResponse<T>>(url, requestInit)
       : // If no query, avoid calling SFAPI & return nothing
         async () => ({data: undefined as unknown as T, errors: undefined}),
-    {cache, preload}
+    {cache, preload, asyncPreload: {url, fetchInit: requestInit}}
   );
 
   /**

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -133,20 +133,18 @@ function queryShopBuilder(shopifyConfig: ShopifyConfig) {
     const {storeDomain, storefrontApiVersion, storefrontToken, defaultLocale} =
       shopifyConfig;
 
-    const request = new Request(
+    const fetcher = fetchBuilder<T>(
       `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
       {
         method: 'POST',
+        body: graphqlRequestBody(query, variables),
         headers: {
           'X-Shopify-Storefront-Access-Token': storefrontToken,
           'Accept-Language': (locale as string) ?? defaultLocale,
           'Content-Type': 'application/json',
         },
-        body: graphqlRequestBody(query, variables),
       }
     );
-
-    const fetcher = fetchBuilder<T>(request);
 
     return await fetcher();
   };

--- a/packages/hydrogen/src/utilities/fetch.ts
+++ b/packages/hydrogen/src/utilities/fetch.ts
@@ -7,7 +7,7 @@ const defaultHeaders = {
   'user-agent': `Hydrogen ${LIB_VERSION}`,
 };
 
-type FetchInit = {
+export type FetchInit = {
   body?: string;
   method?: string;
   headers?: Record<string, string>;

--- a/packages/hydrogen/src/utilities/fetch.ts
+++ b/packages/hydrogen/src/utilities/fetch.ts
@@ -2,20 +2,25 @@ import {print} from 'graphql';
 import {LIB_VERSION} from '../version';
 import {ASTNode} from 'graphql';
 
-export function fetchBuilder<T>(request: Request) {
-  const defaultHeaders: Record<string, string> = {
-    'content-type': 'application/json',
-    'user-agent': `Hydrogen ${LIB_VERSION}`,
+const defaultHeaders = {
+  'content-type': 'application/json',
+  'user-agent': `Hydrogen ${LIB_VERSION}`,
+};
+
+type FetchInit = {
+  body?: string;
+  method?: string;
+  headers?: Record<string, string>;
+};
+
+export function fetchBuilder<T>(url: string, options: FetchInit = {}) {
+  const requestInit = {
+    ...options,
+    headers: {...defaultHeaders, ...options.headers},
   };
 
-  for (const [property, value] of Object.entries(defaultHeaders)) {
-    if (!request.headers.has(property)) {
-      request.headers.append(property, value);
-    }
-  }
-
   return async () => {
-    const response = await fetch(request.url, request);
+    const response = await fetch(url, requestInit);
 
     if (!response.ok) {
       throw response;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

@jplhomer While fixing #777 I also checked if it was possible to implement what I mentioned last Tuesday
**In theory** (read: I haven't actually tried it) with something like this we could save preloading information in a remote cache and retrieve it the first time a worker instance is created.
In your opinion, is any of this worth exploring further? I guess we  don't really have the numbers to understand if it would make an impact in performance.

cc @wizardlyhel 

### Additional context

A `fetcher` is the function that executes the query and it can be created using `url` and `fetchInit` using the `fetchBuilder` function. Both of these can be serialized so we can save them in cache and use them later to create a new `fetcher`.

Basically, the first time `handleRequest` runs in a new worker instance, it checks the remote cache and tries to populate `preloadCache` map so it can be used later in the current request, and in posterior requests that re-use the same worker instance.
When the first time `handleRequest` ends, it sends the preloading info stored in `preloadCache` map to the remote cache -- This should be modified to send information every time a new URL is added, not just the first one.


---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
