### PR TITLE
MediaFile, SellingPlanGroups, UnitPrice, and Metafield

### DIFF
--- a/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
@@ -1,7 +1,5 @@
 import {useShopQuery, flattenConnection, Seo} from '@shopify/hydrogen';
-import {
-  ProductProviderFragment,
-} from '@shopify/hydrogen/fragments';
+import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import LoadMoreProducts from '../../components/LoadMoreProducts.client';

--- a/packages/hydrogen/src/components/MediaFile/README.md
+++ b/packages/hydrogen/src/components/MediaFile/README.md
@@ -9,12 +9,9 @@ The `MediaFile` component renders the media for the Storefront API's
 
 ```tsx
 import {MediaFile, useShopQuery} from '@shopify/hydrogen';
-import {MediaFileFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
-  ${MediaFileFragment}
-
   query Products {
     products(first: 5) {
       edges {
@@ -25,7 +22,45 @@ const QUERY = gql`
           media(first: 1) {
             edges {
               node {
-                ...MediaFileFragment
+                ... on MediaImage {
+                  mediaContentType
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                }
+                ... on Video {
+                  mediaContentType
+                  id
+                  previewImage {
+                    url
+                  }
+                  sources {
+                    mimeType
+                    url
+                  }
+                }
+                ... on ExternalVideo {
+                  mediaContentType
+                  id
+                  embedUrl
+                  host
+                }
+                ... on Model3d {
+                  mediaContentType
+                  id
+                  alt
+                  mediaContentType
+                  previewImage {
+                    url
+                  }
+                  sources {
+                    url
+                  }
+                }
               }
             }
           }

--- a/packages/hydrogen/src/components/MediaFile/examples/media-file.example.tsx
+++ b/packages/hydrogen/src/components/MediaFile/examples/media-file.example.tsx
@@ -1,10 +1,7 @@
 import {MediaFile, useShopQuery} from '@shopify/hydrogen';
-import {MediaFileFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
-  ${MediaFileFragment}
-
   query Products {
     products(first: 5) {
       edges {
@@ -15,7 +12,45 @@ const QUERY = gql`
           media(first: 1) {
             edges {
               node {
-                ...MediaFileFragment
+                ... on MediaImage {
+                  mediaContentType
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                }
+                ... on Video {
+                  mediaContentType
+                  id
+                  previewImage {
+                    url
+                  }
+                  sources {
+                    mimeType
+                    url
+                  }
+                }
+                ... on ExternalVideo {
+                  mediaContentType
+                  id
+                  embedUrl
+                  host
+                }
+                ... on Model3d {
+                  mediaContentType
+                  id
+                  alt
+                  mediaContentType
+                  previewImage {
+                    url
+                  }
+                  sources {
+                    url
+                  }
+                }
               }
             }
           }

--- a/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
@@ -15,7 +15,45 @@ fragment ProductProviderFragment on Product {
   media(first: $numProductMedia) {
     edges {
       node {
-        ...MediaFileFragment
+        ... on MediaImage {
+          mediaContentType
+          image {
+            id
+            url
+            altText
+            width
+            height
+          }
+        }
+        ... on Video {
+          mediaContentType
+          id
+          previewImage {
+            url
+          }
+          sources {
+            mimeType
+            url
+          }
+        }
+        ... on ExternalVideo {
+          mediaContentType
+          id
+          embedUrl
+          host
+        }
+        ... on Model3d {
+          mediaContentType
+          id
+          alt
+          mediaContentType
+          previewImage {
+            url
+          }
+          sources {
+            url
+          }
+        }
       }
     }
   }
@@ -47,7 +85,46 @@ fragment ProductProviderFragment on Product {
   sellingPlanGroups(first: $numProductSellingPlanGroups) {
     edges {
       node {
-        ...SellingPlanGroupsFragment
+        sellingPlans(first: $numProductSellingPlans) {
+          edges {
+            node {
+              id
+              description
+              name
+              options {
+                name
+                value
+              }
+              priceAdjustments {
+                orderCount
+                adjustmentValue {
+                  ... on SellingPlanFixedAmountPriceAdjustment {
+                    adjustmentAmount {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  ... on SellingPlanFixedPriceAdjustment {
+                    price {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  ... on SellingPlanPercentagePriceAdjustment {
+                    adjustmentPercentage
+                  }
+                }
+              }
+              recurringDeliveries
+            }
+          }
+        }
+        appName
+        name
+        options {
+          name
+          values
+        }
       }
     }
   }

--- a/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
@@ -60,7 +60,28 @@ fragment ProductProviderFragment on Product {
   metafields(first: $numProductMetafields) {
     edges {
       node {
-        ...MetafieldFragment
+        id
+        type
+        namespace
+        key
+        value
+        createdAt
+        updatedAt
+        description
+        reference @include(if: $includeReferenceMetafieldDetails) {
+          __typename
+          ... on MediaImage {
+            id
+            mediaContentType
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -107,7 +107,28 @@ fragment ProductProviderFragment on Product {
   metafields(first: $numProductMetafields) {
     edges {
       node {
-        ...MetafieldFragment
+        id
+        type
+        namespace
+        key
+        value
+        createdAt
+        updatedAt
+        description
+        reference @include(if: $includeReferenceMetafieldDetails) {
+          __typename
+          ... on MediaImage {
+            id
+            mediaContentType
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -62,7 +62,45 @@ fragment ProductProviderFragment on Product {
   media(first: $numProductMedia) {
     edges {
       node {
-        ...MediaFileFragment
+        ... on MediaImage {
+          mediaContentType
+          image {
+            id
+            url
+            altText
+            width
+            height
+          }
+        }
+        ... on Video {
+          mediaContentType
+          id
+          previewImage {
+            url
+          }
+          sources {
+            mimeType
+            url
+          }
+        }
+        ... on ExternalVideo {
+          mediaContentType
+          id
+          embedUrl
+          host
+        }
+        ... on Model3d {
+          mediaContentType
+          id
+          alt
+          mediaContentType
+          previewImage {
+            url
+          }
+          sources {
+            url
+          }
+        }
       }
     }
   }
@@ -94,7 +132,46 @@ fragment ProductProviderFragment on Product {
   sellingPlanGroups(first: $numProductSellingPlanGroups) {
     edges {
       node {
-        ...SellingPlanGroupsFragment
+        sellingPlans(first: $numProductSellingPlans) {
+          edges {
+            node {
+              id
+              description
+              name
+              options {
+                name
+                value
+              }
+              priceAdjustments {
+                orderCount
+                adjustmentValue {
+                  ... on SellingPlanFixedAmountPriceAdjustment {
+                    adjustmentAmount {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  ... on SellingPlanFixedPriceAdjustment {
+                    price {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  ... on SellingPlanPercentagePriceAdjustment {
+                    adjustmentPercentage
+                  }
+                }
+              }
+              recurringDeliveries
+            }
+          }
+        }
+        appName
+        name
+        options {
+          name
+          values
+        }
       }
     }
   }

--- a/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
@@ -65,7 +65,28 @@ fragment ProductProviderFragment on Product {
   metafields(first: $numProductMetafields) {
     edges {
       node {
-        ...MetafieldFragment
+        id
+        type
+        namespace
+        key
+        value
+        createdAt
+        updatedAt
+        description
+        reference @include(if: $includeReferenceMetafieldDetails) {
+          __typename
+          ... on MediaImage {
+            id
+            mediaContentType
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
@@ -20,7 +20,45 @@ fragment ProductProviderFragment on Product {
   media(first: $numProductMedia) {
     edges {
       node {
-        ...MediaFileFragment
+        ... on MediaImage {
+          mediaContentType
+          image {
+            id
+            url
+            altText
+            width
+            height
+          }
+        }
+        ... on Video {
+          mediaContentType
+          id
+          previewImage {
+            url
+          }
+          sources {
+            mimeType
+            url
+          }
+        }
+        ... on ExternalVideo {
+          mediaContentType
+          id
+          embedUrl
+          host
+        }
+        ... on Model3d {
+          mediaContentType
+          id
+          alt
+          mediaContentType
+          previewImage {
+            url
+          }
+          sources {
+            url
+          }
+        }
       }
     }
   }
@@ -52,7 +90,46 @@ fragment ProductProviderFragment on Product {
   sellingPlanGroups(first: $numProductSellingPlanGroups) {
     edges {
       node {
-        ...SellingPlanGroupsFragment
+        sellingPlans(first: $numProductSellingPlans) {
+          edges {
+            node {
+              id
+              description
+              name
+              options {
+                name
+                value
+              }
+              priceAdjustments {
+                orderCount
+                adjustmentValue {
+                  ... on SellingPlanFixedAmountPriceAdjustment {
+                    adjustmentAmount {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  ... on SellingPlanFixedPriceAdjustment {
+                    price {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  ... on SellingPlanPercentagePriceAdjustment {
+                    adjustmentPercentage
+                  }
+                }
+              }
+              recurringDeliveries
+            }
+          }
+        }
+        appName
+        name
+        options {
+          name
+          values
+        }
       }
     }
   }

--- a/packages/hydrogen/src/hooks/useProductOptions/README.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/README.md
@@ -167,7 +167,17 @@ fragment VariantFragment on ProductVariant {
     width
     height
   }
-  ...UnitPriceFragment
+  unitPriceMeasurement {
+    measuredType
+    quantityUnit
+    quantityValue
+    referenceUnit
+    referenceValue
+  }
+  unitPrice {
+    currencyCode
+    amount
+  }
   priceV2 {
     currencyCode
     amount

--- a/packages/hydrogen/src/hooks/useProductOptions/README.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/README.md
@@ -183,7 +183,28 @@ fragment VariantFragment on ProductVariant {
   metafields(first: $numProductVariantMetafields) {
     edges {
       node {
-        ...MetafieldFragment
+        id
+        type
+        namespace
+        key
+        value
+        createdAt
+        updatedAt
+        description
+        reference @include(if: $includeReferenceMetafieldDetails) {
+          __typename
+          ... on MediaImage {
+            id
+            mediaContentType
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
@@ -1,7 +1,6 @@
 #import './SellingPlanFragment.graphql'
 #import '../../components/Money/MoneyFragment.graphql'
 #import '../../components/Image/ImageFragment.graphql'
-#import '../../components/UnitPrice/UnitPriceFragment.graphql'
 
 fragment VariantFragment on ProductVariant {
   id
@@ -14,7 +13,17 @@ fragment VariantFragment on ProductVariant {
     width
     height
   }
-  ...UnitPriceFragment
+  unitPriceMeasurement {
+    measuredType
+    quantityUnit
+    quantityValue
+    referenceUnit
+    referenceValue
+  }
+  unitPrice {
+    currencyCode
+    amount
+  }
   priceV2 {
     currencyCode
     amount

--- a/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
@@ -30,7 +30,28 @@ fragment VariantFragment on ProductVariant {
   metafields(first: $numProductVariantMetafields) {
     edges {
       node {
-        ...MetafieldFragment
+        id
+        type
+        namespace
+        key
+        value
+        createdAt
+        updatedAt
+        description
+        reference @include(if: $includeReferenceMetafieldDetails) {
+          __typename
+          ... on MediaImage {
+            id
+            mediaContentType
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
@@ -14,7 +14,17 @@ fragment VariantFragment on ProductVariant {
     width
     height
   }
-  ...UnitPriceFragment
+  unitPriceMeasurement {
+    measuredType
+    quantityUnit
+    quantityValue
+    referenceUnit
+    referenceValue
+  }
+  unitPrice {
+    currencyCode
+    amount
+  }
   priceV2 {
     currencyCode
     amount

--- a/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
+++ b/packages/hydrogen/src/hooks/useProductOptions/docs/4-fragment.md
@@ -30,7 +30,28 @@ fragment VariantFragment on ProductVariant {
   metafields(first: $numProductVariantMetafields) {
     edges {
       node {
-        ...MetafieldFragment
+        id
+        type
+        namespace
+        key
+        value
+        createdAt
+        updatedAt
+        description
+        reference @include(if: $includeReferenceMetafieldDetails) {
+          __typename
+          ... on MediaImage {
+            id
+            mediaContentType
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/utilities/flattenConnection/README.md
+++ b/packages/hydrogen/src/utilities/flattenConnection/README.md
@@ -11,7 +11,6 @@ import {
   useShopQuery,
   MediaFile,
 } from '@shopify/hydrogen/client';
-import {MediaFileFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
@@ -20,13 +19,50 @@ const QUERY = gql`
       media(first: 10) {
         edges {
           node {
-            ...MediaFileFragment
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
           }
         }
       }
     }
   }
-  ${MediaFileFragment}
 `;
 export function Product({handle}) {
   const {data} = useShopQuery({query: QUERY, variables: {handle}});

--- a/packages/hydrogen/src/utilities/flattenConnection/examples/flatten-connection.example.tsx
+++ b/packages/hydrogen/src/utilities/flattenConnection/examples/flatten-connection.example.tsx
@@ -4,7 +4,6 @@ import {
   useShopQuery,
   MediaFile,
 } from '@shopify/hydrogen/client';
-import {MediaFileFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
@@ -13,13 +12,50 @@ const QUERY = gql`
       media(first: 10) {
         edges {
           node {
-            ...MediaFileFragment
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
           }
         }
       }
     }
   }
-  ${MediaFileFragment}
 `;
 export function Product({handle}) {
   const {data} = useShopQuery({query: QUERY, variables: {handle}});

--- a/packages/hydrogen/src/utilities/parseMetafieldValue/README.md
+++ b/packages/hydrogen/src/utilities/parseMetafieldValue/README.md
@@ -8,7 +8,6 @@ The `parseMetafieldValue` function parses a [Metafield](/api/storefront/referenc
 import {
   parseMetafieldValue,
   Metafield,
-  MetafieldFragment,
   flattenConnection,
   useShopQuery,
   Metafield,
@@ -21,14 +20,33 @@ const QUERY = gql`
       metafields(first: 10) {
         edges {
           node {
-            ...MetafieldFragment
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
           }
         }
       }
     }
   }
-
-  ${MetafieldFragment}
 `;
 
 export function Product({handle}) {

--- a/packages/hydrogen/src/utilities/parseMetafieldValue/examples/parse-metafield-value.example.tsx
+++ b/packages/hydrogen/src/utilities/parseMetafieldValue/examples/parse-metafield-value.example.tsx
@@ -1,7 +1,6 @@
 import {
   parseMetafieldValue,
   Metafield,
-  MetafieldFragment,
   flattenConnection,
   useShopQuery,
   Metafield,
@@ -14,14 +13,33 @@ const QUERY = gql`
       metafields(first: 10) {
         edges {
           node {
-            ...MetafieldFragment
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
           }
         }
       }
     }
   }
-
-  ${MetafieldFragment}
 `;
 
 export function Product({handle}) {


### PR DESCRIPTION
### Description

Part of #778 

This one focuses on `MediaFileFragment`, `SellingPlanGroupsFragment`, `UnitPriceFragment`, and `MetafieldFragment` fragments. 

Note that I'm not yet optimizing for whether these fields are being _used_ yet or not; my first priority is to just remove the fragments, and then go on to optimization. 

Also I'm purposely avoiding the `graphql-constants.ts` file, since that will just be full-on deleted when we're done. 