### PR TITLE
Updates to copy and color in npx create flow

### DIFF
--- a/packages/create-hydrogen-app/index.js
+++ b/packages/create-hydrogen-app/index.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const argv = require('minimist')(process.argv.slice(2));
 const {prompt} = require('enquirer');
-const {yellow} = require('kolorist');
+const {cyan, green, yellow, red} = require('kolorist');
 const {copy} = require('./scripts/utils.js');
 
 const cwd = process.cwd();
@@ -35,7 +35,7 @@ async function init() {
 
   const packageName = await getValidPackageName(targetDir);
   const root = path.join(cwd, targetDir);
-  console.log(`\nScaffolding Hydrogen app in ${root}...`);
+  console.log(`\nWriting files...`);
 
   if (!fs.existsSync(root)) {
     fs.mkdirSync(root, {recursive: true});
@@ -48,14 +48,16 @@ async function init() {
       const {yes} = await prompt({
         type: 'confirm',
         name: 'yes',
-        initial: 'Y',
+        initial: false,
         message:
-          `Target directory ${targetDir} is not empty.\n` +
+          `Target directory ${yellow(targetDir + "/")} is not empty.\n` +
           `Remove existing files and continue?`,
       });
       if (yes) {
+        console.log(`Deleting files in ${yellow(targetDir + "/")}...`)
         emptyDir(root);
       } else {
+        console.log("Exiting. No files deleted.")
         return;
       }
     }
@@ -72,7 +74,7 @@ async function init() {
   // --template expects a value
   if (typeof template === 'string') {
     isValidTemplate = TEMPLATES.includes(template);
-    message = `${template} isn't a valid template. Please choose from below:`;
+    message = `${red(template)} isn't a valid template. Please choose from the available options:`;
   }
 
   if (!template || !isValidTemplate) {
@@ -138,15 +140,11 @@ async function init() {
 
   const pkgManager = /yarn/.test(process.env.npm_execpath) ? 'yarn' : 'npm';
 
-  console.log(`\nDone. Now:\n`);
-  console.log(
-    `  Update ${yellow(
-      packageName + '/shopify.config.js'
-    )} with the values for your storefront. If you want to test your Hydrogen app using the demo store, you can skip this step.`
-  );
-  console.log(`\nand then run:\n`);
+  console.log(`Created ${green(packageName)} in directory ${cwd}`);
+  console.log(`\nTo install your project dependencies and start your local `
+    + `development server, run these commands:\n`);
   if (root !== cwd) {
-    console.log(`  cd ${path.relative(cwd, root)}`);
+    console.log(cyan(`  cd ${path.relative(cwd, root)}`));
   }
 
   /**
@@ -155,9 +153,14 @@ async function init() {
    */
   const usesYarn = pkgManager === 'yarn' || process.env.LOCAL;
 
-  console.log(`  ${usesYarn ? `yarn` : `npm install --legacy-peer-deps`}`);
-  console.log(`  ${usesYarn ? `yarn dev` : `npm run dev`}`);
-  console.log();
+  console.log(cyan(`  ${usesYarn ? `yarn` : `npm install --legacy-peer-deps`}`));
+  console.log(cyan(`  ${usesYarn ? `yarn dev` : `npm run dev`}`));
+  console.log(
+    `\nYour project will display inventory from the Hydrogen Demo Store. `
+    + `To connect this project to your Shopify store's inventory instead, `
+    + `update ${yellow(packageName + '/shopify.config.js')} with your `
+    + `store ID and Storefront API key.\n`
+  );
 }
 
 async function getValidPackageName(projectName) {

--- a/packages/create-hydrogen-app/index.js
+++ b/packages/create-hydrogen-app/index.js
@@ -50,14 +50,14 @@ async function init() {
         name: 'yes',
         initial: false,
         message:
-          `Target directory ${yellow(targetDir + "/")} is not empty.\n` +
+          `Target directory ${yellow(targetDir + '/')} is not empty.\n` +
           `Remove existing files and continue?`,
       });
       if (yes) {
-        console.log(`Deleting files in ${yellow(targetDir + "/")}...`)
+        console.log(`Deleting files in ${yellow(targetDir + '/')}...`);
         emptyDir(root);
       } else {
-        console.log("Exiting. No files deleted.")
+        console.log('Exiting. No files deleted.');
         return;
       }
     }
@@ -74,7 +74,9 @@ async function init() {
   // --template expects a value
   if (typeof template === 'string') {
     isValidTemplate = TEMPLATES.includes(template);
-    message = `${red(template)} isn't a valid template. Please choose from the available options:`;
+    message = `${red(
+      template
+    )} isn't a valid template. Please choose from the available options:`;
   }
 
   if (!template || !isValidTemplate) {
@@ -141,8 +143,10 @@ async function init() {
   const pkgManager = /yarn/.test(process.env.npm_execpath) ? 'yarn' : 'npm';
 
   console.log(`Created ${green(packageName)} in directory ${cwd}`);
-  console.log(`\nTo install your project dependencies and start your local `
-    + `development server, run these commands:\n`);
+  console.log(
+    `\nTo install your project dependencies and start your local ` +
+      `development server, run these commands:\n`
+  );
   if (root !== cwd) {
     console.log(cyan(`  cd ${path.relative(cwd, root)}`));
   }
@@ -153,13 +157,15 @@ async function init() {
    */
   const usesYarn = pkgManager === 'yarn' || process.env.LOCAL;
 
-  console.log(cyan(`  ${usesYarn ? `yarn` : `npm install --legacy-peer-deps`}`));
+  console.log(
+    cyan(`  ${usesYarn ? `yarn` : `npm install --legacy-peer-deps`}`)
+  );
   console.log(cyan(`  ${usesYarn ? `yarn dev` : `npm run dev`}`));
   console.log(
-    `\nYour project will display inventory from the Hydrogen Demo Store. `
-    + `To connect this project to your Shopify store's inventory instead, `
-    + `update ${yellow(packageName + '/shopify.config.js')} with your `
-    + `store ID and Storefront API key.\n`
+    `\nYour project will display inventory from the Hydrogen Demo Store. ` +
+      `To connect this project to your Shopify store's inventory instead, ` +
+      `update ${yellow(packageName + '/shopify.config.js')} with your ` +
+      `store ID and Storefront API key.\n`
   );
 }
 

--- a/packages/create-hydrogen-app/template-hydrogen
+++ b/packages/create-hydrogen-app/template-hydrogen
@@ -1,1 +1,1 @@
-examples/template-hydrogen-default/
+../../examples/template-hydrogen-default


### PR DESCRIPTION
### Description

This PR updates the CLI flow when scaffolding a new Hydrogen project with npx. The goal is to align this command-line experience more closely with Shopify CLI, in terms of copy conventions and also colors:

- Commands to run = cyan
- Newly created project names = green
- File names to edit = yellow
- Invalid options to correct = red

Additionally, it updates the symbolic link to the Hydrogen template, which currently points to the wrong place.

## Screenshots:

### Create with project name prompt:
<img width="1207" alt="Screen Shot 2022-03-28 at 15 33 23" src="https://user-images.githubusercontent.com/547470/160474984-c8739892-571d-4744-ad37-3359a2925b41.png">

### Create by passing the name as an option:
<img width="1207" alt="Screen Shot 2022-03-28 at 15 33 50" src="https://user-images.githubusercontent.com/547470/160474989-0b8fe359-71a7-42a5-8592-74d49c1417f4.png">

### By default, don’t overwrite an existing project:
This is notable because the existing functionality defaults to Yes. A destructive option that permanently deletes data should default to No.
<img width="1207" alt="Screen Shot 2022-03-28 at 15 34 13" src="https://user-images.githubusercontent.com/547470/160474995-376714f6-27a5-4716-b165-6dc8858b270a.png">

### Overwrite an existing directory with the user's approval:
<img width="1207" alt="Screen Shot 2022-03-28 at 15 34 24" src="https://user-images.githubusercontent.com/547470/160474999-7736e280-0a1b-4733-826c-3d762d589548.png">

### Pass an invalid template flag
<img width="1207" alt="Screen Shot 2022-03-28 at 15 35 10" src="https://user-images.githubusercontent.com/547470/160475001-88a5b346-fe93-4e3f-98ca-849f93579e74.png">

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] ~Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)~
