### PR TITLE
Change default cache in Oxygen entry point

### DIFF
--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -6,11 +6,6 @@ import entrypoint from '__SERVER_ENTRY__';
 // eslint-disable-next-line node/no-missing-import
 import indexTemplate from '__INDEX_TEMPLATE__?raw';
 
-interface CacheStorage {
-  open(cacheName: string): Promise<Cache>;
-  readonly default: Cache;
-}
-
 const handleRequest = entrypoint as RequestHandler;
 
 declare global {
@@ -34,7 +29,7 @@ export default {
     try {
       return (await handleRequest(request, {
         indexTemplate,
-        cache: (caches as unknown as CacheStorage).default,
+        cache: await caches.open(Oxygen.env.OXYGEN_DEPLOY_ID ?? 'default'),
         context,
       })) as Response;
     } catch (error: any) {

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -29,7 +29,7 @@ export default {
     try {
       return (await handleRequest(request, {
         indexTemplate,
-        cache: await caches.open(Oxygen.env.OXYGEN_DEPLOY_ID ?? 'default'),
+        cache: await caches.open('oxygen'),
         context,
       })) as Response;
     } catch (error: any) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Related: #990

`caches.default` is specific to CFW so this changes it to use web standard API instead.

As suggested, this is using an environment variable with the deployment ID (see discussion linked above for more information).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
