### PR TITLE
Add worker entry with module syntax

### DIFF
--- a/.changeset/quiet-guests-dress.md
+++ b/.changeset/quiet-guests-dress.md
@@ -1,0 +1,5 @@
+---
+'template-hydrogen-default': patch
+---
+
+Added a new default worker entry point that uses module syntax in `@shopify/hydrogen/platforms/worker`.

--- a/.changeset/quiet-guests-dress.md
+++ b/.changeset/quiet-guests-dress.md
@@ -1,5 +1,5 @@
 ---
-'template-hydrogen-default': patch
+'create-hydrogen-app': patch
 ---
 
 Added a new default worker entry point that uses module syntax in `@shopify/hydrogen/platforms/worker`.

--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -216,7 +216,7 @@ addEventListener('fetch', (event) => event.respondWith(handleEvent(event)));
 Update `package.json` to specify the new Worker entry point. If the entry point is in `<root>/worker.js`, then the changes look like the following:
 
 ```diff
-- "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr @shopify/hydrogen/platforms/worker-event",
+- "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr @shopify/hydrogen/platforms/worker",
 + "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr worker",
 ```
 

--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -12,7 +12,7 @@
     "build": "yarn build:client && yarn build:server && yarn build:worker",
     "build:client": "vite build --outDir dist/client --manifest",
     "build:server": "vite build --outDir dist/server --ssr @shopify/hydrogen/platforms/node",
-    "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr @shopify/hydrogen/platforms/worker-event",
+    "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr @shopify/hydrogen/platforms/worker",
     "serve": "node --enable-source-maps dist/server",
     "preview": "npx @shopify/hydrogen-cli@latest preview",
     "test": "WATCH=true vitest",

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -67,7 +67,7 @@ By default, Hydrogen includes a [`@shopify/hydrogen/platforms/node`](https://git
 
 The Hydrogen app is hosted on a worker platform like [Oxygen](/custom-storefronts/hydrogen/deployment#deploy-to-cloudflare-workers) or [Cloudflare](/custom-storefronts/hydrogen/deployment#deploy-to-oxygen).
 
-By default, Hydrogen includes a [`@shopify/hydrogen/platforms/worker-event`](https://github.com/Shopify/hydrogen/blob/main/packages/hydrogen/src/platforms/worker-event.ts) package for server-side rendering. The Cache API and KV API are powered by Oxygen, Cloudflare, or another runtime adapter.
+By default, Hydrogen includes a [`@shopify/hydrogen/platforms/worker`](https://github.com/Shopify/hydrogen/blob/main/packages/hydrogen/src/platforms/worker.ts) package for server-side rendering. The Cache API and KV API are powered by Oxygen, Cloudflare, or another runtime adapter.
 
 ## Configuring default entry points
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -101,7 +101,7 @@ export default () => {
         const packageJson = {
           type: isESM ? 'module' : 'commonjs',
           main: mainFile,
-          exports: {'.': mainFile, mainFile},
+          exports: {'.': mainFile, [mainFile]: mainFile},
         };
 
         fs.writeFileSync(

--- a/packages/hydrogen/src/platforms/worker-event.ts
+++ b/packages/hydrogen/src/platforms/worker-event.ts
@@ -1,10 +1,4 @@
-import type {RequestHandler} from '../entry-server';
-// @ts-ignore
-// eslint-disable-next-line node/no-missing-import
-import entrypoint from '__SERVER_ENTRY__';
-// @ts-ignore
-// eslint-disable-next-line node/no-missing-import
-import indexTemplate from '__INDEX_TEMPLATE__?raw';
+import moduleEntry from './worker';
 
 interface FetchEvent extends Event {
   readonly request: Request;
@@ -13,38 +7,7 @@ interface FetchEvent extends Event {
   waitUntil(promise: Promise<any>): void;
 }
 
-interface CacheStorage {
-  open(cacheName: string): Promise<Cache>;
-  readonly default: Cache;
-}
-
-const handleRequest = entrypoint as RequestHandler;
-
-declare global {
-  // eslint-disable-next-line no-var
-  var globalThis: {
-    Oxygen: {env: any};
-    [key: string]: any;
-  };
-}
-
-if (!globalThis.Oxygen) {
-  globalThis.Oxygen = {env: globalThis};
-}
-
-async function handleEvent(event: FetchEvent) {
-  try {
-    return (await handleRequest(event.request, {
-      indexTemplate,
-      cache: (caches as unknown as CacheStorage).default,
-      context: event,
-    })) as Response;
-  } catch (error: any) {
-    return new Response(error.message || error.toString(), {status: 500});
-  }
-}
-
 // @ts-ignore
 addEventListener('fetch', (event: FetchEvent) =>
-  event.respondWith(handleEvent(event))
+  event.respondWith(moduleEntry.fetch(event.request, globalThis, event))
 );

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -1,0 +1,44 @@
+import type {RequestHandler} from '../entry-server';
+// @ts-ignore
+// eslint-disable-next-line node/no-missing-import
+import entrypoint from '__SERVER_ENTRY__';
+// @ts-ignore
+// eslint-disable-next-line node/no-missing-import
+import indexTemplate from '__INDEX_TEMPLATE__?raw';
+
+interface CacheStorage {
+  open(cacheName: string): Promise<Cache>;
+  readonly default: Cache;
+}
+
+const handleRequest = entrypoint as RequestHandler;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var globalThis: {
+    Oxygen: {env: any};
+    [key: string]: any;
+  };
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: unknown,
+    context: {waitUntil: (promise: Promise<any>) => void}
+  ) {
+    if (!globalThis.Oxygen) {
+      globalThis.Oxygen = {env};
+    }
+
+    try {
+      return (await handleRequest(request, {
+        indexTemplate,
+        cache: (caches as unknown as CacheStorage).default,
+        context,
+      })) as Response;
+    } catch (error: any) {
+      return new Response(error.message || error.toString(), {status: 500});
+    }
+  },
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #902 

This adds `@shopify/hydrogen/platforms/worker` as an entry point for worker builds.

@jplhomer  As we talked last Tuesday, I'm using here `worker` instead of `worker-module` for the name of the file.

Note that I haven't changed the e2e worker because we are still on Miniflare v1, which doesn't support some of the new requirements in `kv-asset-handler`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
