### PR TITLE
[Hydrogen docs]: Add reference to `robots.txt.server.js` file

### DIFF
--- a/.changeset/young-otters-dance.md
+++ b/.changeset/young-otters-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Hydrogen docs: Add reference to robots.txt.server.js file

--- a/packages/hydrogen/src/framework/docs/index.md
+++ b/packages/hydrogen/src/framework/docs/index.md
@@ -44,6 +44,7 @@ Most of the files that you'll work with in the Hydrogen project are located in t
             └── [handle].server.jsx
         └── index.server.jsx
         └── redirect.server.jsx
+        └── robots.txt.server.js
         └── sitemap.xml.server.jsx
     ├── App.server.jsx
     ├── index.css


### PR DESCRIPTION
## This PR: 
- Adds a missing reference to the `robots.txt.server.js` file in the framework docs
- Relates to https://github.com/Shopify/shopify-dev/pull/17397