### PR TITLE
Update deployment docs to better specify custom Node production support

### DIFF
--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -29,7 +29,7 @@ createServer().then(({app}) => {
 });
 ```
 
-If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), or if you want to supply a `cache` input to `hydrogenMiddleware` for [production caching](https://shopify.dev/custom-storefronts/hydrogen/framework/cache#caching-in-production), create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
+If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), or if you want to supply a `cache` input to `hydrogenMiddleware` for [production caching](/custom-storefronts/hydrogen/framework/cache#caching-in-production), then create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
 
 ```js
 import {hydrogenMiddleware} from '@shopify/hydrogen/middleware';
@@ -53,7 +53,7 @@ app.use(
   hydrogenMiddleware({
     getServerEntrypoint: () => import('./src/App.server'),
     indexTemplate: () => import('./dist/client/index.html?raw'),
-    // optional: Provide a cache
+    // Optional: Provide a caching strategy
     cache: customCacheImplementation,
   })
 );

--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -29,31 +29,38 @@ createServer().then(({app}) => {
 });
 ```
 
-If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
+If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), or if you want to supply a `cache` input to `hydrogenMiddleware` for [production caching](https://shopify.dev/custom-storefronts/hydrogen/framework/cache#caching-in-production), create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
 
 ```js
 import {hydrogenMiddleware} from '@shopify/hydrogen/middleware';
 import serveStatic from 'serve-static';
 import compression from 'compression';
 import bodyParser from 'body-parser';
-// ...
+import connect from 'connect';
+import path from 'path';
 
-const app = new MyServerFramework();
+const port = process.env.PORT || 8080;
+
+// Initialize your own server framework like connect
+const app = connect();
 
 // Add desired middlewares and handle static assets
 app.use(compression());
-app.use(serveStatic(path.resolve(__dirname, 'dist', 'client'), {index: false}));
+app.use(serveStatic(path.resolve(__dirname, '../', 'client'), {index: false}));
 app.use(bodyParser.raw({type: '*/*'}));
 
 app.use(
-  '*',
   hydrogenMiddleware({
     getServerEntrypoint: () => import('./src/App.server'),
     indexTemplate: () => import('./dist/client/index.html?raw'),
+    // optional: Provide a cache
+    cache: customCacheImplementation,
   })
 );
 
-app.listen(/* ... */);
+app.listen(port, () => {
+  console.log(`Hydrogen server running at http://localhost:${port}`);
+});
 ```
 
 Update the scripts in `package.json` to specify your new entry point. If the scripts are located in `<root>/server.js`, then the changes would look like the following:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Our Node production deployment docs included an incorrect path to static assets for serving in production. I've also updated the example to include an actual working version with `connect` as well as an example for providing Cache, inspired by this discussion: https://github.com/Shopify/hydrogen/discussions/937