### PR TITLE
Use secret SF API token and forward buyer IP

### DIFF
--- a/.changeset/sixty-mirrors-pump.md
+++ b/.changeset/sixty-mirrors-pump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Update useShopQuery to accept a custom Storefront API secret token, and forward the Buyer IP.

--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -211,6 +211,7 @@ async function handleEvent(event) {
       indexTemplate,
       cache: caches.default,
       context: event,
+      buyerIpHeader: 'cf-connecting-ip',
     });
   } catch (error) {
     return new Response(error.message || error.toString(), {status: 500});

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -66,6 +66,7 @@ interface RequestHandlerOptions {
   dev?: boolean;
   context?: RuntimeContext;
   nonce?: string;
+  buyerIpHeader?: string;
 }
 
 export interface RequestHandler {
@@ -80,9 +81,19 @@ export const renderHydrogen = (
 ) => {
   const handleRequest: RequestHandler = async function (
     rawRequest,
-    {indexTemplate, streamableResponse, dev, cache, context, nonce}
+    {
+      indexTemplate,
+      streamableResponse,
+      dev,
+      cache,
+      context,
+      nonce,
+      buyerIpHeader,
+    }
   ) {
     const request = new ServerComponentRequest(rawRequest);
+    request.ctx.buyerIpHeader = buyerIpHeader;
+
     const url = new URL(request.url);
     const log = getLoggerWithContext(request);
     const componentResponse = new ServerComponentResponse();

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
@@ -54,6 +54,7 @@ export class ServerComponentRequest extends Request {
     queryTimings: Array<QueryTiming>;
     preloadQueries: PreloadQueriesByURL;
     router: RouterContextData;
+    buyerIpHeader?: string;
     [key: string]: any;
   };
 
@@ -63,14 +64,7 @@ export class ServerComponentRequest extends Request {
     if (input instanceof Request) {
       super(input, init);
     } else {
-      super(getUrlFromNodeRequest(input), {
-        headers: new Headers(input.headers as {[key: string]: string}),
-        method: input.method,
-        body:
-          input.method !== 'GET' && input.method !== 'HEAD'
-            ? input.body
-            : undefined,
-      });
+      super(getUrlFromNodeRequest(input), getInitFromNodeRequest(input));
     }
 
     this.time = getTime();
@@ -135,6 +129,15 @@ export class ServerComponentRequest extends Request {
   public savePreloadQueries() {
     preloadCache.set(this.preloadURL, this.ctx.preloadQueries);
   }
+
+  /**
+   * Buyer IP varies by hosting provider and runtime. The developer should provide this
+   * as an argument to the `handleRequest` function for their runtime.
+   * Defaults to `x-forwarded-for` header value.
+   */
+  public getBuyerIp() {
+    return this.headers.get(this.ctx.buyerIpHeader ?? 'x-forwarded-for');
+  }
 }
 
 function mergeMapEntries(
@@ -169,4 +172,21 @@ function getUrlFromNodeRequest(request: any) {
   return new URL(
     `${secure ? 'https' : 'http'}://${request.headers.host! + url}`
   ).toString();
+}
+
+function getInitFromNodeRequest(request: any) {
+  const init = {
+    headers: new Headers(request.headers as {[key: string]: string}),
+    method: request.method,
+    body:
+      request.method !== 'GET' && request.method !== 'HEAD'
+        ? request.body
+        : undefined,
+  };
+
+  if (!init.headers.has('x-forwarded-for')) {
+    init.headers.set('x-forwarded-for', request.socket.remoteAddress);
+  }
+
+  return init;
 }

--- a/packages/hydrogen/src/framework/Hydration/tests/ServerComponentRequest.test.ts
+++ b/packages/hydrogen/src/framework/Hydration/tests/ServerComponentRequest.test.ts
@@ -6,22 +6,16 @@ import {
 } from '../ServerComponentRequest.server';
 
 it('converts node request to Fetch API request', () => {
-  // @ts-ignore
-  const nodeRequest = new IncomingMessage();
-  nodeRequest.headers = {'user-agent': 'Shopify Computer'};
-  nodeRequest.method = 'GET';
-
-  const request = new ServerComponentRequest(nodeRequest);
+  const request = createServerComponentRequest('/', {
+    'user-agent': 'Shopify Computer',
+  });
   expect(request.headers.get('user-agent')).toBe('Shopify Computer');
 });
 
 it('provides just a really nice interface for Cookies', () => {
-  // @ts-ignore
-  const nodeRequest = new IncomingMessage();
-  nodeRequest.headers = {cookie: 'shopifyCartId=12345; favoriteFruit=apple;'};
-  nodeRequest.method = 'GET';
-
-  const request = new ServerComponentRequest(nodeRequest);
+  const request = createServerComponentRequest('/', {
+    cookie: 'shopifyCartId=12345; favoriteFruit=apple;',
+  });
   expect(request.cookies.get('shopifyCartId')).toBe('12345');
 });
 
@@ -30,49 +24,12 @@ it('handles JSON serialized Cookies', () => {
   const productIds = ['productId1=', 'productId2='];
   const serializedProductIds = JSON.stringify(productIds);
 
-  // @ts-ignore
-  const nodeRequest = new IncomingMessage();
-  nodeRequest.headers = {
+  const request = createServerComponentRequest('/', {
     cookie: `shopifyCartId=12345; ${cookieKey}=${serializedProductIds}`,
-  };
-  nodeRequest.method = 'GET';
+  });
 
-  const request = new ServerComponentRequest(nodeRequest);
   expect(JSON.parse(request.cookies.get(cookieKey)!)).toStrictEqual(productIds);
 });
-
-function createServerComponentRequest(
-  url: string,
-  referer?: string
-): ServerComponentRequest {
-  // @ts-ignore
-  const nodeRequest = new IncomingMessage();
-  nodeRequest.method = 'GET';
-  nodeRequest.url = url;
-
-  if (referer) {
-    nodeRequest.headers = {
-      referer,
-    };
-  }
-
-  return new ServerComponentRequest(nodeRequest);
-}
-
-function createPreloadQueryEntry(
-  key: string,
-  preload?: PreloadOptions
-): PreloadQueryEntry {
-  return {
-    key: [key],
-    fetcher: createFetcher(key),
-    preload,
-  };
-}
-
-function createFetcher(data: unknown): () => Promise<unknown> {
-  return () => Promise.resolve(data);
-}
 
 it('does not save preload queries when preload key is not present', () => {
   const request = createServerComponentRequest(`https://localhost:3000/`);
@@ -122,3 +79,47 @@ it('get preload queries on sub-sequent load', () => {
     }
   `);
 });
+
+it('populates buyer IP using Node socket by default', () => {
+  const request = createServerComponentRequest('/', undefined, '123.4.5.6');
+
+  expect(request.getBuyerIp()).toBe('123.4.5.6');
+});
+
+it('allows buyer IP header to be overridden', () => {
+  const request = createServerComponentRequest('/', {foo: '234.5.6.7'});
+  request.ctx.buyerIpHeader = 'foo';
+
+  expect(request.getBuyerIp()).toBe('234.5.6.7');
+});
+
+function createServerComponentRequest(
+  url: string,
+  headers?: Record<string, string>,
+  remoteAddress?: string
+): ServerComponentRequest {
+  // @ts-ignore
+  const nodeRequest = new IncomingMessage();
+  nodeRequest.method = 'GET';
+  nodeRequest.url = url;
+  nodeRequest.headers = headers ?? {};
+  // @ts-ignore
+  nodeRequest.socket = {remoteAddress: remoteAddress ?? '127.0.0.1'};
+
+  return new ServerComponentRequest(nodeRequest);
+}
+
+function createPreloadQueryEntry(
+  key: string,
+  preload?: PreloadOptions
+): PreloadQueryEntry {
+  return {
+    key: [key],
+    fetcher: createFetcher(key),
+    preload,
+  };
+}
+
+function createFetcher(data: unknown): () => Promise<unknown> {
+  return () => Promise.resolve(data);
+}

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -181,7 +181,7 @@ function useCreateShopRequest(body: string, locale?: string) {
 
 function createErrorMessage(fetchError: Response | Error) {
   if (fetchError instanceof Response) {
-    `An error occurred while fetching from the Storefront API. ${
+    return `An error occurred while fetching from the Storefront API. ${
       // 403s to the SF API (almost?) always mean that your Shopify credentials are bad/wrong
       fetchError.status === 403
         ? `You may have a bad value in 'shopify.config.js'`

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -156,7 +156,10 @@ function useCreateShopRequest(body: string, locale?: string) {
     locale: defaultLocale,
   } = useShop();
 
+  const request = useServerRequest();
+
   const secretToken = Oxygen?.env?.SHOPIFY_STOREFRONT_API_SECRET_TOKEN;
+  const buyerIp = request.getBuyerIp();
 
   return {
     key: [storeDomain, storefrontApiVersion, body, locale],
@@ -166,6 +169,7 @@ function useCreateShopRequest(body: string, locale?: string) {
       method: 'POST',
       headers: {
         'X-Shopify-Storefront-Access-Token': secretToken ?? storefrontToken,
+        'Shopify-Storefront-Buyer-IP': buyerIp ?? '',
         'X-SDK-Variant': 'hydrogen',
         'X-SDK-Version': storefrontApiVersion,
         'content-type': 'application/json',

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -53,7 +53,7 @@ export function useShopQuery<T>({
   const log = getLoggerWithContext(serverRequest);
 
   const body = query ? graphqlRequestBody(query, variables) : '';
-  const {key, url, requestInit} = createShopRequest(body, locale);
+  const {key, url, requestInit} = useCreateShopRequest(body, locale);
 
   const {data, error: useQueryError} = useQuery<UseShopQueryResponse<T>>(
     key,
@@ -148,13 +148,15 @@ export function useShopQuery<T>({
   return data!;
 }
 
-function createShopRequest(body: string, locale?: string) {
+function useCreateShopRequest(body: string, locale?: string) {
   const {
     storeDomain,
     storefrontToken,
     storefrontApiVersion,
     locale: defaultLocale,
   } = useShop();
+
+  const secretToken = Oxygen?.env?.SHOPIFY_STOREFRONT_API_SECRET_TOKEN;
 
   return {
     key: [storeDomain, storefrontApiVersion, body, locale],
@@ -163,7 +165,7 @@ function createShopRequest(body: string, locale?: string) {
       body,
       method: 'POST',
       headers: {
-        'X-Shopify-Storefront-Access-Token': storefrontToken,
+        'X-Shopify-Storefront-Access-Token': secretToken ?? storefrontToken,
         'X-SDK-Variant': 'hydrogen',
         'X-SDK-Version': storefrontApiVersion,
         'content-type': 'application/json',

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -31,6 +31,7 @@ export default {
         indexTemplate,
         cache: await caches.open('oxygen'),
         context,
+        buyerIpHeader: 'oxygen-buyer-ip',
       })) as Response;
     } catch (error: any) {
       return new Response(error.message || error.toString(), {status: 500});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #971 

This PR modifies the behavior of `useShopQuery` to send along a secret SFAPI token if it's available in the current environment. It also forwards the buyer IP address as a header.

- Hydrogen looks for an environment variable called `SHOPIFY_STOREFRONT_API_SECRET_TOKEN`
- Hydrogen looks for a header on the incoming Oxygen request called `oxygen-buyer-ip`

### Additional context

The buyer IP address source varies based on the hosting runtime. In Node.js, it's generally accessible via `request.socket.remoteIp`. 

But other hosting platforms will proxy incoming traffic and add it to a header like `x-forwarded-for`. However, this header is sometimes used for other purposes depending on the hosting architecture, so we cannot rely on it be to an accurate Buyer IP.

Instead, we've added a `buyerIpHeader` to Hydrogen's `handleRequest` entry point, which is customized per hosting runtime. The default value is `x-forwarded-for`, but the developer should customize this to meet their needs.

The Hydrogen Node middleware has also been updated to populate the initial value of the `x-forwarded-for` header with the `request.socket.remoteIp` (if the header has not already been set).

Note: This feature of the Storefront API is yet to be documented, so we're holding off on adding Hydrogen docs for now.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
