### PR TITLE
[WIP] Country dropdown extends beyond browser window in default starter

### DIFF
--- a/examples/template-hydrogen-default/src/components/CountrySelector.client.jsx
+++ b/examples/template-hydrogen-default/src/components/CountrySelector.client.jsx
@@ -35,7 +35,7 @@ export default function CountrySelector() {
             </Listbox.Button>
 
             <Listbox.Options className="absolute z-10 mt-2">
-              <div className="bg-white p-4 rounded-lg drop-shadow-2xl">
+              <div className="bg-white p-4 rounded-lg drop-shadow-2xl overflow-y-auto h-64">
                 <Listbox.Option
                   disabled
                   className="p-2 text-md text-left font-medium uppercase"

--- a/examples/template-hydrogen-default/src/components/CountrySelector.client.jsx
+++ b/examples/template-hydrogen-default/src/components/CountrySelector.client.jsx
@@ -1,6 +1,9 @@
-import {useCallback, useMemo} from 'react';
+import React, {useCallback, useMemo, Suspense} from 'react';
 import {useAvailableCountries, useCountry} from '@shopify/hydrogen/client';
 import {Listbox} from '@headlessui/react';
+const CountrySelectorAvailableCountry = React.lazy(() =>
+  import('./CountrySlecterAvailableCountry.client'),
+);
 
 /**
  * A client component that selects the appropriate country to display for products on a website
@@ -33,37 +36,14 @@ export default function CountrySelector() {
               <span className="mr-4">{selectedCountry.name}</span>
               <ArrowIcon isOpen={open} />
             </Listbox.Button>
-
-            <Listbox.Options className="absolute z-10 mt-2">
-              <div className="bg-white p-4 rounded-lg drop-shadow-2xl overflow-y-auto h-64">
-                <Listbox.Option
-                  disabled
-                  className="p-2 text-md text-left font-medium uppercase"
-                >
-                  Country
-                </Listbox.Option>
-                {countries.map((country) => {
-                  const isSelected =
-                    country.isoCode === selectedCountry.isoCode;
-                  return (
-                    <Listbox.Option
-                      key={country.isoCode}
-                      value={country.isoCode}
-                    >
-                      {({active}) => (
-                        <div
-                          className={`w-36 py-2 px-3 flex justify-between items-center text-left cursor-pointer rounded
-                          ${active ? 'bg-gray-200' : null}`}
-                        >
-                          {country.name}
-                          {isSelected ? <CheckIcon /> : null}
-                        </div>
-                      )}
-                    </Listbox.Option>
-                  );
-                })}
-              </div>
-            </Listbox.Options>
+            {open && (
+              <Suspense fallback={<div>Loading...</div>}>
+                <CountrySelectorAvailableCountry
+                  countries={countries}
+                  selectedCountry={selectedCountry}
+                />
+              </Suspense>
+            )}
           </>
         )}
       </Listbox>

--- a/examples/template-hydrogen-default/src/components/CountrySelectorAvailableCountry.client.jsx
+++ b/examples/template-hydrogen-default/src/components/CountrySelectorAvailableCountry.client.jsx
@@ -1,0 +1,36 @@
+import {Listbox} from '@headlessui/react';
+import {CheckIcon} from './CountrySelector.client';
+
+export default function CountrySelectorAvailableCountry({
+  countries,
+  selectedCountry,
+}) {
+  return (
+    <Listbox.Options className="absolute z-10 mt-2">
+      <div className="bg-white p-4 rounded-lg drop-shadow-2xl overflow-y-auto h-64">
+        <Listbox.Option
+          disabled
+          className="p-2 text-md text-left font-medium uppercase"
+        >
+          Country
+        </Listbox.Option>
+        {countries.map((country) => {
+          const isSelected = country.isoCode === selectedCountry.isoCode;
+          return (
+            <Listbox.Option key={country.isoCode} value={country.isoCode}>
+              {({active}) => (
+                <div
+                  className={`w-36 py-2 px-3 flex justify-between items-center text-left cursor-pointer rounded
+                ${active ? 'bg-gray-200' : null}`}
+                >
+                  {country.name}
+                  {isSelected ? <CheckIcon /> : null}
+                </div>
+              )}
+            </Listbox.Option>
+          );
+        })}
+      </div>
+    </Listbox.Options>
+  );
+}

--- a/examples/template-hydrogen-default/src/components/MobileCountrySelector.client.jsx
+++ b/examples/template-hydrogen-default/src/components/MobileCountrySelector.client.jsx
@@ -31,7 +31,7 @@ export default function MobileCountrySelector() {
               {selectedCountry.name}
               <ArrowIcon isOpen={open} />
             </Listbox.Button>
-            <Listbox.Options className="w-full px-3 pb-2 text-lg">
+            <Listbox.Options className="w-full px-3 pb-2 text-lg overflow-y-auto h-64">
               <Listbox.Option
                 disabled
                 className="font-medium px-4 pb-4 w-full text-left uppercase"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

- Edit default starter country dropdown to scrollable
- Modified to lazy load a dropdown using React.lazy

<!-- Insert your description here and provide info about what issue this PR is solving -->

https://github.com/Shopify/hydrogen/issues/741

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Is there any other way to implement delayed loading?

In the issue

> A large chunk of JSON data is being serialized for each and every country in the initial SSR HTML and in the RSC responses

However, we have not been able to check this resource and are not sure if it solves the problem or not.

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
