### PR TITLE
Add a health check after deploying

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -51,3 +51,7 @@ jobs:
         with:
           apiToken: ${{ secrets.DEPLOYMENT_CF_API_TOKEN }}
           workingDirectory: ./examples/template-hydrogen-default
+
+      - name: Run health check
+        run: |
+          yarn ts-node scripts/health-check.ts https://template-default.hydrogen-devs.workers.dev/

--- a/scripts/health-check.ts
+++ b/scripts/health-check.ts
@@ -1,0 +1,26 @@
+import * as https from 'https';
+import * as http from 'http';
+
+function checkHealth(url: string) {
+  return new Promise((resolve, reject) => {
+    const protocol = url.startsWith('https') ? https : http;
+    const req = protocol.get(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(
+          new Error(`${url} responded with status code ${res.statusCode}`)
+        );
+      }
+      res.resume();
+      console.log(`${url} is up!`);
+      resolve(true);
+    });
+    req.on('error', (e) => {
+      reject(e);
+    });
+    req.end();
+  });
+}
+
+const url = process.argv[2];
+
+checkHealth(url);

--- a/scripts/health-check.ts
+++ b/scripts/health-check.ts
@@ -17,7 +17,6 @@ function checkHealth(url: string) {
     req.on('error', (e) => {
       reject(e);
     });
-    req.end();
   });
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We deploy to Cloudflare (and soon to be others) as part of CI. This adds a simple health check to make sure the production deployment isn't returning a non-200 response. This could be expanded eventually to add more checks, perf tests, etc.