### PR TITLE
Improve errors when entry point crashes on load

### DIFF
--- a/.changeset/quiet-rings-sin.md
+++ b/.changeset/quiet-rings-sin.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Improve error thrown in development when entry point crashes on load.
+Improve error thrown in development when entry point fails on load.

--- a/.changeset/quiet-rings-sin.md
+++ b/.changeset/quiet-rings-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improve error thrown in development when entry point crashes on load.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When the entry point (`App.server.jsx`) contains errors, `vite.ssrLoadModule` would only throw the first time it tries to load it. After refreshing the browser or getting a new request, `vite.ssrLoadModule` would just load an empty module instead of throwing again. As a result, we generate a secondary error `handleRequest is not a function` which masks the original error.

This PR stores the original error and keeps throwing it until it's fixed.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
