### PR TITLE
Fix RSC Redirects 

### DIFF
--- a/.changeset/fair-yaks-hug.md
+++ b/.changeset/fair-yaks-hug.md
@@ -1,0 +1,19 @@
+---
+'@shopify/hydrogen': patch
+'create-hydrogen-app': patch
+---
+
+Fix server redirects to work properly with RSC responses. For example, the redirect component within the starter template needs to change:
+
+```diff
+export default function Redirect({response}) {
+-  response.redirect('/products/snowboard');
+-  return <div>This page is redirected</div>;
++  return response.redirect('/products/snowboard');
+}
+```
+
+This server component is rendered two ways:
+
+1. When an app directly loads the redirect route, the server will render a 300 redirect with the proper location header.
+2. The app is already loaded, but the user navigates to the redirected route. We cannot 300 respond in this scenario, instead `response.redirect(...)` returns a component which will redirect on the client.

--- a/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
@@ -1,4 +1,4 @@
-import {Link, useShopQuery, Seo, useRouteParams} from '@shopify/hydrogen';
+import {useShopQuery, Seo, useRouteParams} from '@shopify/hydrogen';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';

--- a/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
+++ b/examples/template-hydrogen-default/src/routes/products/[handle].server.jsx
@@ -1,4 +1,4 @@
-import {useShopQuery, Seo, useRouteParams} from '@shopify/hydrogen';
+import {Link, useShopQuery, Seo, useRouteParams} from '@shopify/hydrogen';
 import gql from 'graphql-tag';
 
 import ProductDetails from '../../components/ProductDetails.client';

--- a/examples/template-hydrogen-default/src/routes/redirect.server.jsx
+++ b/examples/template-hydrogen-default/src/routes/redirect.server.jsx
@@ -1,4 +1,3 @@
 export default function Redirect({response}) {
-  response.redirect('/products/snowboard');
-  return <div>This page is redirected</div>;
+  return response.redirect('/products/snowboard');
 }

--- a/packages/hydrogen/src/foundation/Redirect/Redirect.client.tsx
+++ b/packages/hydrogen/src/foundation/Redirect/Redirect.client.tsx
@@ -9,7 +9,7 @@ export default function Redirect({to}: RedirectProps) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (to.startsWith('http') || to.startsWith('https')) {
+    if (to.startsWith('http')) {
       window.location.href = to;
     } else {
       navigate(to);

--- a/packages/hydrogen/src/foundation/Redirect/Redirect.client.tsx
+++ b/packages/hydrogen/src/foundation/Redirect/Redirect.client.tsx
@@ -1,5 +1,5 @@
 import {useEffect} from 'react';
-import {useNavigate} from '../../client';
+import {useNavigate} from '../../foundation/useNavigate/useNavigate';
 
 type RedirectProps = {
   to: string;

--- a/packages/hydrogen/src/foundation/Redirect/Redirect.client.tsx
+++ b/packages/hydrogen/src/foundation/Redirect/Redirect.client.tsx
@@ -1,0 +1,20 @@
+import {useEffect} from 'react';
+import {useNavigate} from '../../client';
+
+type RedirectProps = {
+  to: string;
+};
+
+export default function Redirect({to}: RedirectProps) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (to.startsWith('http') || to.startsWith('https')) {
+      window.location.href = to;
+    } else {
+      navigate(to);
+    }
+  }, []);
+
+  return null;
+}

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentResponse.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentResponse.server.ts
@@ -56,7 +56,10 @@ export class ServerComponentResponse extends Response {
   }
 
   redirect(location: string, status = 307) {
+    // writeHead is used for SSR, so that the server responds with a redirect
     this.writeHead({status, headers: {location}});
+
+    // in the case of an RSC request, instead render a client component that will redirect
     return React.createElement(Redirect, {to: location});
   }
 

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentResponse.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentResponse.server.ts
@@ -1,6 +1,8 @@
 import {renderToString} from 'react-dom/server';
 import {CacheSeconds, generateCacheControlHeader} from '../CachingStrategy';
 import type {CachingStrategy} from '../../types';
+import Redirect from '../../foundation/Redirect/Redirect.client';
+import React from 'react';
 
 export class ServerComponentResponse extends Response {
   private wait = false;
@@ -55,6 +57,7 @@ export class ServerComponentResponse extends Response {
 
   redirect(location: string, status = 307) {
     this.writeHead({status, headers: {location}});
+    return React.createElement(Redirect, {to: location});
   }
 
   /**

--- a/packages/hydrogen/src/framework/docs/pages.md
+++ b/packages/hydrogen/src/framework/docs/pages.md
@@ -126,7 +126,7 @@ export default function CustomPage({response}) {
 
 #### `response.redirect()`
 
-If you want to return users to a different URL, use `response.redirect()` in your server components. Make sure to return
+If you want to return users to a different URL, use `response.redirect()` in your server components.
 
 {% codeblock file %}
 

--- a/packages/hydrogen/src/framework/docs/pages.md
+++ b/packages/hydrogen/src/framework/docs/pages.md
@@ -126,15 +126,13 @@ export default function CustomPage({response}) {
 
 #### `response.redirect()`
 
-If you want to return users to a different URL, use `response.redirect()` in your server components.
+If you want to return users to a different URL, use `response.redirect()` in your server components. Make sure to return
 
 {% codeblock file %}
 
 ```jsx
 export default function PageThatShouldRedirect({response}) {
-  response.redirect('https://yoursite.com/new-page');
-
-  return <p>Redirecting...</p>;
+  return response.redirect('/new-page');
 }
 ```
 
@@ -145,7 +143,7 @@ The `redirect` function accepts a `location` URL and an optional `statusCode`, w
 {% codeblock file %}
 
 ```jsx
-response.redirect('https://yoursite.com/new-page', 301);
+return response.redirect('https://yoursite.com/new-page', 301);
 ```
 
 {% endcodeblock %}
@@ -154,7 +152,7 @@ response.redirect('https://yoursite.com/new-page', 301);
 > This redirect method only supports initial server-rendered page responses. It does not yet support client-navigated responses.
 
 > Caution:
-> You must call `response.redirect()` before any calls to `useQuery` or `useShopQuery` to prevent streaming while the Suspense data is resolved, or use `response.doNotStream()` to prevent streaming altogether on the response.
+> You must call `return response.redirect()` before any calls to `useQuery` or `useShopQuery` to prevent streaming while the Suspense data is resolved, or use `response.doNotStream()` to prevent streaming altogether on the response. The value must also be returned.
 
 #### `response.send()`
 

--- a/packages/playground/server-components/src/routes/index.server.jsx
+++ b/packages/playground/server-components/src/routes/index.server.jsx
@@ -14,6 +14,10 @@ export default function Index() {
       <Link className="btn" to="/about">
         About
       </Link>
+      <br />
+      <Link className="redirect-btn" to="/redirected">
+        Redirect
+      </Link>
     </>
   );
 }

--- a/packages/playground/server-components/src/routes/redirected.server.jsx
+++ b/packages/playground/server-components/src/routes/redirected.server.jsx
@@ -1,9 +1,3 @@
 export default function Redirected({response}) {
-  response.redirect('/about');
-
-  return (
-    <div>
-      <h1>This page has been moved to /about</h1>
-    </div>
-  );
+  return response.redirect('/about');
 }

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -45,8 +45,12 @@ export default async function testCases({
   });
 
   it('follows synchronous redirects', async () => {
-    await page.goto(getServerUrl() + '/redirected');
-    expect(await page.url()).toContain('/about');
+    await page.goto(getServerUrl() + '/');
+
+    await page.click('.redirect-btn');
+
+    await page.waitForURL('**/about');
+
     expect(await page.textContent('h1')).toContain('About');
   });
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -44,11 +44,15 @@ export default async function testCases({
     );
   });
 
-  it('follows synchronous redirects', async () => {
+  it('follows redirects from SSR responses', async () => {
+    await page.goto(getServerUrl() + '/redirected');
+    expect(await page.url()).toContain('/about');
+    expect(await page.textContent('h1')).toContain('About');
+  });
+
+  it('follows redirects in RSC responses', async () => {
     await page.goto(getServerUrl() + '/');
-
     await page.click('.redirect-btn');
-
     await page.waitForURL('**/about');
 
     expect(await page.textContent('h1')).toContain('About');


### PR DESCRIPTION
### Description

Fix RSC Redirects. Resolves #947 

### Additional context

Fix server redirects to work properly with RSC responses. For example, the redirect component within the starter template changes:

```diff
export default function Redirect({response}) {
-  response.redirect('/products/snowboard');
-  return <div>This page is redirected</div>;
+  return response.redirect('/products/snowboard');
}
```

This server component is executed two ways:

1. When an app directly loads the redirect route, the server will render a 300 redirect with the proper location header.
2. The app is already loaded, but the user navigates to the redirected route. We cannot 300 respond in this scenario, instead `response.redirect(...)` returns a component which will redirect on the client.

The redirect e2e test has been modified to cover this scenario.
