### PR TITLE
Allow server component banned hooks in shared components

### DIFF
--- a/.changeset/little-cheetahs-pay.md
+++ b/.changeset/little-cheetahs-pay.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-hydrogen': patch
+---
+
+Fixes the rule: `server-component-banned-hooks` to allow the banned hooks in shared components.

--- a/packages/eslint-plugin/src/rules/server-component-banned-hooks/server-component-banned-hooks.ts
+++ b/packages/eslint-plugin/src/rules/server-component-banned-hooks/server-component-banned-hooks.ts
@@ -1,7 +1,7 @@
 import {
   createRule,
   isHook,
-  isClientComponent,
+  isServerComponent,
   getHookName,
 } from '../../utilities';
 
@@ -33,7 +33,7 @@ export const serverComponentBannedHooks = createRule({
         const hook = getHookName(node);
 
         if (
-          !isClientComponent(context.getFilename()) &&
+          isServerComponent(context.getFilename()) &&
           isHook(node) &&
           BANNED_HOOKS.includes(hook)
         ) {

--- a/packages/eslint-plugin/src/rules/server-component-banned-hooks/tests/server-component-banned-hooks.test.ts
+++ b/packages/eslint-plugin/src/rules/server-component-banned-hooks/tests/server-component-banned-hooks.test.ts
@@ -90,6 +90,25 @@ ruleTester.run(
         `,
         filename: 'ServerComponent.server.tsx',
       },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useLayoutEffect(() => {});
+            useEffect(() => {});
+            return null;
+          }
+        `,
+        filename: 'ServerComponent.tsx',
+      },
+      {
+        code: dedent`
+          function ServerComponent() {
+            useEffect(() => {});
+            return null;
+          }
+        `,
+        filename: 'ServerComponent.tsx',
+      },
     ],
     invalid: [
       {
@@ -125,37 +144,6 @@ ruleTester.run(
       },
       {
         code: dedent`
-        function ServerComponent() {
-          const [state, setState] = useState();
-          return null;
-        }
-      `,
-        errors: [error('useState')],
-        filename: 'ServerComponent.tsx',
-      },
-      {
-        code: dedent`
-        function ServerComponent() {
-          const [state, dispatch] = useReducer(() => {}, {});
-          return null;
-        }
-      `,
-        errors: [error('useReducer')],
-        filename: 'ServerComponent.tsx',
-      },
-      {
-        code: dedent`
-        function ServerComponent() {
-          const [state, dispatch] = useReducer(() => {}, {});
-          const [state, setState] = useState();
-          return null;
-        }
-      `,
-        errors: [error('useReducer'), error('useState')],
-        filename: 'ServerComponent.tsx',
-      },
-      {
-        code: dedent`
           function ServerComponent() {
             useEffect(() => {});
             return null;
@@ -184,49 +172,6 @@ ruleTester.run(
         `,
         errors: [error('useEffect'), error('useLayoutEffect')],
         filename: 'ServerComponent.server.tsx',
-      },
-      {
-        code: dedent`
-          function ServerComponent() {
-            useEffect(() => {});
-            return null;
-          }
-        `,
-        errors: [error('useEffect')],
-        filename: 'ServerComponent.tsx',
-      },
-      {
-        code: dedent`
-          function ServerComponent() {
-            useEffect(() => {});
-            return null;
-          }
-        `,
-        errors: [error('useEffect')],
-        filename: 'ServerComponent.tsx',
-      },
-      {
-        code: dedent`
-          function ServerComponent() {
-            useLayoutEffect(() => {});
-            useEffect(() => {});
-            return null;
-          }
-        `,
-        errors: [error('useLayoutEffect'), error('useEffect')],
-        filename: 'ServerComponent.tsx',
-      },
-
-      {
-        code: dedent`
-          function ServerComponent() {
-            React.useLayoutEffect(() => {});
-            React.useEffect(() => {});
-            return null;
-          }
-        `,
-        errors: [error('useLayoutEffect'), error('useEffect')],
-        filename: 'ServerComponent.tsx',
       },
     ],
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

With the current logic `useState` would not be allowed in shared components. This modifies the conditional check for this rule to instead only block server components instead of requiring client components.

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
