### PR TITLE
VariantFragment and ProductFragment removal

### DIFF
--- a/examples/template-hydrogen-default/src/components/NotFound.server.jsx
+++ b/examples/template-hydrogen-default/src/components/NotFound.server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, flattenConnection} from '@shopify/hydrogen';
-import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Layout from './Layout.server';
@@ -85,11 +84,275 @@ const QUERY = gql`
     products(first: 3) {
       edges {
         node {
-          ...ProductProviderFragment
+          compareAtPriceRange {
+            maxVariantPrice {
+              currencyCode
+              amount
+            }
+            minVariantPrice {
+              currencyCode
+              amount
+            }
+          }
+          descriptionHtml
+          handle
+          id
+          media(first: $numProductMedia) {
+            edges {
+              node {
+                ... on MediaImage {
+                  mediaContentType
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                }
+                ... on Video {
+                  mediaContentType
+                  id
+                  previewImage {
+                    url
+                  }
+                  sources {
+                    mimeType
+                    url
+                  }
+                }
+                ... on ExternalVideo {
+                  mediaContentType
+                  id
+                  embedUrl
+                  host
+                }
+                ... on Model3d {
+                  mediaContentType
+                  id
+                  alt
+                  mediaContentType
+                  previewImage {
+                    url
+                  }
+                  sources {
+                    url
+                  }
+                }
+              }
+            }
+          }
+          metafields(first: $numProductMetafields) {
+            edges {
+              node {
+                id
+                type
+                namespace
+                key
+                value
+                createdAt
+                updatedAt
+                description
+                reference @include(if: $includeReferenceMetafieldDetails) {
+                  __typename
+                  ... on MediaImage {
+                    id
+                    mediaContentType
+                    image {
+                      id
+                      url
+                      altText
+                      width
+                      height
+                    }
+                  }
+                }
+              }
+            }
+          }
+          priceRange {
+            maxVariantPrice {
+              currencyCode
+              amount
+            }
+            minVariantPrice {
+              currencyCode
+              amount
+            }
+          }
+          title
+          variants(first: $numProductVariants) {
+            edges {
+              node {
+                id
+                title
+                availableForSale
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+                unitPriceMeasurement {
+                  measuredType
+                  quantityUnit
+                  quantityValue
+                  referenceUnit
+                  referenceValue
+                }
+                unitPrice {
+                  currencyCode
+                  amount
+                }
+                priceV2 {
+                  currencyCode
+                  amount
+                }
+                compareAtPriceV2 {
+                  currencyCode
+                  amount
+                }
+                selectedOptions {
+                  name
+                  value
+                }
+                metafields(first: $numProductVariantMetafields) {
+                  edges {
+                    node {
+                      id
+                      type
+                      namespace
+                      key
+                      value
+                      createdAt
+                      updatedAt
+                      description
+                      reference
+                        @include(if: $includeReferenceMetafieldDetails) {
+                        __typename
+                        ... on MediaImage {
+                          id
+                          mediaContentType
+                          image {
+                            id
+                            url
+                            altText
+                            width
+                            height
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                sellingPlanAllocations(
+                  first: $numProductVariantSellingPlanAllocations
+                ) {
+                  edges {
+                    node {
+                      priceAdjustments {
+                        compareAtPrice {
+                          currencyCode
+                          amount
+                        }
+                        perDeliveryPrice {
+                          currencyCode
+                          amount
+                        }
+                        price {
+                          currencyCode
+                          amount
+                        }
+                        unitPrice {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      sellingPlan {
+                        id
+                        description
+                        name
+                        options {
+                          name
+                          value
+                        }
+                        priceAdjustments {
+                          orderCount
+                          adjustmentValue {
+                            ... on SellingPlanFixedAmountPriceAdjustment {
+                              adjustmentAmount {
+                                currencyCode
+                                amount
+                              }
+                            }
+                            ... on SellingPlanFixedPriceAdjustment {
+                              price {
+                                currencyCode
+                                amount
+                              }
+                            }
+                            ... on SellingPlanPercentagePriceAdjustment {
+                              adjustmentPercentage
+                            }
+                          }
+                        }
+                        recurringDeliveries
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          sellingPlanGroups(first: $numProductSellingPlanGroups) {
+            edges {
+              node {
+                sellingPlans(first: $numProductSellingPlans) {
+                  edges {
+                    node {
+                      id
+                      description
+                      name
+                      options {
+                        name
+                        value
+                      }
+                      priceAdjustments {
+                        orderCount
+                        adjustmentValue {
+                          ... on SellingPlanFixedAmountPriceAdjustment {
+                            adjustmentAmount {
+                              currencyCode
+                              amount
+                            }
+                          }
+                          ... on SellingPlanFixedPriceAdjustment {
+                            price {
+                              currencyCode
+                              amount
+                            }
+                          }
+                          ... on SellingPlanPercentagePriceAdjustment {
+                            adjustmentPercentage
+                          }
+                        }
+                      }
+                      recurringDeliveries
+                    }
+                  }
+                }
+                appName
+                name
+                options {
+                  name
+                  values
+                }
+              }
+            }
+          }
         }
       }
     }
   }
-
-  ${ProductProviderFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/collections/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, flattenConnection, Seo} from '@shopify/hydrogen';
-import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import LoadMoreProducts from '../../components/LoadMoreProducts.client';
@@ -93,7 +92,273 @@ const QUERY = gql`
         edges {
           node {
             vendor
-            ...ProductProviderFragment
+            compareAtPriceRange {
+              maxVariantPrice {
+                currencyCode
+                amount
+              }
+              minVariantPrice {
+                currencyCode
+                amount
+              }
+            }
+            descriptionHtml
+            handle
+            id
+            media(first: $numProductMedia) {
+              edges {
+                node {
+                  ... on MediaImage {
+                    mediaContentType
+                    image {
+                      id
+                      url
+                      altText
+                      width
+                      height
+                    }
+                  }
+                  ... on Video {
+                    mediaContentType
+                    id
+                    previewImage {
+                      url
+                    }
+                    sources {
+                      mimeType
+                      url
+                    }
+                  }
+                  ... on ExternalVideo {
+                    mediaContentType
+                    id
+                    embedUrl
+                    host
+                  }
+                  ... on Model3d {
+                    mediaContentType
+                    id
+                    alt
+                    mediaContentType
+                    previewImage {
+                      url
+                    }
+                    sources {
+                      url
+                    }
+                  }
+                }
+              }
+            }
+            metafields(first: $numProductMetafields) {
+              edges {
+                node {
+                  id
+                  type
+                  namespace
+                  key
+                  value
+                  createdAt
+                  updatedAt
+                  description
+                  reference @include(if: $includeReferenceMetafieldDetails) {
+                    __typename
+                    ... on MediaImage {
+                      id
+                      mediaContentType
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            priceRange {
+              maxVariantPrice {
+                currencyCode
+                amount
+              }
+              minVariantPrice {
+                currencyCode
+                amount
+              }
+            }
+            title
+            variants(first: $numProductVariants) {
+              edges {
+                node {
+                  id
+                  title
+                  availableForSale
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                  unitPriceMeasurement {
+                    measuredType
+                    quantityUnit
+                    quantityValue
+                    referenceUnit
+                    referenceValue
+                  }
+                  unitPrice {
+                    currencyCode
+                    amount
+                  }
+                  priceV2 {
+                    currencyCode
+                    amount
+                  }
+                  compareAtPriceV2 {
+                    currencyCode
+                    amount
+                  }
+                  selectedOptions {
+                    name
+                    value
+                  }
+                  metafields(first: $numProductVariantMetafields) {
+                    edges {
+                      node {
+                        id
+                        type
+                        namespace
+                        key
+                        value
+                        createdAt
+                        updatedAt
+                        description
+                        reference
+                          @include(if: $includeReferenceMetafieldDetails) {
+                          __typename
+                          ... on MediaImage {
+                            id
+                            mediaContentType
+                            image {
+                              id
+                              url
+                              altText
+                              width
+                              height
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                  sellingPlanAllocations(
+                    first: $numProductVariantSellingPlanAllocations
+                  ) {
+                    edges {
+                      node {
+                        priceAdjustments {
+                          compareAtPrice {
+                            currencyCode
+                            amount
+                          }
+                          perDeliveryPrice {
+                            currencyCode
+                            amount
+                          }
+                          price {
+                            currencyCode
+                            amount
+                          }
+                          unitPrice {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        sellingPlan {
+                          id
+                          description
+                          name
+                          options {
+                            name
+                            value
+                          }
+                          priceAdjustments {
+                            orderCount
+                            adjustmentValue {
+                              ... on SellingPlanFixedAmountPriceAdjustment {
+                                adjustmentAmount {
+                                  currencyCode
+                                  amount
+                                }
+                              }
+                              ... on SellingPlanFixedPriceAdjustment {
+                                price {
+                                  currencyCode
+                                  amount
+                                }
+                              }
+                              ... on SellingPlanPercentagePriceAdjustment {
+                                adjustmentPercentage
+                              }
+                            }
+                          }
+                          recurringDeliveries
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sellingPlanGroups(first: $numProductSellingPlanGroups) {
+              edges {
+                node {
+                  sellingPlans(first: $numProductSellingPlans) {
+                    edges {
+                      node {
+                        id
+                        description
+                        name
+                        options {
+                          name
+                          value
+                        }
+                        priceAdjustments {
+                          orderCount
+                          adjustmentValue {
+                            ... on SellingPlanFixedAmountPriceAdjustment {
+                              adjustmentAmount {
+                                currencyCode
+                                amount
+                              }
+                            }
+                            ... on SellingPlanFixedPriceAdjustment {
+                              price {
+                                currencyCode
+                                amount
+                              }
+                            }
+                            ... on SellingPlanPercentagePriceAdjustment {
+                              adjustmentPercentage
+                            }
+                          }
+                        }
+                        recurringDeliveries
+                      }
+                    }
+                  }
+                  appName
+                  name
+                  options {
+                    name
+                    values
+                  }
+                }
+              }
+            }
           }
         }
         pageInfo {
@@ -102,6 +367,4 @@ const QUERY = gql`
       }
     }
   }
-
-  ${ProductProviderFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/index.server.jsx
+++ b/examples/template-hydrogen-default/src/routes/index.server.jsx
@@ -5,7 +5,6 @@ import {
   Seo,
   CacheDays,
 } from '@shopify/hydrogen';
-import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import Layout from '../components/Layout.server';
@@ -224,7 +223,274 @@ const QUERY = gql`
           products(first: $numProducts) {
             edges {
               node {
-                ...ProductProviderFragment
+                compareAtPriceRange {
+                  maxVariantPrice {
+                    currencyCode
+                    amount
+                  }
+                  minVariantPrice {
+                    currencyCode
+                    amount
+                  }
+                }
+                descriptionHtml
+                handle
+                id
+                media(first: $numProductMedia) {
+                  edges {
+                    node {
+                      ... on MediaImage {
+                        mediaContentType
+                        image {
+                          id
+                          url
+                          altText
+                          width
+                          height
+                        }
+                      }
+                      ... on Video {
+                        mediaContentType
+                        id
+                        previewImage {
+                          url
+                        }
+                        sources {
+                          mimeType
+                          url
+                        }
+                      }
+                      ... on ExternalVideo {
+                        mediaContentType
+                        id
+                        embedUrl
+                        host
+                      }
+                      ... on Model3d {
+                        mediaContentType
+                        id
+                        alt
+                        mediaContentType
+                        previewImage {
+                          url
+                        }
+                        sources {
+                          url
+                        }
+                      }
+                    }
+                  }
+                }
+                metafields(first: $numProductMetafields) {
+                  edges {
+                    node {
+                      id
+                      type
+                      namespace
+                      key
+                      value
+                      createdAt
+                      updatedAt
+                      description
+                      reference
+                        @include(if: $includeReferenceMetafieldDetails) {
+                        __typename
+                        ... on MediaImage {
+                          id
+                          mediaContentType
+                          image {
+                            id
+                            url
+                            altText
+                            width
+                            height
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                priceRange {
+                  maxVariantPrice {
+                    currencyCode
+                    amount
+                  }
+                  minVariantPrice {
+                    currencyCode
+                    amount
+                  }
+                }
+                title
+                variants(first: $numProductVariants) {
+                  edges {
+                    node {
+                      id
+                      title
+                      availableForSale
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                      unitPriceMeasurement {
+                        measuredType
+                        quantityUnit
+                        quantityValue
+                        referenceUnit
+                        referenceValue
+                      }
+                      unitPrice {
+                        currencyCode
+                        amount
+                      }
+                      priceV2 {
+                        currencyCode
+                        amount
+                      }
+                      compareAtPriceV2 {
+                        currencyCode
+                        amount
+                      }
+                      selectedOptions {
+                        name
+                        value
+                      }
+                      metafields(first: $numProductVariantMetafields) {
+                        edges {
+                          node {
+                            id
+                            type
+                            namespace
+                            key
+                            value
+                            createdAt
+                            updatedAt
+                            description
+                            reference
+                              @include(if: $includeReferenceMetafieldDetails) {
+                              __typename
+                              ... on MediaImage {
+                                id
+                                mediaContentType
+                                image {
+                                  id
+                                  url
+                                  altText
+                                  width
+                                  height
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                      sellingPlanAllocations(
+                        first: $numProductVariantSellingPlanAllocations
+                      ) {
+                        edges {
+                          node {
+                            priceAdjustments {
+                              compareAtPrice {
+                                currencyCode
+                                amount
+                              }
+                              perDeliveryPrice {
+                                currencyCode
+                                amount
+                              }
+                              price {
+                                currencyCode
+                                amount
+                              }
+                              unitPrice {
+                                currencyCode
+                                amount
+                              }
+                            }
+                            sellingPlan {
+                              id
+                              description
+                              name
+                              options {
+                                name
+                                value
+                              }
+                              priceAdjustments {
+                                orderCount
+                                adjustmentValue {
+                                  ... on SellingPlanFixedAmountPriceAdjustment {
+                                    adjustmentAmount {
+                                      currencyCode
+                                      amount
+                                    }
+                                  }
+                                  ... on SellingPlanFixedPriceAdjustment {
+                                    price {
+                                      currencyCode
+                                      amount
+                                    }
+                                  }
+                                  ... on SellingPlanPercentagePriceAdjustment {
+                                    adjustmentPercentage
+                                  }
+                                }
+                              }
+                              recurringDeliveries
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                sellingPlanGroups(first: $numProductSellingPlanGroups) {
+                  edges {
+                    node {
+                      sellingPlans(first: $numProductSellingPlans) {
+                        edges {
+                          node {
+                            id
+                            description
+                            name
+                            options {
+                              name
+                              value
+                            }
+                            priceAdjustments {
+                              orderCount
+                              adjustmentValue {
+                                ... on SellingPlanFixedAmountPriceAdjustment {
+                                  adjustmentAmount {
+                                    currencyCode
+                                    amount
+                                  }
+                                }
+                                ... on SellingPlanFixedPriceAdjustment {
+                                  price {
+                                    currencyCode
+                                    amount
+                                  }
+                                }
+                                ... on SellingPlanPercentagePriceAdjustment {
+                                  adjustmentPercentage
+                                }
+                              }
+                            }
+                            recurringDeliveries
+                          }
+                        }
+                      }
+                      appName
+                      name
+                      options {
+                        name
+                        values
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -232,6 +498,4 @@ const QUERY = gql`
       }
     }
   }
-
-  ${ProductProviderFragment}
 `;

--- a/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
@@ -1,5 +1,4 @@
 import {useShopQuery, Seo, useRouteParams} from '@shopify/hydrogen';
-import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';
@@ -48,7 +47,272 @@ const QUERY = gql`
     product: product(handle: $handle) {
       id
       vendor
-      ...ProductProviderFragment
+      compareAtPriceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      descriptionHtml
+      handle
+      id
+      media(first: $numProductMedia) {
+        edges {
+          node {
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
+          }
+        }
+      }
+      metafields(first: $numProductMetafields) {
+        edges {
+          node {
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
+          }
+        }
+      }
+      priceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      title
+      variants(first: $numProductVariants) {
+        edges {
+          node {
+            id
+            title
+            availableForSale
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+            unitPriceMeasurement {
+              measuredType
+              quantityUnit
+              quantityValue
+              referenceUnit
+              referenceValue
+            }
+            unitPrice {
+              currencyCode
+              amount
+            }
+            priceV2 {
+              currencyCode
+              amount
+            }
+            compareAtPriceV2 {
+              currencyCode
+              amount
+            }
+            selectedOptions {
+              name
+              value
+            }
+            metafields(first: $numProductVariantMetafields) {
+              edges {
+                node {
+                  id
+                  type
+                  namespace
+                  key
+                  value
+                  createdAt
+                  updatedAt
+                  description
+                  reference @include(if: $includeReferenceMetafieldDetails) {
+                    __typename
+                    ... on MediaImage {
+                      id
+                      mediaContentType
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sellingPlanAllocations(
+              first: $numProductVariantSellingPlanAllocations
+            ) {
+              edges {
+                node {
+                  priceAdjustments {
+                    compareAtPrice {
+                      currencyCode
+                      amount
+                    }
+                    perDeliveryPrice {
+                      currencyCode
+                      amount
+                    }
+                    price {
+                      currencyCode
+                      amount
+                    }
+                    unitPrice {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  sellingPlan {
+                    id
+                    description
+                    name
+                    options {
+                      name
+                      value
+                    }
+                    priceAdjustments {
+                      orderCount
+                      adjustmentValue {
+                        ... on SellingPlanFixedAmountPriceAdjustment {
+                          adjustmentAmount {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanFixedPriceAdjustment {
+                          price {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanPercentagePriceAdjustment {
+                          adjustmentPercentage
+                        }
+                      }
+                    }
+                    recurringDeliveries
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      sellingPlanGroups(first: $numProductSellingPlanGroups) {
+        edges {
+          node {
+            sellingPlans(first: $numProductSellingPlans) {
+              edges {
+                node {
+                  id
+                  description
+                  name
+                  options {
+                    name
+                    value
+                  }
+                  priceAdjustments {
+                    orderCount
+                    adjustmentValue {
+                      ... on SellingPlanFixedAmountPriceAdjustment {
+                        adjustmentAmount {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanFixedPriceAdjustment {
+                        price {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanPercentagePriceAdjustment {
+                        adjustmentPercentage
+                      }
+                    }
+                  }
+                  recurringDeliveries
+                }
+              }
+            }
+            appName
+            name
+            options {
+              name
+              values
+            }
+          }
+        }
+      }
       title
       description
       seo {
@@ -79,6 +343,4 @@ const QUERY = gql`
       }
     }
   }
-
-  ${ProductProviderFragment}
 `;

--- a/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProviderFragment.graphql
@@ -99,7 +99,123 @@ fragment ProductProviderFragment on Product {
   variants(first: $numProductVariants) {
     edges {
       node {
-        ...VariantFragment
+        id
+        title
+        availableForSale
+        image {
+          id
+          url
+          altText
+          width
+          height
+        }
+        unitPriceMeasurement {
+          measuredType
+          quantityUnit
+          quantityValue
+          referenceUnit
+          referenceValue
+        }
+        unitPrice {
+          currencyCode
+          amount
+        }
+        priceV2 {
+          currencyCode
+          amount
+        }
+        compareAtPriceV2 {
+          currencyCode
+          amount
+        }
+        selectedOptions {
+          name
+          value
+        }
+        metafields(first: $numProductVariantMetafields) {
+          edges {
+            node {
+              id
+              type
+              namespace
+              key
+              value
+              createdAt
+              updatedAt
+              description
+              reference @include(if: $includeReferenceMetafieldDetails) {
+                __typename
+                ... on MediaImage {
+                  id
+                  mediaContentType
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                }
+              }
+            }
+          }
+        }
+        sellingPlanAllocations(
+          first: $numProductVariantSellingPlanAllocations
+        ) {
+          edges {
+            node {
+              priceAdjustments {
+                compareAtPrice {
+                  currencyCode
+                  amount
+                }
+                perDeliveryPrice {
+                  currencyCode
+                  amount
+                }
+                price {
+                  currencyCode
+                  amount
+                }
+                unitPrice {
+                  currencyCode
+                  amount
+                }
+              }
+              sellingPlan {
+                id
+                description
+                name
+                options {
+                  name
+                  value
+                }
+                priceAdjustments {
+                  orderCount
+                  adjustmentValue {
+                    ... on SellingPlanFixedAmountPriceAdjustment {
+                      adjustmentAmount {
+                        currencyCode
+                        amount
+                      }
+                    }
+                    ... on SellingPlanFixedPriceAdjustment {
+                      price {
+                        currencyCode
+                        amount
+                      }
+                    }
+                    ... on SellingPlanPercentagePriceAdjustment {
+                      adjustmentPercentage
+                    }
+                  }
+                }
+                recurringDeliveries
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/packages/hydrogen/src/components/ProductProvider/README.md
+++ b/packages/hydrogen/src/components/ProductProvider/README.md
@@ -12,11 +12,274 @@ import gql from 'graphql-tag';
 const QUERY = gql`
   query product($handle: String!) {
     product: product(handle: $handle) {
-      ...ProductProviderFragment
+      compareAtPriceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      descriptionHtml
+      handle
+      id
+      media(first: $numProductMedia) {
+        edges {
+          node {
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
+          }
+        }
+      }
+      metafields(first: $numProductMetafields) {
+        edges {
+          node {
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
+          }
+        }
+      }
+      priceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      title
+      variants(first: $numProductVariants) {
+        edges {
+          node {
+            id
+            title
+            availableForSale
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+            unitPriceMeasurement {
+              measuredType
+              quantityUnit
+              quantityValue
+              referenceUnit
+              referenceValue
+            }
+            unitPrice {
+              currencyCode
+              amount
+            }
+            priceV2 {
+              currencyCode
+              amount
+            }
+            compareAtPriceV2 {
+              currencyCode
+              amount
+            }
+            selectedOptions {
+              name
+              value
+            }
+            metafields(first: $numProductVariantMetafields) {
+              edges {
+                node {
+                  id
+                  type
+                  namespace
+                  key
+                  value
+                  createdAt
+                  updatedAt
+                  description
+                  reference @include(if: $includeReferenceMetafieldDetails) {
+                    __typename
+                    ... on MediaImage {
+                      id
+                      mediaContentType
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sellingPlanAllocations(
+              first: $numProductVariantSellingPlanAllocations
+            ) {
+              edges {
+                node {
+                  priceAdjustments {
+                    compareAtPrice {
+                      currencyCode
+                      amount
+                    }
+                    perDeliveryPrice {
+                      currencyCode
+                      amount
+                    }
+                    price {
+                      currencyCode
+                      amount
+                    }
+                    unitPrice {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  sellingPlan {
+                    id
+                    description
+                    name
+                    options {
+                      name
+                      value
+                    }
+                    priceAdjustments {
+                      orderCount
+                      adjustmentValue {
+                        ... on SellingPlanFixedAmountPriceAdjustment {
+                          adjustmentAmount {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanFixedPriceAdjustment {
+                          price {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanPercentagePriceAdjustment {
+                          adjustmentPercentage
+                        }
+                      }
+                    }
+                    recurringDeliveries
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      sellingPlanGroups(first: $numProductSellingPlanGroups) {
+        edges {
+          node {
+            sellingPlans(first: $numProductSellingPlans) {
+              edges {
+                node {
+                  id
+                  description
+                  name
+                  options {
+                    name
+                    value
+                  }
+                  priceAdjustments {
+                    orderCount
+                    adjustmentValue {
+                      ... on SellingPlanFixedAmountPriceAdjustment {
+                        adjustmentAmount {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanFixedPriceAdjustment {
+                        price {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanPercentagePriceAdjustment {
+                        adjustmentPercentage
+                      }
+                    }
+                  }
+                  recurringDeliveries
+                }
+              }
+            }
+            appName
+            name
+            options {
+              name
+              values
+            }
+          }
+        }
+      }
     }
   }
-
-  ${ProductProviderFragment}
 `;
 
 export function Product() {
@@ -146,7 +409,123 @@ fragment ProductProviderFragment on Product {
   variants(first: $numProductVariants) {
     edges {
       node {
-        ...VariantFragment
+        id
+        title
+        availableForSale
+        image {
+          id
+          url
+          altText
+          width
+          height
+        }
+        unitPriceMeasurement {
+          measuredType
+          quantityUnit
+          quantityValue
+          referenceUnit
+          referenceValue
+        }
+        unitPrice {
+          currencyCode
+          amount
+        }
+        priceV2 {
+          currencyCode
+          amount
+        }
+        compareAtPriceV2 {
+          currencyCode
+          amount
+        }
+        selectedOptions {
+          name
+          value
+        }
+        metafields(first: $numProductVariantMetafields) {
+          edges {
+            node {
+              id
+              type
+              namespace
+              key
+              value
+              createdAt
+              updatedAt
+              description
+              reference @include(if: $includeReferenceMetafieldDetails) {
+                __typename
+                ... on MediaImage {
+                  id
+                  mediaContentType
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                }
+              }
+            }
+          }
+        }
+        sellingPlanAllocations(
+          first: $numProductVariantSellingPlanAllocations
+        ) {
+          edges {
+            node {
+              priceAdjustments {
+                compareAtPrice {
+                  currencyCode
+                  amount
+                }
+                perDeliveryPrice {
+                  currencyCode
+                  amount
+                }
+                price {
+                  currencyCode
+                  amount
+                }
+                unitPrice {
+                  currencyCode
+                  amount
+                }
+              }
+              sellingPlan {
+                id
+                description
+                name
+                options {
+                  name
+                  value
+                }
+                priceAdjustments {
+                  orderCount
+                  adjustmentValue {
+                    ... on SellingPlanFixedAmountPriceAdjustment {
+                      adjustmentAmount {
+                        currencyCode
+                        amount
+                      }
+                    }
+                    ... on SellingPlanFixedPriceAdjustment {
+                      price {
+                        currencyCode
+                        amount
+                      }
+                    }
+                    ... on SellingPlanPercentagePriceAdjustment {
+                      adjustmentPercentage
+                    }
+                  }
+                }
+                recurringDeliveries
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -263,11 +642,274 @@ const QUERY = gql`
       featuredImage {
         url
       }
-      ...ProductProviderFragment
+      compareAtPriceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      descriptionHtml
+      handle
+      id
+      media(first: $numProductMedia) {
+        edges {
+          node {
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
+          }
+        }
+      }
+      metafields(first: $numProductMetafields) {
+        edges {
+          node {
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
+          }
+        }
+      }
+      priceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      title
+      variants(first: $numProductVariants) {
+        edges {
+          node {
+            id
+            title
+            availableForSale
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+            unitPriceMeasurement {
+              measuredType
+              quantityUnit
+              quantityValue
+              referenceUnit
+              referenceValue
+            }
+            unitPrice {
+              currencyCode
+              amount
+            }
+            priceV2 {
+              currencyCode
+              amount
+            }
+            compareAtPriceV2 {
+              currencyCode
+              amount
+            }
+            selectedOptions {
+              name
+              value
+            }
+            metafields(first: $numProductVariantMetafields) {
+              edges {
+                node {
+                  id
+                  type
+                  namespace
+                  key
+                  value
+                  createdAt
+                  updatedAt
+                  description
+                  reference @include(if: $includeReferenceMetafieldDetails) {
+                    __typename
+                    ... on MediaImage {
+                      id
+                      mediaContentType
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sellingPlanAllocations(
+              first: $numProductVariantSellingPlanAllocations
+            ) {
+              edges {
+                node {
+                  priceAdjustments {
+                    compareAtPrice {
+                      currencyCode
+                      amount
+                    }
+                    perDeliveryPrice {
+                      currencyCode
+                      amount
+                    }
+                    price {
+                      currencyCode
+                      amount
+                    }
+                    unitPrice {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  sellingPlan {
+                    id
+                    description
+                    name
+                    options {
+                      name
+                      value
+                    }
+                    priceAdjustments {
+                      orderCount
+                      adjustmentValue {
+                        ... on SellingPlanFixedAmountPriceAdjustment {
+                          adjustmentAmount {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanFixedPriceAdjustment {
+                          price {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanPercentagePriceAdjustment {
+                          adjustmentPercentage
+                        }
+                      }
+                    }
+                    recurringDeliveries
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      sellingPlanGroups(first: $numProductSellingPlanGroups) {
+        edges {
+          node {
+            sellingPlans(first: $numProductSellingPlans) {
+              edges {
+                node {
+                  id
+                  description
+                  name
+                  options {
+                    name
+                    value
+                  }
+                  priceAdjustments {
+                    orderCount
+                    adjustmentValue {
+                      ... on SellingPlanFixedAmountPriceAdjustment {
+                        adjustmentAmount {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanFixedPriceAdjustment {
+                        price {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanPercentagePriceAdjustment {
+                        adjustmentPercentage
+                      }
+                    }
+                  }
+                  recurringDeliveries
+                }
+              }
+            }
+            appName
+            name
+            options {
+              name
+              values
+            }
+          }
+        }
+      }
     }
   }
-
-  ${ProductProviderFragment}
 `;
 ```
 

--- a/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
+++ b/packages/hydrogen/src/components/ProductProvider/docs/fragment.md
@@ -104,7 +104,123 @@ fragment ProductProviderFragment on Product {
   variants(first: $numProductVariants) {
     edges {
       node {
-        ...VariantFragment
+        id
+        title
+        availableForSale
+        image {
+          id
+          url
+          altText
+          width
+          height
+        }
+        unitPriceMeasurement {
+          measuredType
+          quantityUnit
+          quantityValue
+          referenceUnit
+          referenceValue
+        }
+        unitPrice {
+          currencyCode
+          amount
+        }
+        priceV2 {
+          currencyCode
+          amount
+        }
+        compareAtPriceV2 {
+          currencyCode
+          amount
+        }
+        selectedOptions {
+          name
+          value
+        }
+        metafields(first: $numProductVariantMetafields) {
+          edges {
+            node {
+              id
+              type
+              namespace
+              key
+              value
+              createdAt
+              updatedAt
+              description
+              reference @include(if: $includeReferenceMetafieldDetails) {
+                __typename
+                ... on MediaImage {
+                  id
+                  mediaContentType
+                  image {
+                    id
+                    url
+                    altText
+                    width
+                    height
+                  }
+                }
+              }
+            }
+          }
+        }
+        sellingPlanAllocations(
+          first: $numProductVariantSellingPlanAllocations
+        ) {
+          edges {
+            node {
+              priceAdjustments {
+                compareAtPrice {
+                  currencyCode
+                  amount
+                }
+                perDeliveryPrice {
+                  currencyCode
+                  amount
+                }
+                price {
+                  currencyCode
+                  amount
+                }
+                unitPrice {
+                  currencyCode
+                  amount
+                }
+              }
+              sellingPlan {
+                id
+                description
+                name
+                options {
+                  name
+                  value
+                }
+                priceAdjustments {
+                  orderCount
+                  adjustmentValue {
+                    ... on SellingPlanFixedAmountPriceAdjustment {
+                      adjustmentAmount {
+                        currencyCode
+                        amount
+                      }
+                    }
+                    ... on SellingPlanFixedPriceAdjustment {
+                      price {
+                        currencyCode
+                        amount
+                      }
+                    }
+                    ... on SellingPlanPercentagePriceAdjustment {
+                      adjustmentPercentage
+                    }
+                  }
+                }
+                recurringDeliveries
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -221,10 +337,273 @@ const QUERY = gql`
       featuredImage {
         url
       }
-      ...ProductProviderFragment
+      compareAtPriceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      descriptionHtml
+      handle
+      id
+      media(first: $numProductMedia) {
+        edges {
+          node {
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
+          }
+        }
+      }
+      metafields(first: $numProductMetafields) {
+        edges {
+          node {
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
+          }
+        }
+      }
+      priceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      title
+      variants(first: $numProductVariants) {
+        edges {
+          node {
+            id
+            title
+            availableForSale
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+            unitPriceMeasurement {
+              measuredType
+              quantityUnit
+              quantityValue
+              referenceUnit
+              referenceValue
+            }
+            unitPrice {
+              currencyCode
+              amount
+            }
+            priceV2 {
+              currencyCode
+              amount
+            }
+            compareAtPriceV2 {
+              currencyCode
+              amount
+            }
+            selectedOptions {
+              name
+              value
+            }
+            metafields(first: $numProductVariantMetafields) {
+              edges {
+                node {
+                  id
+                  type
+                  namespace
+                  key
+                  value
+                  createdAt
+                  updatedAt
+                  description
+                  reference @include(if: $includeReferenceMetafieldDetails) {
+                    __typename
+                    ... on MediaImage {
+                      id
+                      mediaContentType
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sellingPlanAllocations(
+              first: $numProductVariantSellingPlanAllocations
+            ) {
+              edges {
+                node {
+                  priceAdjustments {
+                    compareAtPrice {
+                      currencyCode
+                      amount
+                    }
+                    perDeliveryPrice {
+                      currencyCode
+                      amount
+                    }
+                    price {
+                      currencyCode
+                      amount
+                    }
+                    unitPrice {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  sellingPlan {
+                    id
+                    description
+                    name
+                    options {
+                      name
+                      value
+                    }
+                    priceAdjustments {
+                      orderCount
+                      adjustmentValue {
+                        ... on SellingPlanFixedAmountPriceAdjustment {
+                          adjustmentAmount {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanFixedPriceAdjustment {
+                          price {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanPercentagePriceAdjustment {
+                          adjustmentPercentage
+                        }
+                      }
+                    }
+                    recurringDeliveries
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      sellingPlanGroups(first: $numProductSellingPlanGroups) {
+        edges {
+          node {
+            sellingPlans(first: $numProductSellingPlans) {
+              edges {
+                node {
+                  id
+                  description
+                  name
+                  options {
+                    name
+                    value
+                  }
+                  priceAdjustments {
+                    orderCount
+                    adjustmentValue {
+                      ... on SellingPlanFixedAmountPriceAdjustment {
+                        adjustmentAmount {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanFixedPriceAdjustment {
+                        price {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanPercentagePriceAdjustment {
+                        adjustmentPercentage
+                      }
+                    }
+                  }
+                  recurringDeliveries
+                }
+              }
+            }
+            appName
+            name
+            options {
+              name
+              values
+            }
+          }
+        }
+      }
     }
   }
-
-  ${ProductProviderFragment}
 `;
 ```

--- a/packages/hydrogen/src/components/ProductProvider/examples/product-provider.example.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/examples/product-provider.example.tsx
@@ -1,15 +1,277 @@
 import {ProductProvider} from '@shopify/hydrogen';
-import {ProductProviderFragment} from '@shopify/hydrogen/fragments';
 import gql from 'graphql-tag';
 
 const QUERY = gql`
   query product($handle: String!) {
     product: product(handle: $handle) {
-      ...ProductProviderFragment
+      compareAtPriceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      descriptionHtml
+      handle
+      id
+      media(first: $numProductMedia) {
+        edges {
+          node {
+            ... on MediaImage {
+              mediaContentType
+              image {
+                id
+                url
+                altText
+                width
+                height
+              }
+            }
+            ... on Video {
+              mediaContentType
+              id
+              previewImage {
+                url
+              }
+              sources {
+                mimeType
+                url
+              }
+            }
+            ... on ExternalVideo {
+              mediaContentType
+              id
+              embedUrl
+              host
+            }
+            ... on Model3d {
+              mediaContentType
+              id
+              alt
+              mediaContentType
+              previewImage {
+                url
+              }
+              sources {
+                url
+              }
+            }
+          }
+        }
+      }
+      metafields(first: $numProductMetafields) {
+        edges {
+          node {
+            id
+            type
+            namespace
+            key
+            value
+            createdAt
+            updatedAt
+            description
+            reference @include(if: $includeReferenceMetafieldDetails) {
+              __typename
+              ... on MediaImage {
+                id
+                mediaContentType
+                image {
+                  id
+                  url
+                  altText
+                  width
+                  height
+                }
+              }
+            }
+          }
+        }
+      }
+      priceRange {
+        maxVariantPrice {
+          currencyCode
+          amount
+        }
+        minVariantPrice {
+          currencyCode
+          amount
+        }
+      }
+      title
+      variants(first: $numProductVariants) {
+        edges {
+          node {
+            id
+            title
+            availableForSale
+            image {
+              id
+              url
+              altText
+              width
+              height
+            }
+            unitPriceMeasurement {
+              measuredType
+              quantityUnit
+              quantityValue
+              referenceUnit
+              referenceValue
+            }
+            unitPrice {
+              currencyCode
+              amount
+            }
+            priceV2 {
+              currencyCode
+              amount
+            }
+            compareAtPriceV2 {
+              currencyCode
+              amount
+            }
+            selectedOptions {
+              name
+              value
+            }
+            metafields(first: $numProductVariantMetafields) {
+              edges {
+                node {
+                  id
+                  type
+                  namespace
+                  key
+                  value
+                  createdAt
+                  updatedAt
+                  description
+                  reference @include(if: $includeReferenceMetafieldDetails) {
+                    __typename
+                    ... on MediaImage {
+                      id
+                      mediaContentType
+                      image {
+                        id
+                        url
+                        altText
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            sellingPlanAllocations(
+              first: $numProductVariantSellingPlanAllocations
+            ) {
+              edges {
+                node {
+                  priceAdjustments {
+                    compareAtPrice {
+                      currencyCode
+                      amount
+                    }
+                    perDeliveryPrice {
+                      currencyCode
+                      amount
+                    }
+                    price {
+                      currencyCode
+                      amount
+                    }
+                    unitPrice {
+                      currencyCode
+                      amount
+                    }
+                  }
+                  sellingPlan {
+                    id
+                    description
+                    name
+                    options {
+                      name
+                      value
+                    }
+                    priceAdjustments {
+                      orderCount
+                      adjustmentValue {
+                        ... on SellingPlanFixedAmountPriceAdjustment {
+                          adjustmentAmount {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanFixedPriceAdjustment {
+                          price {
+                            currencyCode
+                            amount
+                          }
+                        }
+                        ... on SellingPlanPercentagePriceAdjustment {
+                          adjustmentPercentage
+                        }
+                      }
+                    }
+                    recurringDeliveries
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      sellingPlanGroups(first: $numProductSellingPlanGroups) {
+        edges {
+          node {
+            sellingPlans(first: $numProductSellingPlans) {
+              edges {
+                node {
+                  id
+                  description
+                  name
+                  options {
+                    name
+                    value
+                  }
+                  priceAdjustments {
+                    orderCount
+                    adjustmentValue {
+                      ... on SellingPlanFixedAmountPriceAdjustment {
+                        adjustmentAmount {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanFixedPriceAdjustment {
+                        price {
+                          currencyCode
+                          amount
+                        }
+                      }
+                      ... on SellingPlanPercentagePriceAdjustment {
+                        adjustmentPercentage
+                      }
+                    }
+                  }
+                  recurringDeliveries
+                }
+              }
+            }
+            appName
+            name
+            options {
+              name
+              values
+            }
+          }
+        }
+      }
     }
   }
-
-  ${ProductProviderFragment}
 `;
 
 export function Product() {

--- a/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
+++ b/packages/hydrogen/src/hooks/useProductOptions/VariantFragment.graphql
@@ -1,7 +1,3 @@
-#import './SellingPlanFragment.graphql'
-#import '../../components/Money/MoneyFragment.graphql'
-#import '../../components/Image/ImageFragment.graphql'
-
 fragment VariantFragment on ProductVariant {
   id
   title


### PR DESCRIPTION
### Description

Part of #778 

This one focuses on `VariantFragment` and `ProductFragment`, which are the last two! 🎉  

With this PR merged, the Fragments have been removed from the demo store, and it's now using the raw query strings. The next step would be to optimize those query strings where they're being used - this is a task that could be parallelized since each page will have its own data needs.

Also I'm purposely avoiding the `graphql-constants.ts` file, since that will just be full-on deleted when we're done. Once this PR is merged and consensus obtained on completely removing fragments, I'll just delete that. 