### PR TITLE
Log with query key

### DIFF
--- a/.changeset/fast-eggs-hang.md
+++ b/.changeset/fast-eggs-hang.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Log query key when provided in string

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -41,7 +41,10 @@ export function useQuery<T>(
   queryOptions?: HydrogenUseQueryOptions
 ) {
   const request = useServerRequest();
-  const withCacheIdKey = ['__QUERY_CACHE_ID__', ...key];
+  const withCacheIdKey = [
+    '__QUERY_CACHE_ID__',
+    ...(typeof key === 'string' ? [key] : key),
+  ];
   const fetcher = cachedQueryFnBuilder<T>(
     withCacheIdKey,
     queryFn,

--- a/packages/hydrogen/src/utilities/log/utils.ts
+++ b/packages/hydrogen/src/utilities/log/utils.ts
@@ -2,10 +2,16 @@ import type {RenderType} from './log';
 
 export function findQueryName(key: string) {
   const decodeKey = decodeURIComponent(key);
+
+  if (key.length < 100) {
+    return key.replace('"__QUERY_CACHE_ID__"', '').replace(/"/g, '');
+  }
+
   const match = decodeKey.match(/query ([^\s\()]*)\s?(|\(\{)/);
   if (match && match.length > 1) {
     return match[1];
   }
+
   return '<unknown>';
 }
 


### PR DESCRIPTION
Fix: https://github.com/Shopify/hydrogen/issues/901

### Description

Make sure query key provided in a string is being logged properly 

### How to test

1. Add `setLoggerOptions({showQueryTiming: true})` in `App.server.jsx`
2. Add the following in one of the route
    `const {data: posts} = useQuery('dummy-posts', () => fetch('https://jsonplaceholder.typicode.com/posts').json());`

In the query timing log, you should see logs for `dummy-post`

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
