### PR TITLE
[Hydrogen docs]: Analytics

### DIFF
--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -165,7 +165,6 @@ const serverDataLayer = useServerAnalytics({
 
 {% endcodeblock %}
 
-
 The following example shows how to retrieve analytics data from a client component:
 
 {% codeblock file, filename: '*.client.js' %}

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -152,6 +152,22 @@ const serverDataLayer = useServerAnalytics();
 
 {% endcodeblock %}
 
+If you need to trigger a different analytics event on navigation, you can specify a list of analytics events
+to publish in the server analytics:
+
+{% codeblock file, filename: '*.server.js' %}
+
+```js
+const serverDataLayer = useServerAnalytics({
+  publishEventsOnNavigate: [ClientAnalytics.eventNames.VIEWED_PRODUCT],
+});
+```
+
+> Caution:
+> Don't use the data from `useServerAnalytics()` for rendering. This will cause occasional mismatches during hydration.
+
+{% endcodeblock %}
+
 The following example shows how to retrieve analytics data from a client component:
 
 {% codeblock file, filename: '*.client.js' %}
@@ -388,7 +404,7 @@ describe('Google Analytics 4', () => {
   it('should emit page_view', async () => {
     // Wait for the Google Analytics 4 network call
     const [request] = await Promise.all([
-      // Test if the request matches a Google Analytics 4 analytic pixel
+      // Test if the request matches a Google Analytics 4 analytics pixel
       session.page.waitForRequest((request) =>
         endpointRegex.test(request.url())
       ),
@@ -396,7 +412,7 @@ describe('Google Analytics 4', () => {
       session.visit('/'),
     ]);
 
-    // Validate data on the Google Analytics 4 analytic pixel
+    // Validate data on the Google Analytics 4 analytics pixel
     const ga4Event = new URL(request.url());
     expect(ga4Event.searchParams.en).toEqual('page_view');
   }, 60000);

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -7,7 +7,7 @@ This guide describes the analytic events that Hydrogen emits by default. It also
 By default, Hydrogen emits the following analytic events:
 
 - `PAGE_VIEW`: When a customer visits a storefront page
-- `ADD_TOCART`: When a customer adds an item to their cart
+- `ADD_TO_CART`: When a customer adds an item to their cart
 - `UPDATE_CART`: When a customer updates an item in their cart
 - `REMOVE_FROM_CART`: When a customer removes an item from their cart
 - `DISCOUNT_CODE_UPDATED`: When a discount code that a customer applies to a cart is updated
@@ -16,8 +16,7 @@ The event name constants are available in `ClientAnalytics.eventNames`.
 
 ## Subscribe to an analytic event
 
-You can subscribe to an analytic event to allow your Hydrogen app to listen for the event.
-The following steps describe how to subscribe to the `PAGE_VIEW` analytic event.
+You can subscribe to an analytic event to allow your Hydrogen app to listen for the event. The following steps describe how to subscribe to the `PAGE_VIEW` analytic event.
 
 1. Create a new client component in the `/components` directory of your Hydrogen app. For example, `components/AnalyticListener.client.jsx`.
 
@@ -31,7 +30,7 @@ The following steps describe how to subscribe to the `PAGE_VIEW` analytic event.
    let init = false;
    export default function AnalyticsListener() {
      useEffect(() => {
-       // Setup common page specific data
+       // Set up common page-specific data
        ClientAnalytics.pushToPageAnalyticData({
          userLocale: navigator.language,
        });
@@ -93,10 +92,7 @@ The following example shows how to configure a custom event to track the pages w
 
 ### Retrieving data from other parts of your Hydrogen app
 
-Collect analaytic data where you are making queries.
-
-For example, making collection name and id available when receive `PAGE_VIEW`
-analytic event:
+You can collect analytic data wherever you make queries. For example, you can make `collectionName` and `collectionId` available when you receive the `PAGE_VIEW` analytic event:
 
 {% codeblock file, filename: 'collections/[handle].server.js' %}
 
@@ -122,7 +118,7 @@ useServerAnalytics({
 
 {% endcodeblock %}
 
-You can add to page analytic data from client components as well.
+You can also add to page analytic data from client components:
 
 {% codeblock file, filename: '*.client.js' %}
 
@@ -137,7 +133,8 @@ useEffect(() => {
 
 {% endcodeblock %}
 
-> Note: All `ClientAnalytics.*` function calls must be wrapped in a `useEffect`
+> Note: 
+> All `ClientAnalytics.*` function calls must be wrapped in a [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hook.
 
 To retrieve the data that's available elsewhere in your Hydrogen app, you can add the following code to your server and client components:
 
@@ -147,11 +144,12 @@ To retrieve the data that's available elsewhere in your Hydrogen app, you can ad
 const serverDataLayer = useServerAnalytics();
 ```
 
-> Note: Do not use the data from `useServerAnalytics()` for rendering. This will cause occasional hydration mismatch.
+> Caution: 
+> Don't use the data from `useServerAnalytics()` for rendering. This will cause occasional mismatches during hydration.
 
 {% endcodeblock %}
 
-You can get analytic data from client components too.
+The following example shows how to retrieve analytic data from a client component:
 
 {% codeblock file, filename: '*.client.js' %}
 
@@ -161,13 +159,14 @@ ClientAnalytics.getPageAnalyticData();
 
 {% endcodeblock %}
 
-> Note: Do not use the data from `ClientAnalytics.getPageAnalyticData()` for rendering. This will cause occasional hydration mismatch.
+> Caution: 
+> Don't use the data from `ClientAnalytics.getPageAnalyticData()` for rendering. This will cause occasional mismatches during hydration.
 
 ## Send analytic data from the server side
 
-In order to send analytics from the server-side, do the following:
+To send analytic data from the server-side, complete the following steps:
 
-1. Create a client-side analytic listener that makes a fetch call to `__event` endpoint
+1. Create a client-side analytic listener that makes a fetch call to the `__event` endpoint.
 
 {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
 
@@ -177,7 +176,7 @@ import {ClientAnalytics} from '@shopify/hydrogen/client';
 let init = false;
 export default function AnalyticsListener() {
   useEffect(() => {
-    // Setup common page specific data
+    // Set up common page-specific data
     ClientAnalytics.pushToPageAnalyticData({
       userLocale: navigator.language,
     });
@@ -211,13 +210,13 @@ export default function AnalyticsListener() {
 
 {% endcodeblock %}
 
-2. Create a server-side analytic connector and pass it into the `serverAnalyticConnectors` config
+2. Create a server-side analytic connector and pass it into the `serverAnalyticConnectors` configuration:
 
 {% codeblock file, filename: 'MyServerAnalyticConnector.jsx' %}
 
 ```js
 export function request(request, data, contentType) {
-  // Deal with your analytic request
+  // Send your analytic request to third-party analytics
 }
 ```
 
@@ -239,13 +238,13 @@ export default renderHydrogen(App, {
 
 {% endcodeblock %}
 
-### ServerAnalyticConnector request function paramters
+### ServerAnalyticConnector request function parameters
 
 | Parameter   | Type           | Description                            |
 | ----------- | -------------- | -------------------------------------- |
-| request     | Request        | The analytic request object            |
-| data        | Object or Text | The result from `.json()` or `.text()` |
-| contentType | string         | 'json' or 'text'                       |
+| `request`    | request        | The analytic request object.            |
+| `data`        | object or text | The result from `.json()` or `.text()`. |
+| `contentType` | string         | The content type. Valid values: `json` or `text`.                       |
 
 ## Unsubscribe from an analytic event
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -54,6 +54,7 @@ Subscribe to an event to enable your Hydrogen app to listen for the event. The f
        });
 
        if (!init) {
+         init = true;
          // One-time initialization
          ClientAnalytics.subscribe(
            ClientAnalytics.eventNames.PAGE_VIEW,
@@ -61,7 +62,6 @@ Subscribe to an event to enable your Hydrogen app to listen for the event. The f
              console.log(payload);
            }
          );
-         init = true;
        }
      });
 
@@ -215,6 +215,7 @@ To send analytics data from the server-side, complete the following steps:
        });
 
        if (!init) {
+         init = true;
          // One-time initialization
          ClientAnalytics.subscribe(
            ClientAnalytics.eventNames.PAGE_VIEW,
@@ -233,7 +234,6 @@ To send analytics data from the server-side, complete the following steps:
              }
            }
          );
-         init = true;
        }
      });
 
@@ -316,12 +316,12 @@ import {ClientAnalytics, loadScript} from '@shopify/hydrogen/client';
 
 const GTAG_ID = '<YOUR_GTAG_ID>';
 const URL = `https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`;
-let isInit = false;
+let init = false;
 
 export function GoogleAnalytics() {
   useEffect(() => {
-    if (!isInit) {
-      isInit = true;
+    if (!init) {
+      init = true;
 
       // Load the gtag script
       loadScript(URL).catch(() => {});
@@ -367,6 +367,7 @@ let init = false;
 export default function GTM() {
   useEffect(() => {
     if (!init) {
+      init = true;
       // One-time initialization
       Analytics({
         app: 'hydrogen-app',
@@ -376,7 +377,6 @@ export default function GTM() {
           }),
         ],
       });
-      init = true;
     }
   });
   return null;

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -2,6 +2,20 @@ Hydrogen includes support for analytics that give you insight into how customers
 
 This guide describes how to subscribe to the default events that Hydrogen offers, configure custom events, send analytics data from the server-side, and unsubscribe from events. It also provides example implementations of client analytics connectors, and shows how to write an end-to-end (E2E) for testing analytics connectors.
 
+## How it works
+
+The following diagram describes how analytics data is processed on the server and client in Hydrogen:
+
+![Shows a diagram that describes how analytics data is processed on the server and client in Hydrogen](/assets/custom-storefronts/hydrogen/hydrogen-analytics.png)
+
+1. On the server, the `useServerAnalytics` hook collects data in a single render request.
+2. On the client, the data is streamed as part of the `Suspense` component. This single render request contains a `dataLayer` output, waits for all queries to complete, and triggers a `PAGE_VIEW` event.
+
+3. Events can be published to external endpoints from the client or server-side:
+
+- **Client**: The client can subscribe to events and publish them to external endpoints.
+- **Server**: Events are published to the `/__event` endpoint, a server analytics route. You can use `serverAnalyticsConnectors` to publish the event to an external endpoint.
+
 ## Default events
 
 By default, Hydrogen publishes the following events to subscribers (`ClientAnalytics.subscribe`):
@@ -13,6 +27,7 @@ By default, Hydrogen publishes the following events to subscribers (`ClientAnaly
 | `UPDATE_CART`           | A customer updates an item in their cart                     |
 | `REMOVE_FROM_CART`      | A customer removes an item from their cart                   |
 | `DISCOUNT_CODE_UPDATED` | A discount code that a customer applies to a cart is updated |
+| `VIEWED_PRODUCT`        | A customer views a product details page                      |
 
 > Note:
 > The event name constants are available in `ClientAnalytics.eventNames`.

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -361,7 +361,8 @@ export default function GTM() {
 
 ## Testing analytics
 
-The following example shows how to write an end-to-end (E2E) test for Google Analytics 4:
+The following example shows how to write an end-to-end (E2E) test for Google Analytics 4.
+This will work for Google Tag Manager if configured with Google Analytic 4:
 
 {% codeblock file, filename: 'tests/e2e/analytics.ga4.test.js' %}
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -133,7 +133,7 @@ useEffect(() => {
 
 {% endcodeblock %}
 
-> Note: 
+> Note:
 > All `ClientAnalytics.*` function calls must be wrapped in a [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hook.
 
 To retrieve the data that's available elsewhere in your Hydrogen app, you can add the following code to your server and client components:
@@ -144,7 +144,7 @@ To retrieve the data that's available elsewhere in your Hydrogen app, you can ad
 const serverDataLayer = useServerAnalytics();
 ```
 
-> Caution: 
+> Caution:
 > Don't use the data from `useServerAnalytics()` for rendering. This will cause occasional mismatches during hydration.
 
 {% endcodeblock %}
@@ -159,7 +159,7 @@ ClientAnalytics.getPageAnalyticData();
 
 {% endcodeblock %}
 
-> Caution: 
+> Caution:
 > Don't use the data from `ClientAnalytics.getPageAnalyticData()` for rendering. This will cause occasional mismatches during hydration.
 
 ## Send analytic data from the server side
@@ -168,87 +168,89 @@ To send analytic data from the server-side, complete the following steps:
 
 1. Create a client-side analytic listener that makes a fetch call to the `__event` endpoint.
 
-{% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
+   {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
 
-```js
-import {ClientAnalytics} from '@shopify/hydrogen/client';
+   ```js
+   import {ClientAnalytics} from '@shopify/hydrogen/client';
 
-let init = false;
-export default function AnalyticsListener() {
-  useEffect(() => {
-    // Set up common page-specific data
-    ClientAnalytics.pushToPageAnalyticData({
-      userLocale: navigator.language,
-    });
+   let init = false;
+   export default function AnalyticsListener() {
+     useEffect(() => {
+       // Set up common page-specific data
+       ClientAnalytics.pushToPageAnalyticData({
+         userLocale: navigator.language,
+       });
 
-    if (!init) {
-      // One time initialization
-      ClientAnalytics.subscribe(
-        ClientAnalytics.eventNames.PAGE_VIEW,
-        (payload) => {
-          try {
-            fetch('/__event', {
-              method: 'post',
-              headers: {
-                'cache-control': 'no-cache',
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify(payload),
-            });
-          } catch (e) {
-            // deal with error
-          }
-        }
-      );
-      init = true;
-    }
-  });
+       if (!init) {
+         // One time initialization
+         ClientAnalytics.subscribe(
+           ClientAnalytics.eventNames.PAGE_VIEW,
+           (payload) => {
+             try {
+               fetch('/__event', {
+                 method: 'post',
+                 headers: {
+                   'cache-control': 'no-cache',
+                   'Content-Type': 'application/json',
+                 },
+                 body: JSON.stringify(payload),
+               });
+             } catch (e) {
+               // Error handling
+             }
+           }
+         );
+         init = true;
+       }
+     });
 
-  return null;
-}
-```
+     return null;
+   }
+   ```
 
-{% endcodeblock %}
+   {% endcodeblock %}
 
 2. Create a server-side analytic connector and pass it into the `serverAnalyticConnectors` configuration:
 
-{% codeblock file, filename: 'MyServerAnalyticConnector.jsx' %}
+   {% codeblock file, filename: 'MyServerAnalyticConnector.jsx' %}
 
-```js
-export function request(request, data, contentType) {
-  // Send your analytic request to third-party analytics
-}
-```
+   ```js
+   export function request(request, data, contentType) {
+     // Send your analytic request to third-party analytics
+   }
+   ```
 
-{% endcodeblock %}
+   {% endcodeblock %}
 
-{% codeblock file, filename: 'App.server.js' %}
+   {% codeblock file, filename: 'App.server.js' %}
 
-```js
-import * as MyServerAnalyticConnector from '/components/MyServerAnalyticConnector.jsx'
+   ```js
+   import * as MyServerAnalyticConnector from '/components/MyServerAnalyticConnector.jsx'
 
-...
+   ...
 
-export default renderHydrogen(App, {
-  shopifyConfig,
-  routes,
-  serverAnalyticConnectors: [MyServerAnalyticConnector]
-});
-```
+   export default renderHydrogen(App, {
+     shopifyConfig,
+     routes,
+     serverAnalyticConnectors: [MyServerAnalyticConnector]
+   });
+   ```
 
-{% endcodeblock %}
+   {% endcodeblock %}
 
-### ServerAnalyticConnector request function parameters
+#### Parameters
 
-| Parameter   | Type           | Description                            |
-| ----------- | -------------- | -------------------------------------- |
-| `request`    | request        | The analytic request object.            |
-| `data`        | object or text | The result from `.json()` or `.text()`. |
-| `contentType` | string         | The content type. Valid values: `json` or `text`.                       |
+The following table describes the request function parameters for `ServerAnalyticConnector`:
+
+| Parameter     | Type           | Description                                       |
+| ------------- | -------------- | ------------------------------------------------- |
+| `request`     | request        | The analytic request object.                      |
+| `data`        | object or text | The result from `.json()` or `.text()`.           |
+| `contentType` | string         | The content type. Valid values: `json` or `text`. |
 
 ## Unsubscribe from an analytic event
 
-You can unsubscribe from analytic events that you no longer want your Hydrogen app to track. For example:
+You can unsubscribe from analytic events that you no longer want your Hydrogen app to track. The following example shows how to unsubscribe from the `PAGE_VIEW` analytic event:
 
 {% codeblock file, filename: 'components/SomeComponent.client.jsx' %}
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -1,6 +1,6 @@
 Hydrogen includes support for analytics that give you insight into how customers are interacting with a custom storefront.
 
-This guide describes how to subscribe to the default events that Hydrogen offers, configure custom events, send analytic data from the server-side, and unsubscribe from events. It also provides example implementations of client analytics connectors, and shows how to write an end-to-end (E2E) for testing analytics connectors.
+This guide describes how to subscribe to the default events that Hydrogen offers, configure custom events, send analytics data from the server-side, and unsubscribe from events. It also provides example implementations of client analytics connectors, and shows how to write an end-to-end (E2E) for testing analytics connectors.
 
 ## Default events
 
@@ -21,11 +21,11 @@ By default, Hydrogen publishes the following events to subscribers (`ClientAnaly
 
 Subscribe to an event to enable your Hydrogen app to listen for the event. The following steps describe how to subscribe to the `PAGE_VIEW` event.
 
-1. Create a new client component in the `/components` directory of your Hydrogen app. For example, `components/AnalyticListener.client.jsx`.
+1. Create a new client component in the `/components` directory of your Hydrogen app. For example, `components/AnalyticsListener.client.jsx`.
 
 2. In your client component, add the following code to subscribe to the event:
 
-   {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
+   {% codeblock file, filename: 'components/AnalyticsListener.client.jsx' %}
 
    ```jsx
    import {ClientAnalytics} from '@shopify/hydrogen/client';
@@ -34,7 +34,7 @@ Subscribe to an event to enable your Hydrogen app to listen for the event. The f
    export default function AnalyticsListener() {
      useEffect(() => {
        // Set up common page-specific data
-       ClientAnalytics.pushToPageAnalyticData({
+       ClientAnalytics.pushToPageAnalyticsData({
          userLocale: navigator.language,
        });
 
@@ -93,7 +93,7 @@ Aside from the [default events](#default-events) that Hydrogen supports, you can
 
 ### Retrieving data from other parts of your Hydrogen app
 
-You can collect analytic data wherever you make queries. For example, to gather information about the collection that a customer has interacted with, you can make `collectionName` and `collectionId` available when you receive the `PAGE_VIEW` event:
+You can collect analytics data wherever you make queries. For example, to gather information about the collection that a customer has interacted with, you can make `collectionName` and `collectionId` available when you receive the `PAGE_VIEW` event:
 
 {% codeblock file, filename: 'collections/[handle].server.js' %}
 
@@ -128,7 +128,7 @@ You can also capture events in client components. For example, when a customer m
 ```js
 // some.client.jsx
 useEffect(() => {
-  ClientAnalytics.pushToPageAnalyticData({
+  ClientAnalytics.pushToPageAnalyticsData({
     heroBanner: 'hero-1',
   });
 });
@@ -152,28 +152,28 @@ const serverDataLayer = useServerAnalytics();
 
 {% endcodeblock %}
 
-The following example shows how to retrieve analytic data from a client component:
+The following example shows how to retrieve analytics data from a client component:
 
 {% codeblock file, filename: '*.client.js' %}
 
 ```js
-ClientAnalytics.getPageAnalyticData();
+ClientAnalytics.getPageAnalyticsData();
 ```
 
 {% endcodeblock %}
 
 > Caution:
-> Don't use the data from `ClientAnalytics.getPageAnalyticData()` for rendering. This will cause occasional mismatches during hydration.
+> Don't use the data from `ClientAnalytics.getPageAnalyticsData()` for rendering. This will cause occasional mismatches during hydration.
 
-## Send analytic data from the server-side
+## Send analytics data from the server-side
 
-Some events are only available on the server, which makes sending analytic data from the server-side a good option. Server-side analytics monitor activities on the server itself and only process server-side information. Every request on your server is recorded in the server logs. You can send Shopify analytic data from the server-side because you know exactly what data you need to send.
+Some events are only available on the server, which makes sending analytics data from the server-side a good option. Server-side analytics monitor activities on the server itself and only process server-side information. Every request on your server is recorded in the server logs. You can send Shopify analytics data from the server-side because you know exactly what data you need to send.
 
-To send analytic data from the server-side, complete the following steps:
+To send analytics data from the server-side, complete the following steps:
 
-1. Create a client-side analytic listener that makes a fetch call to the `__event` endpoint.
+1. Create a client-side analytics listener that makes a fetch call to the `__event` endpoint.
 
-   {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
+   {% codeblock file, filename: 'components/AnalyticsListener.client.jsx' %}
 
    ```jsx
    import {ClientAnalytics} from '@shopify/hydrogen/client';
@@ -182,7 +182,7 @@ To send analytic data from the server-side, complete the following steps:
    export default function AnalyticsListener() {
      useEffect(() => {
        // Set up common page-specific data
-       ClientAnalytics.pushToPageAnalyticData({
+       ClientAnalytics.pushToPageAnalyticsData({
          userLocale: navigator.language,
        });
 
@@ -215,13 +215,13 @@ To send analytic data from the server-side, complete the following steps:
 
    {% endcodeblock %}
 
-2. Create a server-side analytic connector and pass it into the `serverAnalyticConnectors` configuration:
+2. Create a server-side analytics connector and pass it into the `serverAnalyticsConnectors` configuration:
 
-   {% codeblock file, filename: 'MyServerAnalyticConnector.jsx' %}
+   {% codeblock file, filename: 'MyServerAnalyticsConnector.jsx' %}
 
    ```jsx
    export function request(request, data, contentType) {
-     // Send your analytic request to third-party analytics
+     // Send your analytics request to third-party analytics
    }
    ```
 
@@ -230,14 +230,14 @@ To send analytic data from the server-side, complete the following steps:
    {% codeblock file, filename: 'App.server.js' %}
 
    ```js
-   import * as MyServerAnalyticConnector from '/components/MyServerAnalyticConnector.jsx'
+   import * as MyServerAnalyticsConnector from '/components/MyServerAnalyticsConnector.jsx'
 
    ...
 
    export default renderHydrogen(App, {
     shopifyConfig,
     routes,
-    serverAnalyticConnectors: [MyServerAnalyticConnector]
+    serverAnalyticsConnectors: [MyServerAnalyticsConnector]
    });
    ```
 
@@ -245,11 +245,11 @@ To send analytic data from the server-side, complete the following steps:
 
 #### Parameters
 
-The following table describes the request function parameters for `ServerAnalyticConnector`:
+The following table describes the request function parameters for `ServerAnalyticsConnector`:
 
 | Parameter     | Type           | Description                                       |
 | ------------- | -------------- | ------------------------------------------------- |
-| `request`     | request        | The analytic request object.                      |
+| `request`     | request        | The analytics request object.                     |
 | `data`        | object or text | The result from `.json()` or `.text()`.           |
 | `contentType` | string         | The content type. Valid values: `json` or `text`. |
 
@@ -386,7 +386,7 @@ describe('Google Analytics 4', () => {
   });
 
   it('should emit page_view', async () => {
-    // Wait for the Google Analytics 4 analytic network call
+    // Wait for the Google Analytics 4 network call
     const [request] = await Promise.all([
       // Test if the request matches a Google Analytics 4 analytic pixel
       session.page.waitForRequest((request) =>

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -14,7 +14,8 @@ By default, Hydrogen publishes the following events to subscribers (`ClientAnaly
 | `REMOVE_FROM_CART`      | A customer removes an item from their cart                   |
 | `DISCOUNT_CODE_UPDATED` | A discount code that a customer applies to a cart is updated |
 
-The event name constants are available in `ClientAnalytics.eventNames`.
+> Note:
+> The event name constants are available in `ClientAnalytics.eventNames`.
 
 ## Subscribe to an event
 
@@ -271,6 +272,91 @@ useEffect(() => {
     acceptMarketingSubscriber.unsubscribe();
   };
 });
+```
+
+{% endcodeblock %}
+
+## Example analytics connectors
+
+The following example shows an implementation of a client analytics connector with Google Tag Manager:
+
+{% codeblock file, filename: 'components/GoogleTagManager.client.jsx' %}
+
+```jsx
+import Analytics from 'analytics';
+import googleTagManager from '@analytics/google-tag-manager';
+import {useEffect} from 'react';
+
+let init = false;
+export default function GTM() {
+  useEffect(() => {
+    if (!init) {
+      // One-time initialization
+      Analytics({
+        app: 'hydrogen-app',
+        plugins: [
+          googleTagManager({
+            containerId: 'GTM-WLTS4QF',
+          }),
+        ],
+      });
+      init = true;
+    }
+  });
+  return null;
+}
+```
+
+{% endcodeblock %}
+
+The following example shows an implementation of a client analytics connector with Google Analytics:
+
+{% codeblock file, filename: 'components/GoogleAnalytics.client.jsx' %}
+
+```jsx
+import {useEffect} from 'react';
+import {ClientAnalytics, loadScript} from '@shopify/hydrogen/client';
+
+const URL = 'https://www.googletagmanager.com/gtag/js?id=G-39VXD1NQYB';
+let isInit = false;
+
+export function GoogleAnalytics() {
+  useEffect(() => {
+    if (!isInit) {
+      isInit = true;
+
+      loadScript(URL).catch(() => {});
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-39VXD1NQYB', {
+        send_page_view: false,
+      });
+
+      ClientAnalytics.subscribe('page-view', (payload) => {
+        console.log('Google analytic page-view', payload);
+        gtag('event', 'page_view');
+      });
+    }
+  }, [isInit]);
+
+  return null;
+}
+```
+
+{% endcodeblock %}
+
+## Testing analytics
+
+The following example shows how to write an end-to-end (E2E) test for analytics:
+
+{% codeblock file, filename: 'PLACEHOLDER NAME OF FILE' %}
+
+```jsx
+PLACEHOLDER FOR CODE
 ```
 
 {% endcodeblock %}

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -260,7 +260,7 @@ You can unsubscribe from events that you no longer want your Hydrogen app to tra
 
 ```jsx
 useEffect(() => {
-  const pageViewSubscriber = ClientAnalytics.subscribe(
+  const acceptMarketingSubscriber = ClientAnalytics.subscribe(
     'accepts-marketing',
     (payload) => {
       console.log(payload);
@@ -268,7 +268,7 @@ useEffect(() => {
   );
 
   return function cleanup() {
-    pageViewSubscriber.unsubscribe();
+    acceptMarketingSubscriber.unsubscribe();
   };
 });
 ```

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -389,13 +389,17 @@ describe('Google Analytics 4', () => {
   });
 
   it('should emit page_view', async () => {
+    // Wait for the ga4 analytic network call
     const [request] = await Promise.all([
+      // Test if request matches a ga4 analytic pixel
       session.page.waitForRequest((request) =>
         endpointRegex.test(request.url())
       ),
+      // Navigate to home page
       session.visit('/'),
     ]);
 
+    // Validate data on the ga4 analytic pixel
     const ga4Event = new URL(request.url());
     expect(ga4Event.searchParams.en).toEqual('page_view');
   }, 60000);

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -1,0 +1,179 @@
+Hydrogen includes support for analytics that give you insight into how customers are interacting with a custom storefront.
+
+This guide describes the analytic events that Hydrogen emits by default. It also explains how to subscribe to events, configure custom events, send analytic data from the server side, and unsubscribe from events.
+
+## Default analytic events
+
+By default, Hydrogen emits the following analytic events:
+
+- `page-view`: When a customer visits a storefront page
+- `add-to-cart`: When a customer adds an item to their cart
+- `update-cart`: When a customer updates an item in their cart
+- `remove-from-cart`: When a customer removes an item from their cart
+- `discount-code-updated`: When a discount code that a customer applies to a cart is updated
+
+## Subscribe to an analytic event
+
+You can subscribe to an analytic event to allow your Hydrogen app to listen for the event. The following steps describe how to subscribe to the `page-view` analytic event.
+
+1. Create a new client component in the `/components` directory of your Hydrogen app. For example, `components/AnalyticListener.client.jsx`.
+
+2. In your client component, add the following code to subscribe to the analytic event:
+
+   {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
+
+   ```js
+   import {ClientAnalytics} from '@shopify/hydrogen/client';
+
+   let init = false;
+   export default function AnalyticsListener() {
+     if (!init) {
+       ClientAnalytics.subscribe('page-view', (payload) => {
+         console.log(payload);
+       });
+       init = true;
+     }
+
+     return null;
+   }
+   ```
+
+   {% endcodeblock %}
+
+3. Add your client component to `App.server.jsx`, the main app component:
+
+   {% codeblock file, filename: 'App.server.jsx' %}
+
+   ```js
+   function App({routes}) {
+     return (
+       <>
+         <Suspense fallback={<LoadingFallback />}>...</Suspense>
+         <AnalyticsListener />
+       </>
+     );
+   }
+   ```
+
+   {% endcodeblock %}
+
+## Configure a custom analytic event
+
+Aside from the [default analytic events](#default-analytic-events) that Hydrogen supports, you can also configure custom analytic events. For example, you might have a promotional banner that displays on multiple pages.
+
+The following example shows how to configure a custom event to track the pages where a promotional banner is being clicked the most:
+
+{% codeblock file, filename: 'components/CustomAnalyticListener.client.jsx' %}
+
+```js
+<Banner onClick={(event) => {
+  ClientAnalytics.publish('select_promotion', {
+    creative_name: "Summer Banner",
+    creative_slot: "featured_app_1",
+    ...
+  })
+}}
+```
+
+{% endcodeblock %}
+
+### Retrieving data from other parts of your Hydrogen app
+
+You might need data that's available elsewhere in your Hydrogen app. For example, the data you need might be available in other server and client components:
+
+{% codeblock file, filename: '*.server.js' %}
+
+```js
+useServerDatalayer({locale});
+```
+
+{% endcodeblock %}
+
+{% codeblock file, filename: '*.client.js' %}
+
+```js
+// some.client.jsx
+ClientAnalytics.pushToDataLayer({
+  heroBanner: 'hero-1',
+});
+```
+
+{% endcodeblock %}
+
+To retrieve the data that's available elsewhere in your Hydrogen app, you can add the following code to your server and client components:
+
+{% codeblock file, filename: '*.server.js' %}
+
+```js
+const serverDataLayer = useServerDatalayer();
+```
+
+{% endcodeblock %}
+
+{% codeblock file, filename: '*.client.js' %}
+
+```js
+ClientAnalytics.getDataLayer();
+```
+
+{% endcodeblock %}
+
+## Send analytic data from the server side
+
+All events that are configured in client components are sent to the server using the `/__event` endpoint. You can listen to the `/__event` endpoint on the server side by supplying a server analytic connector:
+
+{% codeblock file, filename: 'MyServerAnalyticConnector.jsx' %}
+
+```js
+export function request(request: Request): void {
+  Promise.resolve(request.json())
+    .then((data) => {
+      if (data.eventname) {
+        console.log(data.eventname, data.payload);
+      }
+    })
+    .catch((error) => {
+      log.warn('Failed to resolve server analytics: ', error);
+    });
+}
+```
+
+{% endcodeblock %}
+
+{% codeblock file, filename: 'App.server.js' %}
+
+```js
+import * as MyServerAnalyticConnector from '/components/MyServerAnalyticConnector.jsx'
+
+...
+
+export default renderHydrogen(App, {
+  shopifyConfig,
+  routes,
+  serverAnalyticConnectors: [MyServerAnalyticConnector]
+});
+```
+
+{% endcodeblock %}
+
+## Unsubscribe from an analytic event
+
+You can unsubscribe from analytic events that you no longer want your Hydrogen app to track. For example, you can unsubscribe from the `page-view` event:
+
+{% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
+
+```js
+const pageViewSubscriber = ClientAnalytics.subscribe('page-view', (payload) => {
+  console.log(payload);
+});
+...
+// Some condition is met
+pageViewSubscriber.unsubscribe();
+```
+
+{% endcodeblock %}
+
+## Next steps
+
+- Learn about [React Server Components](/custom-storefronts/hydrogen/framework/react-server-components), an opinionated data-fetching and rendering workflow for React apps.
+- Learn how to customize the output of [SEO-related tags](/custom-storefronts/hydrogen/framework/seo) in your Hydrogen client and server components.

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -9,7 +9,7 @@ The following diagram describes how analytics data is processed on the server an
 ![Shows a diagram that describes how analytics data is processed on the server and client in Hydrogen](/assets/custom-storefronts/hydrogen/hydrogen-analytics.png)
 
 1. On the server, the `useServerAnalytics` hook collects data in a single render request.
-2. On the client, the data is streamed as part of the `Suspense` component. This single render request contains a `dataLayer` output, waits for all queries to complete, and triggers a `PAGE_VIEW` event.
+2. On the client, the data is streamed as part of the `Suspense` component. This single render request waits for all queries to complete, outputs the collected data from the server-side, and triggers a `PAGE_VIEW` event.
 
 3. Events can be published to external endpoints from the client or server-side:
 
@@ -27,7 +27,7 @@ By default, Hydrogen publishes the following events to subscribers (`ClientAnaly
 | `UPDATE_CART`           | A customer updates an item in their cart                     |
 | `REMOVE_FROM_CART`      | A customer removes an item from their cart                   |
 | `DISCOUNT_CODE_UPDATED` | A discount code that a customer applies to a cart is updated |
-| `VIEWED_PRODUCT`        | A customer views a product details page                      |
+| `VIEWED_PRODUCT`        | A customer views a product details page. This is set with `publishEventsOnNavigate` on product pages.                    |
 
 > Note:
 > The event name constants are available in `ClientAnalytics.eventNames`.
@@ -167,7 +167,7 @@ const serverDataLayer = useServerAnalytics();
 
 {% endcodeblock %}
 
-If you need to trigger different analytics events on navigation, then you can specify a list of analytics events
+If you need to trigger additional analytics events on navigation, then you can specify a list of analytics events
 to publish in your server component:
 
 {% codeblock file, filename: '*.server.js' %}
@@ -195,7 +195,7 @@ ClientAnalytics.getPageAnalyticsData();
 
 ## Send analytics data from the server-side
 
-Some events are only available on the server, which makes sending analytics data from the server-side a good option. Server-side analytics monitor activities on the server itself and only process server-side information. Every request on your server is recorded in the server logs. You can send Shopify analytics data from the server-side because you know exactly what data you need to send.
+Some data is only available on the server. For example, detailed information about how many API calls a single page render makes and how long each API call took is only available on the server. This is information that users don't need to see and helps development teams gain insights about performance. If this is your use case, then sending analytics data from the server-side a good option.
 
 To send analytics data from the server-side, complete the following steps:
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -221,7 +221,7 @@ To send analytics data from the server-side, complete the following steps:
            ClientAnalytics.eventNames.PAGE_VIEW,
            (payload) => {
              try {
-               fetch('/__event', {
+               ClientAnalytics.pushToServer({
                  method: 'post',
                  headers: {
                    'cache-control': 'no-cache',

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -165,8 +165,6 @@ const serverDataLayer = useServerAnalytics({
 
 {% endcodeblock %}
 
-> Caution:
-> Don't use the data from `useServerAnalytics()` for rendering. This will cause occasional mismatches during hydration.
 
 The following example shows how to retrieve analytics data from a client component:
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -1,30 +1,32 @@
 Hydrogen includes support for analytics that give you insight into how customers are interacting with a custom storefront.
 
-This guide describes the analytic events that Hydrogen emits by default. It also explains how to subscribe to events, configure custom events, send analytic data from the server side, and unsubscribe from events.
+This guide describes the events that Hydrogen publishes by default. It also explains how to subscribe to events, configure custom events, send analytic data from the server side, and unsubscribe from events.
 
-## Default analytic events
+## Default events
 
-By default, Hydrogen emits the following analytic events:
+By default, Hydrogen publishes the following events to subscribers (`ClientAnalytics.subscribe`):
 
-- `PAGE_VIEW`: When a customer visits a storefront page
-- `ADD_TO_CART`: When a customer adds an item to their cart
-- `UPDATE_CART`: When a customer updates an item in their cart
-- `REMOVE_FROM_CART`: When a customer removes an item from their cart
-- `DISCOUNT_CODE_UPDATED`: When a discount code that a customer applies to a cart is updated
+| Event name              | When the event is published                                  |
+| ----------------------- | ------------------------------------------------------------ |
+| `PAGE_VIEW`             | A customer visits a storefront page                          |
+| `ADD_TO_CART`           | A customer adds an item to their cart                        |
+| `UPDATE_CART`           | A customer updates an item in their cart                     |
+| `REMOVE_FROM_CART`      | A customer removes an item from their cart                   |
+| `DISCOUNT_CODE_UPDATED` | A discount code that a customer applies to a cart is updated |
 
 The event name constants are available in `ClientAnalytics.eventNames`.
 
-## Subscribe to an analytic event
+## Subscribe to an event
 
-You can subscribe to an analytic event to allow your Hydrogen app to listen for the event. The following steps describe how to subscribe to the `PAGE_VIEW` analytic event.
+Subscribe to an event to enable your Hydrogen app to listen for the event. The following steps describe how to subscribe to the `PAGE_VIEW` event.
 
 1. Create a new client component in the `/components` directory of your Hydrogen app. For example, `components/AnalyticListener.client.jsx`.
 
-2. In your client component, add the following code to subscribe to the analytic event:
+2. In your client component, add the following code to subscribe to the event:
 
    {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
 
-   ```js
+   ```jsx
    import {ClientAnalytics} from '@shopify/hydrogen/client';
 
    let init = false;
@@ -36,7 +38,7 @@ You can subscribe to an analytic event to allow your Hydrogen app to listen for 
        });
 
        if (!init) {
-         // One time initialization
+         // One-time initialization
          ClientAnalytics.subscribe(
            ClientAnalytics.eventNames.PAGE_VIEW,
            (payload) => {
@@ -53,11 +55,11 @@ You can subscribe to an analytic event to allow your Hydrogen app to listen for 
 
    {% endcodeblock %}
 
-3. Add your client component to `App.server.jsx`, the main app component:
+3. Add your client component to `App.server.jsx`, which is the main app component:
 
    {% codeblock file, filename: 'App.server.jsx' %}
 
-   ```js
+   ```jsx
    function App({routes}) {
      return (
        <>
@@ -70,15 +72,13 @@ You can subscribe to an analytic event to allow your Hydrogen app to listen for 
 
    {% endcodeblock %}
 
-## Configure a custom analytic event
+## Configure a custom event
 
-Aside from the [default analytic events](#default-analytic-events) that Hydrogen supports, you can also configure custom analytic events. For example, you might have a promotional banner that displays on multiple pages.
-
-The following example shows how to configure a custom event to track the pages where a promotional banner is being clicked the most:
+Aside from the [default events](#default-events) that Hydrogen supports, you can also configure custom events. For example, you might want to configure a custom event that tracks the pages where a promotional banner is being clicked the most:
 
 {% codeblock file, filename: 'components/Banner.client.jsx' %}
 
-```js
+```jsx
 <Banner onClick={(event) => {
   ClientAnalytics.publish('select_promotion', {
     creative_name: "Summer Banner",
@@ -92,7 +92,7 @@ The following example shows how to configure a custom event to track the pages w
 
 ### Retrieving data from other parts of your Hydrogen app
 
-You can collect analytic data wherever you make queries. For example, you can make `collectionName` and `collectionId` available when you receive the `PAGE_VIEW` analytic event:
+You can collect analytic data wherever you make queries. For example, to gather information about the collection that a customer has interacted with, you can make `collectionName` and `collectionId` available when you receive the `PAGE_VIEW` event:
 
 {% codeblock file, filename: 'collections/[handle].server.js' %}
 
@@ -109,6 +109,8 @@ const {data} = useShopQuery({
 
 const collection = data.collection;
 
+// Use the `useServerAnalytics` hook to supply data
+// when events are published
 useServerAnalytics({
   canonicalPageUrl: `/collections/${handle}`,
   collectionName: collection.title,
@@ -118,7 +120,7 @@ useServerAnalytics({
 
 {% endcodeblock %}
 
-You can also add to page analytic data from client components:
+You can also capture events in client components. For example, when a customer makes a query, such as adding an item to their cart, or clicking on a promotional banner, you can capture the event in your client component:
 
 {% codeblock file, filename: '*.client.js' %}
 
@@ -162,7 +164,9 @@ ClientAnalytics.getPageAnalyticData();
 > Caution:
 > Don't use the data from `ClientAnalytics.getPageAnalyticData()` for rendering. This will cause occasional mismatches during hydration.
 
-## Send analytic data from the server side
+## Send analytic data from the server-side
+
+Some events are only available on the server, which makes sending analytic data from the server-side a good option. Server-side analytics monitor activities on the server itself and only process server-side information. Every request on your server is recorded in the server logs. You can send Shopify analytic data from the server-side because you know exactly what data you need to send.
 
 To send analytic data from the server-side, complete the following steps:
 
@@ -170,7 +174,7 @@ To send analytic data from the server-side, complete the following steps:
 
    {% codeblock file, filename: 'components/AnalyticListener.client.jsx' %}
 
-   ```js
+   ```jsx
    import {ClientAnalytics} from '@shopify/hydrogen/client';
 
    let init = false;
@@ -182,7 +186,7 @@ To send analytic data from the server-side, complete the following steps:
        });
 
        if (!init) {
-         // One time initialization
+         // One-time initialization
          ClientAnalytics.subscribe(
            ClientAnalytics.eventNames.PAGE_VIEW,
            (payload) => {
@@ -214,7 +218,7 @@ To send analytic data from the server-side, complete the following steps:
 
    {% codeblock file, filename: 'MyServerAnalyticConnector.jsx' %}
 
-   ```js
+   ```jsx
    export function request(request, data, contentType) {
      // Send your analytic request to third-party analytics
    }
@@ -248,9 +252,9 @@ The following table describes the request function parameters for `ServerAnalyti
 | `data`        | object or text | The result from `.json()` or `.text()`.           |
 | `contentType` | string         | The content type. Valid values: `json` or `text`. |
 
-## Unsubscribe from an analytic event
+## Unsubscribe from an event
 
-You can unsubscribe from analytic events that you no longer want your Hydrogen app to track. The following example shows how to unsubscribe from the `PAGE_VIEW` analytic event:
+You can unsubscribe from events that you no longer want your Hydrogen app to track. The following example shows how to unsubscribe from the `PAGE_VIEW` event:
 
 {% codeblock file, filename: 'components/SomeComponent.client.jsx' %}
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -1,6 +1,6 @@
 Hydrogen includes support for analytics that give you insight into how customers are interacting with a custom storefront.
 
-This guide describes the events that Hydrogen publishes by default. It also explains how to subscribe to events, configure custom events, send analytic data from the server side, and unsubscribe from events.
+This guide describes how to subscribe to the default events that Hydrogen offers, configure custom events, send analytic data from the server-side, and unsubscribe from events. It also provides example implementations of client analytics connectors, and shows how to write an end-to-end (E2E) for testing analytics connectors.
 
 ## Default events
 
@@ -139,7 +139,7 @@ useEffect(() => {
 > Note:
 > All `ClientAnalytics.*` function calls must be wrapped in a [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hook.
 
-To retrieve the data that's available elsewhere in your Hydrogen app, you can add the following code to your server and client components:
+To retrieve the data that's available elsewhere in your Hydrogen app, you can add the following code to your server components:
 
 {% codeblock file, filename: '*.server.js' %}
 
@@ -235,9 +235,9 @@ To send analytic data from the server-side, complete the following steps:
    ...
 
    export default renderHydrogen(App, {
-     shopifyConfig,
-     routes,
-     serverAnalyticConnectors: [MyServerAnalyticConnector]
+    shopifyConfig,
+    routes,
+    serverAnalyticConnectors: [MyServerAnalyticConnector]
    });
    ```
 
@@ -278,8 +278,7 @@ useEffect(() => {
 
 ## Example analytics connectors
 
-The following example shows an implementation of a client analytics connector with
-[Google Analytics 4](https://developers.google.com/analytics/devguides/collection/ga4):
+The following example shows an implementation of a client analytics connector with [Google Analytics 4](https://developers.google.com/analytics/devguides/collection/ga4):
 
 {% codeblock file, filename: 'components/GoogleAnalytics.client.jsx' %}
 
@@ -327,8 +326,7 @@ export function GoogleAnalytics() {
 
 {% endcodeblock %}
 
-The following example shows an implementation of a client analytics connector using
-[getanalytics.io Google Tag Manager package](https://getanalytics.io/plugins/google-tag-manager/)
+The following example shows an implementation of a client analytics connector using the [getanalytics.io Google Tag Manager package](https://getanalytics.io/plugins/google-tag-manager/):
 
 {% codeblock file, filename: 'components/GoogleTagManager.client.jsx' %}
 
@@ -359,10 +357,9 @@ export default function GTM() {
 
 {% endcodeblock %}
 
-## Testing analytics
+### Testing analytics connectors
 
-The following example shows how to write an end-to-end (E2E) test for Google Analytics 4.
-This will work for Google Tag Manager if configured with Google Analytic 4:
+The following example shows how to write an end-to-end (E2E) test for Google Analytics 4. This test will also work for Google Tag Manager if you've configured it with Google Analytics 4:
 
 {% codeblock file, filename: 'tests/e2e/analytics.ga4.test.js' %}
 
@@ -389,17 +386,17 @@ describe('Google Analytics 4', () => {
   });
 
   it('should emit page_view', async () => {
-    // Wait for the ga4 analytic network call
+    // Wait for the Google Analytics 4 analytic network call
     const [request] = await Promise.all([
-      // Test if request matches a ga4 analytic pixel
+      // Test if the request matches a Google Analytics 4 analytic pixel
       session.page.waitForRequest((request) =>
         endpointRegex.test(request.url())
       ),
-      // Navigate to home page
+      // Navigate to the home page
       session.visit('/'),
     ]);
 
-    // Validate data on the ga4 analytic pixel
+    // Validate data on the Google Analytics 4 analytic pixel
     const ga4Event = new URL(request.url());
     expect(ga4Event.searchParams.en).toEqual('page_view');
   }, 60000);

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -152,8 +152,8 @@ const serverDataLayer = useServerAnalytics();
 
 {% endcodeblock %}
 
-If you need to trigger a different analytics event on navigation, you can specify a list of analytics events
-to publish in the server analytics:
+If you need to trigger different analytics events on navigation, then you can specify a list of analytics events
+to publish in your server component:
 
 {% codeblock file, filename: '*.server.js' %}
 
@@ -163,10 +163,10 @@ const serverDataLayer = useServerAnalytics({
 });
 ```
 
+{% endcodeblock %}
+
 > Caution:
 > Don't use the data from `useServerAnalytics()` for rendering. This will cause occasional mismatches during hydration.
-
-{% endcodeblock %}
 
 The following example shows how to retrieve analytics data from a client component:
 

--- a/packages/hydrogen/src/framework/docs/analytics.md
+++ b/packages/hydrogen/src/framework/docs/analytics.md
@@ -20,14 +20,14 @@ The following diagram describes how analytics data is processed on the server an
 
 By default, Hydrogen publishes the following events to subscribers (`ClientAnalytics.subscribe`):
 
-| Event name              | When the event is published                                  |
-| ----------------------- | ------------------------------------------------------------ |
-| `PAGE_VIEW`             | A customer visits a storefront page                          |
-| `ADD_TO_CART`           | A customer adds an item to their cart                        |
-| `UPDATE_CART`           | A customer updates an item in their cart                     |
-| `REMOVE_FROM_CART`      | A customer removes an item from their cart                   |
-| `DISCOUNT_CODE_UPDATED` | A discount code that a customer applies to a cart is updated |
-| `VIEWED_PRODUCT`        | A customer views a product details page. This is set with `publishEventsOnNavigate` on product pages.                    |
+| Event name              | When the event is published                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `PAGE_VIEW`             | A customer visits a storefront page                                                                   |
+| `ADD_TO_CART`           | A customer adds an item to their cart                                                                 |
+| `UPDATE_CART`           | A customer updates an item in their cart                                                              |
+| `REMOVE_FROM_CART`      | A customer removes an item from their cart                                                            |
+| `DISCOUNT_CODE_UPDATED` | A discount code that a customer applies to a cart is updated                                          |
+| `VIEWED_PRODUCT`        | A customer views a product details page. This is set with `publishEventsOnNavigate` on product pages. |
 
 > Note:
 > The event name constants are available in `ClientAnalytics.eventNames`.
@@ -54,8 +54,8 @@ Subscribe to an event to enable your Hydrogen app to listen for the event. The f
        });
 
        if (!init) {
-         init = true;
          // One-time initialization
+         init = true;
          ClientAnalytics.subscribe(
            ClientAnalytics.eventNames.PAGE_VIEW,
            (payload) => {
@@ -215,8 +215,8 @@ To send analytics data from the server-side, complete the following steps:
        });
 
        if (!init) {
-         init = true;
          // One-time initialization
+         init = true;
          ClientAnalytics.subscribe(
            ClientAnalytics.eventNames.PAGE_VIEW,
            (payload) => {
@@ -367,8 +367,8 @@ let init = false;
 export default function GTM() {
   useEffect(() => {
     if (!init) {
-      init = true;
       // One-time initialization
+      init = true;
       Analytics({
         app: 'hydrogen-app',
         plugins: [

--- a/packages/hydrogen/src/framework/docs/pages.md
+++ b/packages/hydrogen/src/framework/docs/pages.md
@@ -143,13 +143,11 @@ The `redirect` function accepts a `location` URL and an optional `statusCode`, w
 {% codeblock file %}
 
 ```jsx
+// This redirect function only supports initial server-rendered page responses. It doesn't yet support client-navigated responses.
 return response.redirect('https://yoursite.com/new-page', 301);
 ```
 
 {% endcodeblock %}
-
-> Note:
-> This redirect method only supports initial server-rendered page responses. It does not yet support client-navigated responses.
 
 > Caution:
 > You must call `return response.redirect()` before any calls to `useQuery` or `useShopQuery` to prevent streaming while the Suspense data is resolved, or use `response.doNotStream()` to prevent streaming altogether on the response. The value must also be returned.

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -385,6 +385,13 @@ async function runHydrogenGenerator(args: Partial<Options> = {}) {
       entry: 'framework/docs/cache.md',
     }),
     generator.section({
+      title: 'Analytics',
+      description:
+        'Learn about the analytics support build into Hydrogen apps.',
+      url: '/custom-storefronts/hydrogen/framework/analytics.md',
+      entry: 'framework/docs/analytics.md',
+    }),
+    generator.section({
       title: 'Preloaded queries',
       description:
         'Learn how to configure queries to preload in your Hydrogen app.',


### PR DESCRIPTION
## This PR: 
- Adds a new framework topic to the Hydrogen docs that does the following:
  - Describes the analytic events that Hydrogen emits by default
  - Explains how to subscribe to events, configure custom events, send analytic data from the server side, and unsubscribe from events
- Relates to https://github.com/Shopify/shopify-dev/pull/17920, https://github.com/Shopify/hydrogen/pull/890, https://github.com/Shopify/hydrogen/pull/1016, https://github.com/Shopify/hydrogen/pull/934, and https://github.com/Shopify/hydrogen/pull/1029

### Tophatted

![screencapture-shopify-dev-myshopify-io-custom-storefronts-hydrogen-framework-analytics-2022-04-11-12_13_02](https://user-images.githubusercontent.com/65373971/162812790-d6e390c3-4cdd-4e2f-8157-21102e3acaeb.png)


