### PR TITLE
Warn of over-fetching to GraphQL data to developers

### DIFF
--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -97,6 +97,79 @@ export function useShopQuery<T>({
     log.error(`GraphQL errors: ${errors.length}`);
   }
 
+  if (import.meta.env.DEV) {
+    // Create a map of read fields
+    const readFieldsMap: Record<string | symbol, any> = {};
+
+    // Create a proxy object that allows us to inspect the fields that were fetched
+    const dataProxy = JSON.parse(JSON.stringify(data), (_, value) => {
+      if (typeof value === 'object' && value && !Array.isArray(value)) {
+        return new Proxy(value, {
+          get(target, prop) {
+            readFieldsMap[prop as any] = true;
+            return target[prop];
+          },
+        });
+      }
+
+      return value;
+    });
+
+    setTimeout(() => {
+      // Track all the selections that were fetched
+      const selections: string[] = [];
+
+      // TODO: Fields that match this regex should be ignored.
+      // Improve to look for Fragment at the end of the name.
+      const regex = /(Fragment|__typename|edges|node)/;
+
+      // Loop through the read fields map and add the
+      // selections to the selections array
+      JSON.parse(JSON.stringify(query), (key, value) => {
+        if (
+          value &&
+          typeof value === 'object' &&
+          value.kind === 'SelectionSet'
+        ) {
+          const selection = value.selections.map((sel: any) => {
+            if (!sel.name || regex.test(sel.name?.value)) {
+              return;
+            }
+
+            return sel.name?.value;
+          });
+
+          selections.push(selection.filter(Boolean));
+        }
+
+        return value;
+      });
+
+      const flattenedSelections = [...new Set(selections.flat())];
+
+      // Check if any of the selections were not read
+      const unusedGraphQLFields = flattenedSelections.filter(
+        (prop) => !readFieldsMap[prop]
+      );
+
+      if (unusedGraphQLFields) {
+        // TODO support aliased fields
+        const defs = (query as any)?.definitions;
+        const queryName = defs && defs[0].name?.value;
+
+        log.warn(
+          `
+Potentially overfetching fields in GraphQL query: \`${queryName}\`.
+• ${unusedGraphQLFields.join(`\n• `)}
+Examine the list of fields above to confirm that they are being used.
+`
+        );
+      }
+    }, 2000);
+
+    return dataProxy as UseShopQueryResponse<T>;
+  }
+
   return data as UseShopQueryResponse<T>;
 }
 

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -108,10 +108,22 @@ export function useShopQuery<T>({
     typeof query !== 'string' &&
     data?.data
   ) {
-    return wrapInGraphQLTracker({query, data, log}) as UseShopQueryResponse<T>;
+    return wrapInGraphQLTracker({
+      query,
+      data,
+      onUnusedData: ({queryName, properties}) => {
+        log.warn(
+          `
+Potentially overfetching fields in GraphQL query: \`${queryName}\`.
+• ${properties.join(`\n• `)}
+Examine the list of fields above to confirm that they are being used.
+`
+        );
+      },
+    });
   }
 
-  return data as UseShopQueryResponse<T>;
+  return data!;
 }
 
 function createShopRequest(body: string, locale?: string) {

--- a/packages/hydrogen/src/utilities/graphql-tracker.ts
+++ b/packages/hydrogen/src/utilities/graphql-tracker.ts
@@ -8,8 +8,6 @@ type TrackerParams = {
 };
 
 export function wrapInGraphQLTracker<T>({query, data, log}: TrackerParams) {
-  if (!import.meta.env.DEV) return;
-
   // Create a map of read fields
   const readFieldsMap: Record<string | symbol, any> = {};
 
@@ -75,5 +73,5 @@ Examine the list of fields above to confirm that they are being used.
     }
   }, 2000);
 
-  return dataProxy;
+  return dataProxy as T;
 }

--- a/packages/hydrogen/src/utilities/graphql-tracker.ts
+++ b/packages/hydrogen/src/utilities/graphql-tracker.ts
@@ -1,13 +1,66 @@
 import type {ASTNode} from 'graphql';
 import type {Logger} from './log';
 
+export const TIMEOUT_MS = 2000;
+
 type TrackerParams = {
   query: ASTNode;
   log: Logger;
   data: {data: unknown};
 };
 
+function checkReadValues(
+  map: Record<string, string>,
+  query: TrackerParams['query'],
+  log: TrackerParams['log']
+) {
+  // Track all the selections that were fetched
+  const selections: string[] = [];
+
+  // TODO: Fields that match this regex should be ignored.
+  // Improve to look for Fragment at the end of the name.
+  const regex = /(Fragment|__typename|edges|node)/;
+
+  // Loop through the read fields map and add the
+  // selections to the selections array
+  JSON.parse(JSON.stringify(query), (key, value) => {
+    if (value && typeof value === 'object' && value.kind === 'SelectionSet') {
+      const selection = value.selections.map((sel: any) => {
+        if (!sel.name || regex.test(sel.name?.value)) {
+          return;
+        }
+
+        return sel.name?.value;
+      });
+
+      selections.push(selection.filter(Boolean));
+    }
+
+    return value;
+  });
+
+  const flattenedSelections = [...new Set(selections.flat())];
+
+  // Check if any of the selections were not read
+  const unusedGraphQLFields = flattenedSelections.filter((prop) => !map[prop]);
+
+  if (unusedGraphQLFields) {
+    // TODO support aliased fields
+    const defs = (query as any)?.definitions;
+    const queryName = defs && defs[0].name?.value;
+
+    log.warn(
+      `
+Potentially overfetching fields in GraphQL query: \`${queryName}\`.
+• ${unusedGraphQLFields.join(`\n• `)}
+Examine the list of fields above to confirm that they are being used.
+`
+    );
+  }
+}
+
 export function wrapInGraphQLTracker<T>({query, data, log}: TrackerParams) {
+  let readTimeout: ReturnType<typeof setTimeout>;
   // Create a map of read fields
   const readFieldsMap: Record<string | symbol, any> = {};
 
@@ -15,8 +68,17 @@ export function wrapInGraphQLTracker<T>({query, data, log}: TrackerParams) {
   const dataProxy = JSON.parse(JSON.stringify(data), (_, value) => {
     if (typeof value === 'object' && value && !Array.isArray(value)) {
       return new Proxy(value, {
-        get(target, prop) {
-          readFieldsMap[prop as any] = true;
+        get(target, prop: any) {
+          if (!readFieldsMap[prop]) {
+            clearTimeout(readTimeout);
+            readTimeout = setTimeout(
+              () => checkReadValues(readFieldsMap, query, log),
+              TIMEOUT_MS
+            );
+          }
+
+          readFieldsMap[prop] = true;
+
           return target[prop];
         },
       });
@@ -24,54 +86,6 @@ export function wrapInGraphQLTracker<T>({query, data, log}: TrackerParams) {
 
     return value;
   });
-
-  setTimeout(() => {
-    // Track all the selections that were fetched
-    const selections: string[] = [];
-
-    // TODO: Fields that match this regex should be ignored.
-    // Improve to look for Fragment at the end of the name.
-    const regex = /(Fragment|__typename|edges|node)/;
-
-    // Loop through the read fields map and add the
-    // selections to the selections array
-    JSON.parse(JSON.stringify(query), (key, value) => {
-      if (value && typeof value === 'object' && value.kind === 'SelectionSet') {
-        const selection = value.selections.map((sel: any) => {
-          if (!sel.name || regex.test(sel.name?.value)) {
-            return;
-          }
-
-          return sel.name?.value;
-        });
-
-        selections.push(selection.filter(Boolean));
-      }
-
-      return value;
-    });
-
-    const flattenedSelections = [...new Set(selections.flat())];
-
-    // Check if any of the selections were not read
-    const unusedGraphQLFields = flattenedSelections.filter(
-      (prop) => !readFieldsMap[prop]
-    );
-
-    if (unusedGraphQLFields) {
-      // TODO support aliased fields
-      const defs = (query as any)?.definitions;
-      const queryName = defs && defs[0].name?.value;
-
-      log.warn(
-        `
-Potentially overfetching fields in GraphQL query: \`${queryName}\`.
-• ${unusedGraphQLFields.join(`\n• `)}
-Examine the list of fields above to confirm that they are being used.
-`
-      );
-    }
-  }, 2000);
 
   return dataProxy as T;
 }

--- a/packages/hydrogen/src/utilities/graphql-tracker.ts
+++ b/packages/hydrogen/src/utilities/graphql-tracker.ts
@@ -1,0 +1,79 @@
+import type {ASTNode} from 'graphql';
+import type {Logger} from './log';
+
+type TrackerParams = {
+  query: ASTNode;
+  log: Logger;
+  data: {data: unknown};
+};
+
+export function wrapInGraphQLTracker<T>({query, data, log}: TrackerParams) {
+  if (!import.meta.env.DEV) return;
+
+  // Create a map of read fields
+  const readFieldsMap: Record<string | symbol, any> = {};
+
+  // Create a proxy object that allows us to inspect the fields that were fetched
+  const dataProxy = JSON.parse(JSON.stringify(data), (_, value) => {
+    if (typeof value === 'object' && value && !Array.isArray(value)) {
+      return new Proxy(value, {
+        get(target, prop) {
+          readFieldsMap[prop as any] = true;
+          return target[prop];
+        },
+      });
+    }
+
+    return value;
+  });
+
+  setTimeout(() => {
+    // Track all the selections that were fetched
+    const selections: string[] = [];
+
+    // TODO: Fields that match this regex should be ignored.
+    // Improve to look for Fragment at the end of the name.
+    const regex = /(Fragment|__typename|edges|node)/;
+
+    // Loop through the read fields map and add the
+    // selections to the selections array
+    JSON.parse(JSON.stringify(query), (key, value) => {
+      if (value && typeof value === 'object' && value.kind === 'SelectionSet') {
+        const selection = value.selections.map((sel: any) => {
+          if (!sel.name || regex.test(sel.name?.value)) {
+            return;
+          }
+
+          return sel.name?.value;
+        });
+
+        selections.push(selection.filter(Boolean));
+      }
+
+      return value;
+    });
+
+    const flattenedSelections = [...new Set(selections.flat())];
+
+    // Check if any of the selections were not read
+    const unusedGraphQLFields = flattenedSelections.filter(
+      (prop) => !readFieldsMap[prop]
+    );
+
+    if (unusedGraphQLFields) {
+      // TODO support aliased fields
+      const defs = (query as any)?.definitions;
+      const queryName = defs && defs[0].name?.value;
+
+      log.warn(
+        `
+Potentially overfetching fields in GraphQL query: \`${queryName}\`.
+• ${unusedGraphQLFields.join(`\n• `)}
+Examine the list of fields above to confirm that they are being used.
+`
+      );
+    }
+  }, 2000);
+
+  return dataProxy;
+}

--- a/packages/hydrogen/src/utilities/tests/graphql-tracker.test.ts
+++ b/packages/hydrogen/src/utilities/tests/graphql-tracker.test.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line node/no-extraneous-import
+import gql from 'graphql-tag';
+import {wrapInGraphQLTracker} from '../graphql-tracker';
+import type {Logger} from '../log';
+
+const query = gql`
+  query shopName {
+    shop {
+      id
+      name
+      description
+      moneyFormat
+      paymentSettings {
+        countryCode
+        currencyCode
+      }
+    }
+  }
+`;
+
+const data = {
+  data: {
+    shop: {
+      id: 'id',
+      name: 'name',
+      description: 'description',
+      moneyFormat: 'moneyFormat',
+      paymentSettings: {
+        countryCode: 'ES',
+        currencyCode: 'EUR',
+      },
+    },
+  },
+};
+
+describe('GraphQL Tracker', () => {
+  jest.useFakeTimers();
+
+  it('warns about unused properties', () => {
+    const warnings = [] as string[];
+    const log = {
+      warn: (string: string) => warnings.push(string),
+    } as unknown as Logger;
+
+    const tracker = wrapInGraphQLTracker<typeof data>({query, data, log});
+
+    // Read stuff via destructuring or direct access
+    tracker.data.shop.id + tracker.data.shop.name;
+
+    const {
+      data: {
+        shop: {
+          // @ts-ignore
+          paymentSettings: {countryCode},
+        },
+      },
+    } = tracker;
+
+    jest.advanceTimersByTime(2100);
+
+    const warning = warnings.join('\n');
+    expect(warning).toContain('shopName');
+
+    expect(warning).toContain('description');
+    expect(warning).toContain('moneyFormat');
+    expect(warning).toContain('currencyCode');
+
+    expect(warning).not.toContain('id');
+    expect(warning).not.toContain('name');
+    expect(warning).not.toContain('countryCode');
+  });
+});

--- a/packages/hydrogen/src/utilities/tests/graphql-tracker.test.ts
+++ b/packages/hydrogen/src/utilities/tests/graphql-tracker.test.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line node/no-extraneous-import
 import gql from 'graphql-tag';
-import {wrapInGraphQLTracker} from '../graphql-tracker';
+import {wrapInGraphQLTracker, TIMEOUT_MS} from '../graphql-tracker';
 import type {Logger} from '../log';
 
 const query = gql`
@@ -47,6 +47,8 @@ describe('GraphQL Tracker', () => {
     // Read stuff via destructuring or direct access
     tracker.data.shop.id + tracker.data.shop.name;
 
+    jest.advanceTimersByTime(TIMEOUT_MS / 2);
+
     const {
       data: {
         shop: {
@@ -56,7 +58,12 @@ describe('GraphQL Tracker', () => {
       },
     } = tracker;
 
-    jest.advanceTimersByTime(2100);
+    jest.advanceTimersByTime(TIMEOUT_MS / 2 + 100);
+    // Not enough time since last read
+    expect(warnings.length).toEqual(0);
+    jest.advanceTimersByTime(TIMEOUT_MS / 2);
+    // Enough time since last read
+    expect(warnings.length).toBeGreaterThan(0);
 
     const warning = warnings.join('\n');
     expect(warning).toContain('shopName');


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is a potential solution that @frandiox and I collaborated on to prevent developers from over-fetching data from the storefront API. We do this by wrapping the returned `data` object from `useShopQuery` in a proxy to keep an internal Map of the fields that are accessed in the React components. We then compare that to the fields requested in their query and print the difference.

<img width="745" alt="Screen Shot 2022-03-11 at 16 53 51" src="https://user-images.githubusercontent.com/462077/157901855-7980cea1-e1b1-4547-b14c-69c82357458c.png">

Note this is not super performant and we can iterate on that aspect later quite easily.

Looking for early feedback on the idea before taking it too far. cc/ @Shopify/hydrogen 

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
