### PR TITLE
Remove path-to-regexp dep from template

### DIFF
--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -42,7 +42,6 @@
     "body-parser": "^1.19.1",
     "compression": "^1.7.4",
     "graphql-tag": "^2.12.4",
-    "path-to-regexp": "^6.2.0",
     "react": "0.0.0-experimental-529dc3ce8-20220124",
     "react-dom": "0.0.0-experimental-529dc3ce8-20220124",
     "serve-static": "^1.14.1"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This isn't isn't needed as a template dep, because it's only used in Hydrogen, which includes it as a dep already.