### PR TITLE
Don't attach a buyer IP header if it's null

### DIFF
--- a/.changeset/strange-steaks-dress.md
+++ b/.changeset/strange-steaks-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix CORS issue in StackBlitz

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -162,12 +162,17 @@ function useCreateShopRequest(body: string, locale?: string) {
   } = useShop();
 
   const request = useServerRequest();
-
   const secretToken =
     typeof Oxygen !== 'undefined'
       ? Oxygen?.env?.SHOPIFY_STOREFRONT_API_SECRET_TOKEN
       : null;
   const buyerIp = request.getBuyerIp();
+
+  const extraHeaders = {} as Record<string, any>;
+
+  if (buyerIp) {
+    extraHeaders['Shopify-Storefront-Buyer-IP'] = buyerIp;
+  }
 
   return {
     key: [storeDomain, storefrontApiVersion, body, locale],
@@ -177,11 +182,11 @@ function useCreateShopRequest(body: string, locale?: string) {
       method: 'POST',
       headers: {
         'X-Shopify-Storefront-Access-Token': secretToken ?? storefrontToken,
-        'Shopify-Storefront-Buyer-IP': buyerIp ?? '',
         'X-SDK-Variant': 'hydrogen',
         'X-SDK-Version': storefrontApiVersion,
         'content-type': 'application/json',
         'Accept-Language': (locale as string) ?? defaultLocale,
+        ...extraHeaders,
       },
     },
   };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

StackBlitz is broken right now as of v0.13.1

<img width="806" alt="Screen Shot 2022-03-29 at 1 50 09 PM" src="https://user-images.githubusercontent.com/848147/160685011-d185626e-5b89-424a-b6f4-fc7ce1ec79c3.png">

This is because SB is actually running in browser. Fetch requests made from the browser have to adhere to CORS policies. Shopify's Storefront API does not yet acknowledge the new `shopify-storefront-buyer-ip`, so it's not yet in the list of `allowed-headers` for CORS. 

The inclusion of this IP breaks CORS, because the header is included in the outgoing request regardless of whether it is present.

This does not solve the _actual_ issue, which is to either remove Buyer IP or to add it to our allowed CORS headers. However, I'm OK with this because:

- StackBlitz does not provide a `x-forwarded-for` or `socket.remoteAddress` currently
- These requests will be made server-side, where CORS is not an issue