### PR TITLE
Do not cache responses that contain GraphQL errors

### DIFF
--- a/.changeset/fair-guests-speak.md
+++ b/.changeset/fair-guests-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Do not cache Storefront API responses that contain GraphQL errors (amend previous fix).

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -17,7 +17,8 @@ export interface UseShopQueryResponse<T> {
 }
 
 // Check if the response body has GraphQL errors
-const shouldCacheResponse = (body: any) => !(body?.error || body?.data?.errors);
+// https://spec.graphql.org/June2018/#sec-Response-Format
+const shouldCacheResponse = (body: any) => !body?.errors;
 
 /**
  * The `useShopQuery` hook allows you to make server-only GraphQL queries to the Storefront API. It must be a descendent of a `ShopifyProvider` component.

--- a/packages/hydrogen/src/hooks/useShopQuery/tests/useShopQuery.test.tsx
+++ b/packages/hydrogen/src/hooks/useShopQuery/tests/useShopQuery.test.tsx
@@ -74,7 +74,7 @@ describe('useShopQuery', () => {
   });
 
   it('handles GraphQL errors with OK status', async () => {
-    const errorResult = '{"data":{"errors":[{}]}}';
+    const errorResult = '{"errors":[{}]}';
     mockedFetch.mockResolvedValue(new Response(errorResult, {status: 200}));
     const component = await mountComponent();
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #993 (again)

This was first addressed in #1000 but looks like I added too many `data` wraps 😅 
According to the GraphQL spec, the `errors` property should only be present at the top level if there is at least one error. Can someone confirm this change in the unit tests is correct?

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
