### PR TITLE
Default trackOverfetch to off. 

### DIFF
--- a/examples/template-hydrogen-default/src/App.server.jsx
+++ b/examples/template-hydrogen-default/src/App.server.jsx
@@ -25,4 +25,7 @@ function App({routes}) {
 
 const routes = import.meta.globEager('./routes/**/*.server.[jt](s|sx)');
 
-export default renderHydrogen(App, {shopifyConfig, routes});
+export default renderHydrogen(App, {
+  shopifyConfig,
+  routes,
+});

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -74,13 +74,14 @@ export interface RequestHandler {
 
 export const renderHydrogen = (
   App: any,
-  {shopifyConfig, routes}: ServerHandlerConfig
+  {shopifyConfig, routes, trackOverfetch = false}: ServerHandlerConfig
 ) => {
   const handleRequest: RequestHandler = async function (
     rawRequest,
     {indexTemplate, streamableResponse, dev, cache, context, nonce}
   ) {
     const request = new ServerComponentRequest(rawRequest);
+    request.ctx.trackOverfetch = trackOverfetch;
     const url = new URL(request.url);
     const log = getLoggerWithContext(request);
     const componentResponse = new ServerComponentResponse();

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
@@ -54,6 +54,7 @@ export class ServerComponentRequest extends Request {
     queryTimings: Array<QueryTiming>;
     preloadQueries: PreloadQueriesByURL;
     router: RouterContextData;
+    trackOverfetch: boolean;
     [key: string]: any;
   };
 
@@ -79,6 +80,7 @@ export class ServerComponentRequest extends Request {
     this.ctx = {
       cache: new Map(),
       head: new HeadData({}),
+      trackOverfetch: false,
       router: {
         routeRendered: false,
         serverProps: {},

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -23,7 +23,7 @@ export function useShopQuery<T>({
   cache,
   locale = '',
   preload = false,
-  trackOverfetch = true,
+  trackOverfetch = false,
 }: {
   /** A string of the GraphQL query.
    * If no query is provided, useShopQuery will make no calls to the Storefront API.
@@ -52,6 +52,8 @@ export function useShopQuery<T>({
   }
 
   const serverRequest = useServerRequest();
+  trackOverfetch = trackOverfetch || serverRequest.ctx.trackOverfetch;
+
   const log = getLoggerWithContext(serverRequest);
 
   const body = query ? graphqlRequestBody(query, variables) : '';

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -48,6 +48,7 @@ export type ImportGlobEagerOutput = Record<
 export type ServerHandlerConfig = {
   routes?: ImportGlobEagerOutput;
   shopifyConfig: ShopifyConfig;
+  trackOverfetch?: boolean;
 };
 
 export type ClientHandlerConfig = {


### PR DESCRIPTION
### Description

Default `trackOverfetch` to off. Re-enable by passing `trackOverfetch: true` prop:

```js
export default renderHydrogen(App, {
  shopifyConfig,
  routes,
  trackOverfetch: true,
});
```

Fixes #916


### Additional context

For now I say we leave this undocumented, until we know exactly where the config property will end up.
