### PR TITLE
GraphQL Tracker improvements

### DIFF
--- a/.changeset/two-onions-tap.md
+++ b/.changeset/two-onions-tap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Provide a Logger option to use GraphQL and disable by default. Improve logging of unused query properties.

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -23,7 +23,6 @@ export function useShopQuery<T>({
   cache,
   locale = '',
   preload = false,
-  trackOverfetch = true,
 }: {
   /** A string of the GraphQL query.
    * If no query is provided, useShopQuery will make no calls to the Storefront API.
@@ -42,8 +41,6 @@ export function useShopQuery<T>({
    * to preload the query for all requests.
    */
   preload?: PreloadOptions;
-  /** Detect and warn about unused data from the GraphQL request in development. */
-  trackOverfetch?: boolean;
 }): UseShopQueryResponse<T> {
   if (!import.meta.env.SSR) {
     throw new Error(
@@ -103,7 +100,7 @@ export function useShopQuery<T>({
 
   if (
     import.meta.env.DEV &&
-    trackOverfetch &&
+    log.options().showUnusedQueryProperties &&
     query &&
     typeof query !== 'string' &&
     data?.data

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -6,7 +6,7 @@ import type {CachingStrategy, PreloadOptions} from '../../types';
 import {fetchBuilder, graphqlRequestBody} from '../../utilities';
 import {getConfig} from '../../framework/config';
 import {useServerRequest} from '../../foundation/ServerRequestProvider';
-import {wrapInGraphQLTracker} from '../../utilities/graphql-tracker';
+import {injectGraphQLTracker} from '../../utilities/graphql-tracker';
 
 export interface UseShopQueryResponse<T> {
   /** The data returned by the query. */
@@ -105,17 +105,14 @@ export function useShopQuery<T>({
     typeof query !== 'string' &&
     data?.data
   ) {
-    return wrapInGraphQLTracker({
+    injectGraphQLTracker({
       query,
       data,
       onUnusedData: ({queryName, properties}) => {
-        log.warn(
-          `
-Potentially overfetching fields in GraphQL query: \`${queryName}\`.
-• ${properties.join(`\n• `)}
-Examine the list of fields above to confirm that they are being used.
-`
-        );
+        const footer = `Examine the list of fields above to confirm that they are being used.\n`;
+        const header = `Potentially overfetching fields in GraphQL query \`${queryName}\`:\n`;
+
+        log.warn(header + `• ${properties.join(`\n• `)}\n` + footer);
       },
     });
   }

--- a/packages/hydrogen/src/utilities/graphql-tracker.ts
+++ b/packages/hydrogen/src/utilities/graphql-tracker.ts
@@ -1,88 +1,222 @@
-import type {ASTNode} from 'graphql';
+import type {
+  DocumentNode,
+  OperationDefinitionNode,
+  FragmentDefinitionNode,
+  FieldNode,
+  SelectionNode,
+  ASTNode,
+} from 'graphql';
 
 export const TIMEOUT_MS = 2000;
 
 type TrackerParams = {
   query: ASTNode;
   data: {data: unknown};
-  onUnusedData: (params: {queryName: string; properties: string[]}) => void;
+  onUnusedData?: (params: {queryName: string; properties: string[]}) => void;
 };
 
-function checkReadValues(
-  map: Record<string, string>,
-  query: TrackerParams['query'],
-  onUnusedData: TrackerParams['onUnusedData']
-) {
-  // Track all the selections that were fetched
-  const selections: string[] = [];
-
-  // TODO: Fields that match this regex should be ignored.
-  // Improve to look for Fragment at the end of the name.
-  const regex = /(Fragment|__typename|edges|node)/;
-
-  // Loop through the read fields map and add the
-  // selections to the selections array
-  JSON.parse(JSON.stringify(query), (key, value) => {
-    if (value && typeof value === 'object' && value.kind === 'SelectionSet') {
-      const selection = value.selections.map((sel: any) => {
-        if (!sel.name || regex.test(sel.name?.value)) {
-          return;
-        }
-
-        return sel.name?.value;
-      });
-
-      selections.push(selection.filter(Boolean));
-    }
-
-    return value;
-  });
-
-  const flattenedSelections = [...new Set(selections.flat())];
-
-  // Check if any of the selections were not read
-  const unusedGraphQLFields = flattenedSelections.filter((prop) => !map[prop]);
-
-  if (unusedGraphQLFields) {
-    // TODO support aliased fields
-    const defs = (query as any)?.definitions;
-    const queryName = defs && defs[0].name?.value;
-
-    onUnusedData({queryName, properties: unusedGraphQLFields});
-  }
-}
-
-export function wrapInGraphQLTracker<T>({
+export function injectGraphQLTracker({
   query,
   data,
   onUnusedData,
 }: TrackerParams) {
+  const {fieldNodes, fragments} = convertQueryToResolveInfo(
+    query as DocumentNode
+  );
+
+  // E.g. ['shop.stuff.myString']
+  const requestedFields = Object.keys(
+    flattenObject(getSelectionFieldsFromAST(fieldNodes, fragments))
+  );
+
+  // Remove the last key of each path to avoid proxying primitive
+  // values. Reverse order to avoid accessing already defined
+  // proxies (i.e. handle child properties before parent properties)
+  // E.g. `shop.stuff.myString` => `shop.stuff`
+  const uniqueFieldPaths = [
+    ...new Set(
+      requestedFields.map((path) => path.split('.').slice(0, -1).join('.'))
+    ),
+  ].reverse();
+
+  const queryName =
+    findOperationDefinition(query as DocumentNode).name?.value || '';
+
+  // Record fields that are read in the proxy to compare later.
+  const readFieldsMap: Record<string, any> = {};
+
+  let isCheckedOnce = false;
+  const checkFields = (check = onUnusedData!) => {
+    isCheckedOnce = true;
+
+    const properties = requestedFields
+      .filter((prop) => !readFieldsMap[prop] && !prop.endsWith('.__typename'))
+      .map((prop) => prop.replace(/\.edges\./g, '.').replace(/\.node\./g, '.'));
+
+    if (properties.length > 0) {
+      return check({queryName, properties});
+    }
+  };
+
   let readTimeout: ReturnType<typeof setTimeout>;
-  // Create a map of read fields
-  const readFieldsMap: Record<string | symbol, any> = {};
+  uniqueFieldPaths.forEach((fieldPath) =>
+    deepTransform(data, 'data.' + fieldPath, (value: any) => {
+      if (typeof value !== 'object' || value === null) return value;
 
-  // Create a proxy object that allows us to inspect the fields that were fetched
-  const dataProxy = JSON.parse(JSON.stringify(data), (_, value) => {
-    if (typeof value === 'object' && value && !Array.isArray(value)) {
       return new Proxy(value, {
-        get(target, prop: any) {
-          if (!readFieldsMap[prop]) {
-            clearTimeout(readTimeout);
-            readTimeout = setTimeout(
-              () => checkReadValues(readFieldsMap, query, onUnusedData),
-              TIMEOUT_MS
-            );
-          }
+        get(target, prop: string | symbol) {
+          if (typeof prop === 'string') {
+            const fullPath = fieldPath + '.' + prop;
 
-          readFieldsMap[prop] = true;
+            if (!readFieldsMap[fullPath]) {
+              readFieldsMap[fullPath] = true;
+              if (onUnusedData && !isCheckedOnce) {
+                clearTimeout(readTimeout);
+                readTimeout = setTimeout(checkFields, TIMEOUT_MS);
+              }
+            }
+          }
 
           return target[prop];
         },
       });
+    })
+  );
+
+  return checkFields;
+}
+
+function findOperationDefinition(query: DocumentNode) {
+  return query.definitions.find(
+    (def) => def.kind === 'OperationDefinition'
+  ) as OperationDefinitionNode;
+}
+
+function convertQueryToResolveInfo(query: DocumentNode) {
+  const operation = findOperationDefinition(query);
+
+  const fragments = query.definitions
+    .filter(({kind}) => kind === 'FragmentDefinition')
+    .reduce((result, current) => {
+      current = current as FragmentDefinitionNode;
+      return {
+        ...result,
+        [current.name.value]: current,
+      };
+    }, {} as Record<string, FragmentDefinitionNode>);
+
+  return {
+    fieldNodes: operation?.selectionSet.selections as FieldNode[],
+    fragments,
+  };
+}
+
+/**
+ * Extracts the selection fields from a query AST as a plain JS object.
+ * @param selectionNodes - Selection nodes from the AST
+ * @param fragments - Fragments from the AST
+ * @param root - Internal pointer for recursion
+ * @returns A plain JS object representing the selection fields
+ */
+function getSelectionFieldsFromAST(
+  selectionNodes: SelectionNode | SelectionNode[],
+  fragments: Record<string, FragmentDefinitionNode> = {},
+  root: Record<string, any> = {}
+) {
+  const nodes = Array.isArray(selectionNodes)
+    ? selectionNodes
+    : [selectionNodes];
+
+  return nodes.reduce(function (tree, value) {
+    if (value.kind === 'Field') {
+      const name =
+        (value.alias && value.alias.value) || (value.name && value.name.value);
+
+      if (value.selectionSet) {
+        tree[name] ??= {};
+
+        getSelectionFieldsFromAST(
+          value.selectionSet.selections as SelectionNode[], // readonly type?
+          fragments,
+          tree[name]
+        );
+      } else {
+        tree[name] = true;
+      }
+    } else if (value.kind === 'FragmentSpread') {
+      const name = value.name.value;
+      const fragment = fragments[name];
+      if (!fragment) {
+        throw new Error('Unknown fragment "' + name + '"');
+      }
+
+      getSelectionFieldsFromAST(
+        fragment.selectionSet.selections as SelectionNode[],
+        fragments,
+        tree
+      );
+    } else if (value.kind === 'InlineFragment') {
+      getSelectionFieldsFromAST(
+        value.selectionSet.selections as SelectionNode[],
+        fragments,
+        tree
+      );
     }
 
-    return value;
-  });
+    return tree;
+  }, root);
+}
 
-  return dataProxy as T;
+/**
+ * Generates a new object with only one level depth where all the
+ * original nested properties are concatenated with dots.
+ * @param input - Object to flatten
+ * @param key - Internal pointer for recursion
+ * @param output - Internal pointer for recursion
+ * @returns
+ */
+function flattenObject(input: any, key = '', output: Record<string, any> = {}) {
+  if (input === null || typeof input !== 'object') {
+    // This is a leaf, stop here
+    output[key] = input;
+  } else {
+    // Array or object, continue recursively for each child
+    const prefix = key ? key + '.' : key;
+    for (const nextKey of Object.keys(input)) {
+      flattenObject(input[nextKey], prefix + nextKey, output);
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Transform a nested property in a given object (in place).
+ * @param input - Object to transform
+ * @param path - Dot-separated path to the nested property
+ * @param valueTransform - Transformer function
+ */
+function deepTransform(
+  input: any,
+  path: string | string[],
+  valueTransform: (v: any) => any
+) {
+  const keys = Array.isArray(path) ? path : path.split('.');
+  let obj = input;
+  let key;
+
+  for (let index = 0; !!obj && index < keys.length; index++) {
+    key = keys[index];
+
+    if (index === keys.length - 1) {
+      // Last property, transform value
+      obj[key] = valueTransform(obj[key]);
+    } else if (Array.isArray(obj[key])) {
+      // We've found an array in the middle, run this recursively
+      const subKeys = keys.slice(index + 1);
+      obj[key].forEach((v: any) => deepTransform(v, subKeys, valueTransform));
+    }
+
+    obj = obj[key];
+  }
 }

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -28,6 +28,7 @@ export type LoggerOptions = {
   showCacheControlHeader?: boolean;
   showCacheApiStatus?: boolean;
   showQueryTiming?: boolean;
+  showUnusedQueryProperties?: boolean;
 };
 
 export type RenderType = 'str' | 'rsc' | 'ssr' | 'api';

--- a/packages/hydrogen/src/utilities/tests/graphql-tracker.test.ts
+++ b/packages/hydrogen/src/utilities/tests/graphql-tracker.test.ts
@@ -5,47 +5,97 @@ import {wrapInGraphQLTracker, TIMEOUT_MS} from '../graphql-tracker';
 const query = gql`
   query shopName {
     shop {
+      __typename
       id
-      name
-      description
+      title: name
+      summary: description
       moneyFormat
       paymentSettings {
-        countryCode
-        currencyCode
+        __typename
+        ...CodesFragment
+        supportedDigitalWallets
+      }
+    }
+    products {
+      edges {
+        node {
+          handle
+          variants {
+            edges {
+              node {
+                title
+                compareAtPriceV2 {
+                  amount
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
+
+  fragment CodesFragment on PaymentSettings {
+    countryCode
+    currencyCode
+  }
 `;
 
-const data = {
+const getData = () => ({
   data: {
     shop: {
       id: 'id',
-      name: 'name',
-      description: 'description',
+      title: 'aliased name',
+      summary: 'description',
       moneyFormat: 'moneyFormat',
       paymentSettings: {
         countryCode: 'ES',
         currencyCode: 'EUR',
+        supportedDigitalWallets: ['ANDROID_PAY', 'SHOPIFY_PAY'],
       },
     },
+    products: {
+      edges: [
+        {
+          node: {
+            handle: 'handle-0',
+            variants: {
+              edges: [{node: {title: 'title-0', compareAtPriceV2: null}}],
+            },
+          },
+        },
+        {
+          node: {
+            handle: 'handle-1',
+            variants: {
+              edges: [
+                {node: {title: 'title-1', compareAtPriceV2: {amount: 12}}},
+              ],
+            },
+          },
+        },
+      ],
+    },
   },
-};
+});
 
 describe('GraphQL Tracker', () => {
   jest.useFakeTimers();
 
   it('warns about unused properties', () => {
-    let unusedData: null | {queryName: string; properties: string[]} = null;
+    let unusedData = {
+      queryName: '',
+      properties: [] as string[],
+    };
 
-    const tracker = wrapInGraphQLTracker<typeof data>({
+    const dataMock = wrapInGraphQLTracker({
       query,
-      data,
-      onUnusedData: (params) => (unusedData = params),
+      data: getData(),
+      onUnusedData: (params: typeof unusedData) => (unusedData = params),
     });
 
-    // Read stuff via destructuring or direct access
-    tracker.data.shop.id + tracker.data.shop.name;
+    // Read stuff via direct access or destructuring
+    dataMock.data.shop.id + dataMock.data.shop.title;
 
     jest.advanceTimersByTime(TIMEOUT_MS / 2);
 
@@ -55,26 +105,58 @@ describe('GraphQL Tracker', () => {
           // @ts-ignore
           paymentSettings: {countryCode},
         },
+        products: {
+          edges: [
+            // @ts-ignore
+            firstProductEdge,
+            {
+              // @ts-ignore
+              node: {handle},
+            },
+          ],
+        },
       },
-    } = tracker;
+    } = dataMock;
 
     jest.advanceTimersByTime(TIMEOUT_MS / 2 + 100);
     // Not enough time since last read
-    expect(unusedData).toBeFalsy();
+    expect(unusedData.properties.length).toEqual(0);
+
     jest.advanceTimersByTime(TIMEOUT_MS / 2);
     // Enough time since last read
-    expect(unusedData).toBeTruthy();
+    expect(unusedData.properties.length).toBeGreaterThan(0);
 
-    const {queryName, properties} = unusedData!;
+    expect(unusedData.queryName).toEqual('shopName');
 
-    expect(queryName).toEqual('shopName');
+    // Properties that are not used:
+    expect(unusedData.properties).toContain('shop.summary');
+    expect(unusedData.properties).toContain('shop.moneyFormat');
+    expect(unusedData.properties).toContain(
+      'shop.paymentSettings.currencyCode'
+    );
+    expect(unusedData.properties).toContain('products.variants.title');
+    expect(unusedData.properties).toContain(
+      'products.variants.compareAtPriceV2.amount'
+    );
+    expect(unusedData.properties).toContain(
+      'shop.paymentSettings.supportedDigitalWallets'
+    );
 
-    expect(properties).toContain('description');
-    expect(properties).toContain('moneyFormat');
-    expect(properties).toContain('currencyCode');
+    // Properties that have been read or are excluded for any reason:
+    expect(unusedData.properties).not.toContain('shop.id');
+    expect(unusedData.properties).not.toContain('shop.__typename'); // Ignored
+    expect(unusedData.properties).not.toContain('shop.name'); // Aliased to title
+    expect(unusedData.properties).not.toContain('shop.title');
+    expect(unusedData.properties).not.toContain('shop.description'); // Alaised to summary
+    expect(unusedData.properties).not.toContain(
+      'shop.paymentSettings.countryCode'
+    );
+    expect(unusedData.properties).not.toContain(
+      'shop.paymentSettings.__typename'
+    ); // Ignored
+    expect(unusedData.properties).not.toContain('products.handle');
 
-    expect(properties).not.toContain('id');
-    expect(properties).not.toContain('name');
-    expect(properties).not.toContain('countryCode');
+    // Make sure the data has not been altered during the proxy injection
+    expect(JSON.stringify(dataMock)).toEqual(JSON.stringify(getData()));
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Closes #911
Closes #916

### Description

The GraphQL tracker we made originally was a quick PoC and had some issues. This PR changes the implementation to a more robust version that traverses the query AST to get extra information.
- Disable tracker by default and provide a Logger option to enable it (like all the other cache/header logs).
- Show all the property path: `shop.products.handle` instead of just `handle`.
- Handle aliases in queries.
- Handle fragment spreads in queries.
- Show file and location of the query.
- Trim the logs when there are too many unused properties.

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/1634092/158514847-30b33dd8-f6f4-46c3-a4bd-ea84e37ad0d3.png">


### Additional context

The code is more complex than before because we can't rely on simple JSON revivers anymore. I would recommend checking the tests and the comments to understand what's going on. It should all be tree-shaked during build, in any case.

The easiest way to test this is adding the following to `App.server.jsx`:

```js
// @ts-ignore
globalThis.__logger = {
  // @ts-ignore
  ...globalThis.__logger,
  options: () => ({
    showUnusedQueryProperties: true,
  }),
};
```

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
