### PR TITLE
Removed SEO and Image fragments from demo store

### DIFF
--- a/examples/template-hydrogen-default/src/components/DefaultSeo.server.jsx
+++ b/examples/template-hydrogen-default/src/components/DefaultSeo.server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, Seo, CacheDays} from '@shopify/hydrogen';
-import {DefaultPageSeoFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 /**
@@ -30,9 +29,8 @@ export default function DefaultSeo() {
 const QUERY = gql`
   query shopInfo {
     shop {
-      ...DefaultPageSeoFragment
+      title: name
+      description
     }
   }
-
-  ${DefaultPageSeoFragment}
 `;

--- a/examples/template-hydrogen-default/src/components/Layout.server.jsx
+++ b/examples/template-hydrogen-default/src/components/Layout.server.jsx
@@ -4,7 +4,6 @@ import {
   LocalizationProvider,
   CacheHours,
 } from '@shopify/hydrogen';
-import {ImageFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Header from './Header.client';
@@ -69,7 +68,11 @@ const QUERY = gql`
           id
           title
           image {
-            ...ImageFragment
+            id
+            url
+            altText
+            width
+            height
           }
         }
       }
@@ -82,5 +85,4 @@ const QUERY = gql`
       }
     }
   }
-  ${ImageFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
@@ -2,7 +2,6 @@ import {useShopQuery, flattenConnection, Seo} from '@shopify/hydrogen';
 import {
   MediaFileFragment,
   ProductProviderFragment,
-  CollectionSeoFragment,
 } from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
@@ -81,7 +80,17 @@ const QUERY = gql`
       id
       title
       descriptionHtml
-      ...CollectionSeoFragment
+      description
+      seo {
+        description
+        title
+      }
+      image {
+        url
+        width
+        height
+        altText
+      }
       products(first: $numProducts) {
         edges {
           node {
@@ -96,7 +105,6 @@ const QUERY = gql`
     }
   }
 
-  ${CollectionSeoFragment}
   ${MediaFileFragment}
   ${ProductProviderFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
@@ -86,6 +86,7 @@ const QUERY = gql`
         title
       }
       image {
+        id
         url
         width
         height

--- a/examples/template-hydrogen-default/src/routes/index.server.jsx
+++ b/examples/template-hydrogen-default/src/routes/index.server.jsx
@@ -5,11 +5,7 @@ import {
   Seo,
   CacheDays,
 } from '@shopify/hydrogen';
-import {
-  ProductProviderFragment,
-  ImageFragment,
-  HomeSeoFragment,
-} from '@shopify/hydrogen/fragments';
+import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Layout from '../components/Layout.server';
@@ -190,11 +186,10 @@ function GradientBackground() {
 const SEO_QUERY = gql`
   query homeShopInfo {
     shop {
-      ...HomeSeoFragment
+      title: name
+      description
     }
   }
-
-  ${HomeSeoFragment}
 `;
 
 const QUERY = gql`
@@ -220,7 +215,11 @@ const QUERY = gql`
           id
           title
           image {
-            ...ImageFragment
+            id
+            url
+            altText
+            width
+            height
           }
           products(first: $numProducts) {
             edges {
@@ -235,5 +234,4 @@ const QUERY = gql`
   }
 
   ${ProductProviderFragment}
-  ${ImageFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/pages/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/pages/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, Seo} from '@shopify/hydrogen';
-import {PageSeoFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Layout from '../../components/Layout.server';
@@ -32,9 +31,11 @@ const QUERY = gql`
     pageByHandle(handle: $handle) {
       title
       body
-      ...PageSeoFragment
+      title
+      seo {
+        description
+        title
+      }
     }
   }
-
-  ${PageSeoFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
@@ -1,8 +1,5 @@
 import {useShopQuery, Seo, useRouteParams} from '@shopify/hydrogen';
-import {
-  ProductProviderFragment,
-  ProductSeoFragment,
-} from '@shopify/hydrogen/fragments';
+import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';
@@ -52,10 +49,36 @@ const QUERY = gql`
       id
       vendor
       ...ProductProviderFragment
-      ...ProductSeoFragment
+      title
+      description
+      seo {
+        description
+        title
+      }
+      vendor
+      featuredImage {
+        url
+        width
+        height
+        altText
+      }
+      variants(first: $numProductVariants) {
+        edges {
+          node {
+            image {
+              url
+            }
+            availableForSale
+            priceV2 {
+              amount
+              currencyCode
+            }
+            sku
+          }
+        }
+      }
     }
   }
 
   ${ProductProviderFragment}
-  ${ProductSeoFragment}
 `;

--- a/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.graphql
+++ b/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.graphql
@@ -37,7 +37,11 @@ fragment CartFragment on Cart {
             requiresShipping
             title
             image {
-              ...ImageFragment
+              id
+              url
+              altText
+              width
+              height
             }
             product {
               handle

--- a/packages/hydrogen/src/components/Image/README.md
+++ b/packages/hydrogen/src/components/Image/README.md
@@ -17,7 +17,11 @@ const QUERY = gql`
 
   productByHandle(handle: "my-product") {
     featuredImage {
-      ...ImageFragment
+      id
+      url
+      altText
+      width
+      height
     }
   }
 `;

--- a/packages/hydrogen/src/components/Image/README.md
+++ b/packages/hydrogen/src/components/Image/README.md
@@ -9,12 +9,9 @@ The `Image` component renders an image for the Storefront API's
 /** Storefront API images */
 
 import {Image} from '@shopify/hydrogen';
-import {ImageFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
-  ${ImageFragment}
-
   productByHandle(handle: "my-product") {
     featuredImage {
       id

--- a/packages/hydrogen/src/components/Image/examples/1-storefront-api-images.example.tsx
+++ b/packages/hydrogen/src/components/Image/examples/1-storefront-api-images.example.tsx
@@ -1,12 +1,9 @@
 /** Storefront API images */
 
 import {Image} from '@shopify/hydrogen';
-import {ImageFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
-  ${ImageFragment}
-
   productByHandle(handle: "my-product") {
     featuredImage {
       id

--- a/packages/hydrogen/src/components/Image/examples/1-storefront-api-images.example.tsx
+++ b/packages/hydrogen/src/components/Image/examples/1-storefront-api-images.example.tsx
@@ -9,7 +9,11 @@ const QUERY = gql`
 
   productByHandle(handle: "my-product") {
     featuredImage {
-      ...ImageFragment
+      id
+      url
+      altText
+      width
+      height
     }
   }
 `;

--- a/packages/hydrogen/src/components/MediaFile/MediaFileFragment.graphql
+++ b/packages/hydrogen/src/components/MediaFile/MediaFileFragment.graphql
@@ -1,4 +1,3 @@
-#import '../Image/ImageFragment.graphql'
 #import '../Video/VideoFragment.graphql'
 #import '../ExternalVideo/ExternalVideoFragment.graphql'
 #import '../Model3D/Model3DFragment.graphql'
@@ -7,7 +6,11 @@ fragment MediaFileFragment on Media {
   ... on MediaImage {
     mediaContentType
     image {
-      ...ImageFragment
+      id
+      url
+      altText
+      width
+      height
     }
   }
   ... on Video {

--- a/packages/hydrogen/src/components/MediaFile/README.md
+++ b/packages/hydrogen/src/components/MediaFile/README.md
@@ -70,7 +70,11 @@ fragment MediaFileFragment on Media {
   ... on MediaImage {
     mediaContentType
     image {
-      ...ImageFragment
+      id
+      url
+      altText
+      width
+      height
     }
   }
   ... on Video {

--- a/packages/hydrogen/src/components/MediaFile/docs/fragment.md
+++ b/packages/hydrogen/src/components/MediaFile/docs/fragment.md
@@ -7,7 +7,11 @@ fragment MediaFileFragment on Media {
   ... on MediaImage {
     mediaContentType
     image {
-      ...ImageFragment
+      id
+      url
+      altText
+      width
+      height
     }
   }
   ... on Video {

--- a/packages/hydrogen/src/components/Metafield/MetafieldFragment.graphql
+++ b/packages/hydrogen/src/components/Metafield/MetafieldFragment.graphql
@@ -1,5 +1,3 @@
-#import '../Image/ImageFragment.graphql'
-
 fragment MetafieldFragment on Metafield {
   id
   type
@@ -15,7 +13,11 @@ fragment MetafieldFragment on Metafield {
       id
       mediaContentType
       image {
-        ...ImageFragment
+        id
+        url
+        altText
+        width
+        height
       }
     }
   }

--- a/packages/hydrogen/src/components/Metafield/README.md
+++ b/packages/hydrogen/src/components/Metafield/README.md
@@ -78,7 +78,11 @@ fragment MetafieldFragment on Metafield {
       id
       mediaContentType
       image {
-        ...ImageFragment
+        id
+        url
+        altText
+        width
+        height
       }
     }
   }

--- a/packages/hydrogen/src/components/Metafield/docs/4-fragment.md
+++ b/packages/hydrogen/src/components/Metafield/docs/4-fragment.md
@@ -18,7 +18,11 @@ fragment MetafieldFragment on Metafield {
       id
       mediaContentType
       image {
-        ...ImageFragment
+        id
+        url
+        altText
+        width
+        height
       }
     }
   }

--- a/packages/hydrogen/src/hooks/useProductOptions/README.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/README.md
@@ -161,7 +161,11 @@ fragment VariantFragment on ProductVariant {
   title
   availableForSale
   image {
-    ...ImageFragment
+    id
+    url
+    altText
+    width
+    height
   }
   ...UnitPriceFragment
   priceV2 {

--- a/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
@@ -8,7 +8,11 @@ fragment VariantFragment on ProductVariant {
   title
   availableForSale
   image {
-    ...ImageFragment
+    id
+    url
+    altText
+    width
+    height
   }
   ...UnitPriceFragment
   priceV2 {

--- a/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
@@ -8,7 +8,11 @@ fragment VariantFragment on ProductVariant {
   title
   availableForSale
   image {
-    ...ImageFragment
+    id
+    url
+    altText
+    width
+    height
   }
   ...UnitPriceFragment
   priceV2 {


### PR DESCRIPTION
### Description

Part of #778 

I'll be making a bunch of independent/standalone PRs so that they can be merged without needing a specific order or anything like that. This one focuses on `ImageFragment` and the SEO fragments. 

Note that I'm not yet optimizing for whether these fields are being _used_ yet or not; my first priority is to just remove the fragments, and then go on to optimization. 

Also I'm purposely avoiding the `graphql-constants.ts` file, since that will just be full-on deleted when we're done. 