### PR TITLE
Improve dev: Disable build caching and don't continue on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "dev": "cross-env LOCAL_DEV=true yarn turbo run dev --parallel --continue",
+    "dev": "cross-env LOCAL_DEV=true yarn turbo run dev --parallel",
     "build": "yarn turbo run build",
     "lint": "run-p lint:js lint:language",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx packages/*/src",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "baseBranch": "origin/main",
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "cache": false
     },
     "test": {
       "outputs": []


### PR DESCRIPTION
- Disables build caching. This should prevent stale hydrogen build info from affecting local dev server. It's slower, but fuck it — it's more consistent until we find a better way to invalidate Turbo's cache.
- Disables continuing on failed build. E.g. if the initial hydrogen build fails, we don't want to try to start the Vite dev server, because it will also fail due to missing Vite plugin files.

TODO: Eventually prevent the need to run `build` on the start of `dev`. It's silly to make this a req't because it's slow and you shouldn't need to have Types perfect when developing stuff.