### PR TITLE
Sync latest release to main

### DIFF
--- a/.github/workflows/sync_main.yml
+++ b/.github/workflows/sync_main.yml
@@ -1,0 +1,21 @@
+name: Sync to main
+
+on:
+  push:
+    branches:
+      - 'v1.x-2022-07'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Sync the release branch to main
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Push to main branch
+        run: |
+          git show-ref
+          git config user.email "hydrogen@shopify.com"
+          git config user.name "Hydrogen Bot"
+          git push origin HEAD:main --force


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #941 

We reference `main` a lot in external docs, etc. So this PR syncs our latest stable branch with `main`.