### PR TITLE
Product provider no fragment

### DIFF
--- a/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
@@ -1,15 +1,15 @@
 import React, {ReactNode, useMemo} from 'react';
-import {useProductOptions, useParsedMetafields} from '../../hooks';
-import {flattenConnection} from '../../utilities';
+import {useProductOptions} from '../../hooks';
 import {ProductContext, ProductContextType} from './context';
-import {Product} from './types';
+// import {Product} from './types';
+import {Product} from '../../graphql/types/types';
 import {ProductOptionsProvider} from './ProductOptionsProvider.client';
 
 export interface ProductProviderProps {
   /** A `ReactNode` element. */
   children: ReactNode;
   /** A [Product object](/api/storefront/reference/products/product). */
-  data: Product;
+  data: Partial<Product>;
   /** The initially selected variant. If this is missing, then `selectedVariantId`
    * in the returned `object` from the `useProduct` hook uses the first available variant
    * or the first variant (if none are available).
@@ -28,27 +28,11 @@ export function ProductProvider({
   data: product,
   initialVariantId,
 }: ProductProviderProps) {
-  const metafields = useParsedMetafields(product.metafields);
-
   const providerValue = useMemo<ProductContextType>(() => {
     return {
       ...product,
-      metafields,
-      metafieldsConnection: product.metafields,
-      media: product.media ? flattenConnection(product.media) : undefined,
-      mediaConnection: product.media,
-      variants: product.variants
-        ? flattenConnection(product.variants)
-        : undefined,
-      variantsConnection: product.variants,
-      images: product.images ? flattenConnection(product.images) : undefined,
-      imagesConnection: product.images,
-      collections: product.collections
-        ? flattenConnection(product.collections)
-        : undefined,
-      collectionsConnection: product.collections,
     };
-  }, [metafields, product]);
+  }, [product]);
 
   return (
     <ProductContext.Provider value={providerValue}>

--- a/packages/hydrogen/src/components/ProductProvider/context.ts
+++ b/packages/hydrogen/src/components/ProductProvider/context.ts
@@ -1,34 +1,10 @@
 import {createContext} from 'react';
 import {ProductOptionsHookValue} from '../../hooks';
-import {ParsedMetafield} from '../../types';
-import {ProductProviderFragmentFragment} from './ProductProviderFragment';
-import {Product} from './types';
-import {Collection, Image} from '../../graphql/types/types';
-import type {Variant} from '../../hooks/useProductOptions';
+import type {Product} from '../../graphql/types/types';
 
 export const ProductContext = createContext<ProductContextType | null>(null);
 
-export type ProductContextType = Omit<
-  Product,
-  | 'media'
-  | 'metafields'
-  | 'images'
-  | 'collections'
-  | 'variants'
-  | 'sellingPlanGroups'
-  | 'options'
-> & {
-  media?: ProductProviderFragmentFragment['media']['edges'][0]['node'][];
-  mediaConnection?: Product['media'];
-  metafields?: ParsedMetafield[];
-  metafieldsConnection?: Product['metafields'];
-  images?: Partial<Image>[];
-  imagesConnection?: Product['images'];
-  collections?: Partial<Collection>[];
-  collectionsConnection?: Product['collections'];
-  variants?: Partial<Variant>[];
-  variantsConnection?: Product['variants'];
-};
+export type ProductContextType = Partial<Product>;
 
 export const ProductOptionsContext =
   createContext<ProductOptionsHookValue | null>(null);


### PR DESCRIPTION
Not intended to merge, only meant to demonstrate what ProductProvider looks like when we drop Fragments.

Because we can't guarantee that any specific property exists on product (because we don't want to force devs to query for properties that they don't use), all we're left with is... essentially the product object that they give us. I don't see any value in this component anymore.

This also indicates that `useProduct()` isn't useful, because again we aren't guaranteed to have any property on `const product = useProduct()`.

In turn, it also means that components like `Product[thing]` are kind of pointless, too. 

So I propose that we get rid of ALL `Product[thing]` components, and make our base components (such as `Metafield`, `Money`, etc) more robust and the developer uses props to pass things from Product. 

If there is logic in a specific `Product[thing]` component that is helpful, we can turn those into functions and/or hooks that the dev can use themselves. For example, the logic in `ProductPrice.client.tsx` can be extracted into a helper function called `getProductPrice()`. That way we can still help with common use cases!