### PR TITLE
Allow empty array values in flattenConnection utility

### DIFF
--- a/.changeset/happy-planets-kneel.md
+++ b/.changeset/happy-planets-kneel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow empty array values in flattenConnection utility.

--- a/packages/hydrogen/src/utilities/flattenConnection/flattenConnection.ts
+++ b/packages/hydrogen/src/utilities/flattenConnection/flattenConnection.ts
@@ -7,12 +7,9 @@ import type {PartialDeep} from 'type-fest';
 export function flattenConnection<T>(
   connection: PartialDeep<GraphQLConnection<T>>
 ): PartialDeep<T>[] {
-  if (!connection.edges || connection.edges.length < 1) {
-    throw new Error('must have edges');
-  }
-  return connection.edges.map((edge) => {
+  return (connection.edges || []).map((edge) => {
     if (!edge?.node) {
-      throw new Error('must have node');
+      throw new Error('Connection edges must contain nodes');
     }
     return edge.node;
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #986 

It seems throwing errors on empty arrays is unnecessary and is causing issues in some cases.

Edit: @frehner oops, I just saw you assigned yourself to this issue an hour ago 😅 

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
