### PR TITLE
chore: GitHub action to announce new releases in Discord

### DIFF
--- a/.github/workflows/discord_announcement.yml
+++ b/.github/workflows/discord_announcement.yml
@@ -1,0 +1,25 @@
+name: Discord announcement
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    if: startsWith(github.event.release.tag_name, '@shopify/hydrogen@')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Hydrogen version as env
+        run: |
+          TAG=${{ github.event.release.tag_name }}
+          echo "HYDROGEN_VERSION=${TAG//@shopify\/hydrogen@/}" >> $GITHUB_ENV
+
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: Shopify Devs
+          DISCORD_AVATAR: https://cdn.discordapp.com/avatars/905537246990590012/0f6a687b93ef3f81a036c817fb02ccbf.webp
+        uses: Ilshidur/action-discord@08d9328877d6954120eef2b07abbc79249bb6210
+        with:
+          args: "Hydrogen ${{ env.HYDROGEN_VERSION }} has been released.\n${{ github.event.release.html_url }}"


### PR DESCRIPTION
### Description

:wave: Hey @jplhomer

This creates a new GH action to send a message to the `#hydrogen-announcements` channel on the Shopify Devs discord when a new release is published.

Can you think of a way to grab the version number by itself? Would be cool to show `Hydrogen 0.13.1 has been released` instead of `Hydrogen @shopify/hydrogen@0.13.1 has been released`

![image](https://user-images.githubusercontent.com/59898611/160707212-93da9543-b653-403e-801f-81734f708155.png)

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
