### PR TITLE
Exploration: internal API for request lifecycle events

### DIFF
--- a/packages/hydrogen/src/framework/cache.ts
+++ b/packages/hydrogen/src/framework/cache.ts
@@ -21,7 +21,7 @@ export function getCacheControlHeader({dev}: {dev?: boolean}) {
 }
 
 export function hashKey(key: QueryKey): string {
-  const rawKey = key instanceof Array ? key : [key];
+  const rawKey = Array.isArray(key) ? key : [key];
 
   /**
    * TODO: Smarter hash

--- a/packages/playground/server-components/src/routes/request-lifecycle.server.jsx
+++ b/packages/playground/server-components/src/routes/request-lifecycle.server.jsx
@@ -1,0 +1,19 @@
+import {createData} from '../utils';
+
+export default function Lifecycle({request}) {
+  const d1 = createData('d1', 100);
+  const d2 = createData('d2', 100);
+
+  // This is an experimental private API, do not use it
+  request.on('done', 'unique-key', ({responseAppend}) =>
+    responseAppend('<div data-test="lifecycle-done"></div>')
+  );
+
+  return (
+    <div>
+      <h1>Lifecycle</h1>
+      <div>{d1.read()}</div>
+      <div>{d2.read()}</div>
+    </div>
+  );
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -172,6 +172,14 @@ export default async function testCases({
     expect(body).toEqual('User-agent: *\nDisallow: /admin\n');
   });
 
+  it("emits lifecycle event 'done' and allows appending HTML to the response", async () => {
+    await page.goto(getServerUrl() + '/request-lifecycle');
+
+    // Event runs exactly once, even if `request.on` is called
+    // multiple times due to React rendering cycles.
+    expect(await page.$$('[data-test=lifecycle-done]')).toHaveLength(1);
+  });
+
   describe('HMR', () => {
     if (isBuild) return;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

WIP

Exploring a small internal API to add hooks/events to the request lifecycle.

This could be useful in the new GraphQL Tracker so that it checks unused props right before ending the request instead of after a random interval of 2 seconds.

```ts
const {dataProxy, check} = wrapInGraphQLTracker({
    query,
    data,
});

serverRequest.on('done', key, ({responseAppend}) => {
    const result = check();
    if (result) {
        const warning = `Properties unused in query ${result.queryName}: ${result.properties.join(', ')}`;
        responseAppend(`<script>console.warn('${warning}')</script>`)
    }
})

return dataProxy;
```


I was thinking we could use this to send devtools info to the browser for some kind of UI. ~~However, I realized `responseAppend` wouldn't be useful for RSC requests (I don't think we can append anything to an RSC response)~~, so perhaps it's not that interesting.

@jplhomer @cartogram  Thoughts?

-- Update: We can actually append line comments or custom syntax to the RSC response and simply remove these lines before passing it to the RSC consumer in the browser 🤯 


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
