### PR TITLE
Make useShopQuery more lenient about missing Oxygen env

### DIFF
--- a/.github/deployments/cloudflare/worker.js
+++ b/.github/deployments/cloudflare/worker.js
@@ -37,6 +37,11 @@ async function handleEvent(event) {
       return await handleAsset(url, event);
     }
 
+    // TODO: Switch to module syntax and transfer args to Oxygen.env
+    if (!globalThis.Oxygen) {
+      globalThis.Oxygen = {};
+    }
+
     return await handleRequest(event.request, {
       indexTemplate,
       cache: caches.default,

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -163,7 +163,10 @@ function useCreateShopRequest(body: string, locale?: string) {
 
   const request = useServerRequest();
 
-  const secretToken = Oxygen?.env?.SHOPIFY_STOREFRONT_API_SECRET_TOKEN;
+  const secretToken =
+    typeof Oxygen !== 'undefined'
+      ? Oxygen?.env?.SHOPIFY_STOREFRONT_API_SECRET_TOKEN
+      : null;
   const buyerIp = request.getBuyerIp();
 
   return {


### PR DESCRIPTION

### Description

...and set Oxygen env in CD worker script.

This fixes our CD deploys to Cloudflare Workers for the time being.

I am going to revisit how we do runtime env vars in general, and probably switch to something like `process.env` (maybe).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->