### PR TITLE
Allow passing `cache` parameter to `createServer` in Node entry

### DIFF
--- a/.changeset/few-queens-shop.md
+++ b/.changeset/few-queens-shop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow passing `cache` parameter to `createServer` in Node entry.

--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -21,7 +21,6 @@ If you're using the default server entry point in the `build:server` script (`@s
 const {createServer} = require('./dist/server');
 
 createServer({
-  port: 8080,
   cache: customCacheImplementation,
 }).then(({app}) => {
   app.use(/* ... */);
@@ -32,7 +31,7 @@ createServer({
 });
 ```
 
-This function accepts a `port` and a [`cache` instance](https://developer.mozilla.org/en-US/docs/Web/API/Cache) as optional parameters.
+This function accepts an optional [`cache` instance](https://developer.mozilla.org/en-US/docs/Web/API/Cache) parameter.
 
 If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), then create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
 

--- a/docs/framework/deployment.md
+++ b/docs/framework/deployment.md
@@ -20,7 +20,10 @@ If you're using the default server entry point in the `build:server` script (`@s
 ```js
 const {createServer} = require('./dist/server');
 
-createServer().then(({app}) => {
+createServer({
+  port: 8080,
+  cache: customCacheImplementation,
+}).then(({app}) => {
   app.use(/* ... */);
 
   app.listen(3000, () => {
@@ -29,7 +32,9 @@ createServer().then(({app}) => {
 });
 ```
 
-If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), or if you want to supply a `cache` input to `hydrogenMiddleware` for [production caching](/custom-storefronts/hydrogen/framework/cache#caching-in-production), then create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
+This function accepts a `port` and a [`cache` instance](https://developer.mozilla.org/en-US/docs/Web/API/Cache) as optional parameters.
+
+If you want to use a different Node.js framework like [Express](https://expressjs.com/) or [Fastify](https://www.fastify.io/), then create a new server entry point (for example, `server.js`) and import `hydrogenMiddleware`:
 
 ```js
 import {hydrogenMiddleware} from '@shopify/hydrogen/middleware';

--- a/packages/hydrogen/src/platforms/node.ts
+++ b/packages/hydrogen/src/platforms/node.ts
@@ -19,10 +19,12 @@ import connect, {NextHandleFunction} from 'connect';
 const handleRequest = entrypoint as RequestHandler;
 
 type CreateServerOptions = {
+  cache?: Cache;
   port?: number | string;
 };
 
 export async function createServer({
+  cache,
   port = process.env.PORT || 8080,
 }: CreateServerOptions = {}) {
   // @ts-ignore
@@ -44,6 +46,7 @@ export async function createServer({
     hydrogenMiddleware({
       getServerEntrypoint: () => handleRequest,
       indexTemplate,
+      cache,
     })
   );
 

--- a/packages/hydrogen/src/platforms/node.ts
+++ b/packages/hydrogen/src/platforms/node.ts
@@ -20,13 +20,9 @@ const handleRequest = entrypoint as RequestHandler;
 
 type CreateServerOptions = {
   cache?: Cache;
-  port?: number | string;
 };
 
-export async function createServer({
-  cache,
-  port = process.env.PORT || 8080,
-}: CreateServerOptions = {}) {
+export async function createServer({cache}: CreateServerOptions = {}) {
   // @ts-ignore
   globalThis.Oxygen = {env: process.env};
 
@@ -50,11 +46,12 @@ export async function createServer({
     })
   );
 
-  return {app, port};
+  return {app};
 }
 
 if (require.main === module) {
-  createServer().then(({app, port}) => {
+  createServer().then(({app}) => {
+    const port = process.env.PORT || 8080;
     app.listen(port, () => {
       console.log(`Hydrogen server running at http://localhost:${port}`);
     });

--- a/packages/playground/server-components/start-node.js
+++ b/packages/playground/server-components/start-node.js
@@ -3,15 +3,16 @@
 const {createServer} = require('./dist/server');
 const {loadProdEnv} = require('./utils');
 
-function createServerWithEnv(port) {
+function createServerWithEnv() {
   return loadProdEnv().then((env) => {
     Object.assign(process.env, env);
-    return createServer({port});
+    return createServer();
   });
 }
 
 if (require.main === module) {
-  createServerWithEnv().then(({app, port}) => {
+  createServerWithEnv().then(({app}) => {
+    const port = 8080;
     // @ts-ignore
     app.listen(port, () => {
       console.log(`Hydrogen running at http://localhost:${port}`);

--- a/packages/playground/server-components/start-worker.js
+++ b/packages/playground/server-components/start-worker.js
@@ -3,7 +3,7 @@ const path = require('path');
 const {Miniflare} = require('miniflare');
 const {loadProdEnv} = require('./utils');
 
-async function createServer({port = 8080, root = process.cwd()} = {}) {
+async function createServer({root = process.cwd()} = {}) {
   const mf = new Miniflare({
     scriptPath: path.resolve(root, 'dist/worker/index.js'),
     sitePath: path.resolve(root, 'dist/client'),
@@ -12,15 +12,16 @@ async function createServer({port = 8080, root = process.cwd()} = {}) {
 
   const app = mf.createServer();
 
-  return {app, port};
+  return {app};
 }
 
 if (require.main === module) {
-  createServer().then(({app, port}) =>
+  createServer().then(({app}) => {
+    const port = 8080;
     app.listen(port, () => {
       console.log(`http://localhost:${port}`);
-    })
-  );
+    });
+  });
 }
 
 // for test use

--- a/packages/playground/server-components/tests/node-prod-e2e.serve.ts
+++ b/packages/playground/server-components/tests/node-prod-e2e.serve.ts
@@ -16,7 +16,7 @@ export async function serve(root: string, isProd: boolean) {
 
   // @ts-ignore
   const {createServer} = await import(resolve(root, 'start-node.js'));
-  const {app} = await createServer(port);
+  const {app} = await createServer();
 
   return new Promise((resolve, reject) => {
     try {

--- a/packages/playground/server-components/tests/worker-e2e.serve.ts
+++ b/packages/playground/server-components/tests/worker-e2e.serve.ts
@@ -16,7 +16,7 @@ export async function serve(root: string, isProd: boolean) {
 
   // @ts-ignore
   const {createServer} = await import(resolve(root, 'start-worker.js'));
-  const {app} = await createServer({port, root, isProd});
+  const {app} = await createServer({root, isProd});
 
   return new Promise((resolve, reject) => {
     try {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #976

Allow passing `cache` parameter to `createServer` in Node entry and remove redundant `port` (undocumented).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
