### PR TITLE
Removal of Money and SellingPlan fragments

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.graphql
+++ b/packages/hydrogen/src/components/CartProvider/graphql/CartFragment.graphql
@@ -29,10 +29,12 @@ fragment CartFragment on Cart {
             id
             availableForSale
             compareAtPriceV2 {
-              ...MoneyFragment
+              currencyCode
+              amount
             }
             priceV2 {
-              ...MoneyFragment
+              currencyCode
+              amount
             }
             requiresShipping
             title
@@ -54,16 +56,20 @@ fragment CartFragment on Cart {
   }
   estimatedCost {
     subtotalAmount {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     totalAmount {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     totalDutyAmount {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     totalTaxAmount {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   note

--- a/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
@@ -1,16 +1,12 @@
-#import '../MediaFile/MediaFileFragment.graphql'
-#import '../Metafield/MetafieldFragment.graphql'
-#import '../../hooks/useProductOptions/VariantFragment.graphql'
-#import '../../hooks/useProductOptions/SellingPlanGroupsFragment.graphql'
-#import '../Money/MoneyFragment.graphql'
-
 fragment ProductProviderFragment on Product {
   compareAtPriceRange {
     maxVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     minVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   descriptionHtml
@@ -32,10 +28,12 @@ fragment ProductProviderFragment on Product {
   }
   priceRange {
     maxVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     minVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   title

--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -48,10 +48,12 @@ The following GraphQL fragment is available for your GraphQL queries using `Prod
 fragment ProductProviderFragment on Product {
   compareAtPriceRange {
     maxVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     minVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   descriptionHtml
@@ -73,10 +75,12 @@ fragment ProductProviderFragment on Product {
   }
   priceRange {
     maxVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     minVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   title

--- a/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
@@ -6,10 +6,12 @@ The following GraphQL fragment is available for your GraphQL queries using `Prod
 fragment ProductProviderFragment on Product {
   compareAtPriceRange {
     maxVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     minVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   descriptionHtml
@@ -31,10 +33,12 @@ fragment ProductProviderFragment on Product {
   }
   priceRange {
     maxVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
     minVariantPrice {
-      ...MoneyFragment
+      currencyCode
+      amount
     }
   }
   title

--- a/packages/hydrogen/src/components/UnitPrice/README.md
+++ b/packages/hydrogen/src/components/UnitPrice/README.md
@@ -70,7 +70,8 @@ fragment UnitPriceFragment on ProductVariant {
     referenceValue
   }
   unitPrice {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
 }
 ```

--- a/packages/hydrogen/src/components/UnitPrice/UnitPriceFragment.graphql
+++ b/packages/hydrogen/src/components/UnitPrice/UnitPriceFragment.graphql
@@ -9,6 +9,7 @@ fragment UnitPriceFragment on ProductVariant {
     referenceValue
   }
   unitPrice {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
 }

--- a/packages/hydrogen/src/components/UnitPrice/docs/fragment.md
+++ b/packages/hydrogen/src/components/UnitPrice/docs/fragment.md
@@ -12,7 +12,8 @@ fragment UnitPriceFragment on ProductVariant {
     referenceValue
   }
   unitPrice {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
 }
 ```

--- a/packages/hydrogen/src/hooks/useProductOptions/README.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/README.md
@@ -165,10 +165,12 @@ fragment VariantFragment on ProductVariant {
   }
   ...UnitPriceFragment
   priceV2 {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
   compareAtPriceV2 {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
   selectedOptions {
     name
@@ -186,20 +188,51 @@ fragment VariantFragment on ProductVariant {
       node {
         priceAdjustments {
           compareAtPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           perDeliveryPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           price {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           unitPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
         }
         sellingPlan {
-          ...SellingPlanFragment
+          id
+          description
+          name
+          options {
+            name
+            value
+          }
+          priceAdjustments {
+            orderCount
+            adjustmentValue {
+              ... on SellingPlanFixedAmountPriceAdjustment {
+                adjustmentAmount {
+                  currencyCode
+                  amount
+                }
+              }
+              ... on SellingPlanFixedPriceAdjustment {
+                price {
+                  currencyCode
+                  amount
+                }
+              }
+              ... on SellingPlanPercentagePriceAdjustment {
+                adjustmentPercentage
+              }
+            }
+          }
+          recurringDeliveries
         }
       }
     }

--- a/packages/hydrogen/src/hooks/useProductOptions/SellingPlanFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/SellingPlanFragment.graphql
@@ -1,5 +1,3 @@
-#import '../../components/Money/MoneyFragment.graphql'
-
 fragment SellingPlanFragment on SellingPlan {
   id
   description
@@ -13,12 +11,14 @@ fragment SellingPlanFragment on SellingPlan {
     adjustmentValue {
       ... on SellingPlanFixedAmountPriceAdjustment {
         adjustmentAmount {
-          ...MoneyFragment
+          currencyCode
+          amount
         }
       }
       ... on SellingPlanFixedPriceAdjustment {
         price {
-          ...MoneyFragment
+          currencyCode
+          amount
         }
       }
       ... on SellingPlanPercentagePriceAdjustment {

--- a/packages/hydrogen/src/hooks/useProductOptions/SellingPlanGroupsFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/SellingPlanGroupsFragment.graphql
@@ -4,7 +4,34 @@ fragment SellingPlanGroupsFragment on SellingPlanGroup {
   sellingPlans(first: $numProductSellingPlans) {
     edges {
       node {
-        ...SellingPlanFragment
+        id
+        description
+        name
+        options {
+          name
+          value
+        }
+        priceAdjustments {
+          orderCount
+          adjustmentValue {
+            ... on SellingPlanFixedAmountPriceAdjustment {
+              adjustmentAmount {
+                currencyCode
+                amount
+              }
+            }
+            ... on SellingPlanFixedPriceAdjustment {
+              price {
+                currencyCode
+                amount
+              }
+            }
+            ... on SellingPlanPercentagePriceAdjustment {
+              adjustmentPercentage
+            }
+          }
+        }
+        recurringDeliveries
       }
     }
   }

--- a/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
@@ -12,10 +12,12 @@ fragment VariantFragment on ProductVariant {
   }
   ...UnitPriceFragment
   priceV2 {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
   compareAtPriceV2 {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
   selectedOptions {
     name
@@ -33,20 +35,51 @@ fragment VariantFragment on ProductVariant {
       node {
         priceAdjustments {
           compareAtPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           perDeliveryPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           price {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           unitPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
         }
         sellingPlan {
-          ...SellingPlanFragment
+          id
+          description
+          name
+          options {
+            name
+            value
+          }
+          priceAdjustments {
+            orderCount
+            adjustmentValue {
+              ... on SellingPlanFixedAmountPriceAdjustment {
+                adjustmentAmount {
+                  currencyCode
+                  amount
+                }
+              }
+              ... on SellingPlanFixedPriceAdjustment {
+                price {
+                  currencyCode
+                  amount
+                }
+              }
+              ... on SellingPlanPercentagePriceAdjustment {
+                adjustmentPercentage
+              }
+            }
+          }
+          recurringDeliveries
         }
       }
     }

--- a/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
@@ -12,10 +12,12 @@ fragment VariantFragment on ProductVariant {
   }
   ...UnitPriceFragment
   priceV2 {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
   compareAtPriceV2 {
-    ...MoneyFragment
+    currencyCode
+    amount
   }
   selectedOptions {
     name
@@ -33,20 +35,51 @@ fragment VariantFragment on ProductVariant {
       node {
         priceAdjustments {
           compareAtPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           perDeliveryPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           price {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
           unitPrice {
-            ...MoneyFragment
+            currencyCode
+            amount
           }
         }
         sellingPlan {
-          ...SellingPlanFragment
+          id
+          description
+          name
+          options {
+            name
+            value
+          }
+          priceAdjustments {
+            orderCount
+            adjustmentValue {
+              ... on SellingPlanFixedAmountPriceAdjustment {
+                adjustmentAmount {
+                  currencyCode
+                  amount
+                }
+              }
+              ... on SellingPlanFixedPriceAdjustment {
+                price {
+                  currencyCode
+                  amount
+                }
+              }
+              ... on SellingPlanPercentagePriceAdjustment {
+                adjustmentPercentage
+              }
+            }
+          }
+          recurringDeliveries
         }
       }
     }


### PR DESCRIPTION
### Description

Part of #778 

I'll be making a bunch of independent/standalone PRs so that they can be merged without needing a specific order or anything like that. This one focuses on `Money` and `SellingPlan` fragments. 

Note that I'm not yet optimizing for whether these fields are being _used_ yet or not; my first priority is to just remove the fragments, and then go on to optimization. 

Also I'm purposely avoiding the `graphql-constants.ts` file, since that will just be full-on deleted when we're done. 