### PR TITLE
Always exit pre mode before doing a snapshot release

### DIFF
--- a/shipit.unstable.yml
+++ b/shipit.unstable.yml
@@ -3,5 +3,6 @@ deploy:
     - yarn install
     - >-
       yarn workspace @shopify/hydrogen build --force &&
+      node_modules/.bin/changeset pre exit &&
       node_modules/.bin/changeset version --snapshot unstable &&
       node_modules/.bin/changeset publish --no-git-tag --tag unstable


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When releasing unstable today, it failed the first time because we were still in pre mode. This fixes that by always switching out of pre mode before cutting a snapshot release.