### PR TITLE
Allow disabling minification in Vite config

### DIFF
--- a/.changeset/calm-starfishes-retire.md
+++ b/.changeset/calm-starfishes-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow disabling minification in vite.config.js

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -14,7 +14,7 @@ export default () => {
       },
 
       build: {
-        minify: 'esbuild',
+        minify: config.build?.minify ?? 'esbuild',
         sourcemap: true,
         /**
          * By default, SSR dedupe logic gets bundled which runs `require('module')`.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Disabling minification is sometimes useful for checking if server logic has leaked to the client build. Currently, the minification option in `vite.config.js` is overwritten by Hydrogen's config.

```js
import {defineConfig} from 'vite';
import hydrogen from '@shopify/hydrogen/plugin';
import shopifyConfig from './shopify.config';

export default defineConfig({
  plugins: [hydrogen(shopifyConfig)],
  optimizeDeps: {include: ['@headlessui/react']},
  build: {minify: false},
});

```

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
