### PR TITLE
Catch hydration errors and link to Hydrogen issue

### DIFF
--- a/.changeset/silly-wasps-hide.md
+++ b/.changeset/silly-wasps-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Catch hydration errors related to experimental server components bugs and prevent them from being logged in production.

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -42,7 +42,21 @@ const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
           <Content clientWrapper={ClientWrapper} />
         </Suspense>
       </ErrorBoundary>
-    </RootComponent>
+    </RootComponent>,
+    {
+      onRecoverableError(e: any) {
+        if (__DEV__) {
+          console.log(
+            `React encountered an error while attempting to hydrate the application. ` +
+              `This is likely due to a bug in React's Suspense behavior related to experimental server components, ` +
+              `and it is safe to ignore this error.\n` +
+              `Visit this issue to learn more: https://github.com/Shopify/hydrogen/issues/920.\n\n` +
+              `The original error is printed below:`
+          );
+          console.log(e);
+        }
+      },
+    }
   );
 };
 

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -34,6 +34,8 @@ const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
   // default to StrictMode on, unless explicitly turned off
   const RootComponent = config?.strictMode !== false ? StrictMode : Fragment;
 
+  let hasCaughtError = false;
+
   hydrateRoot(
     root,
     <RootComponent>
@@ -45,7 +47,8 @@ const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
     </RootComponent>,
     {
       onRecoverableError(e: any) {
-        if (__DEV__) {
+        if (__DEV__ && !hasCaughtError) {
+          hasCaughtError = true;
           console.log(
             `React encountered an error while attempting to hydrate the application. ` +
               `This is likely due to a bug in React's Suspense behavior related to experimental server components, ` +


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We see quite a few hydration errors right now related to Suspense and server components: #920 

<img width="1010" alt="Screen Shot 2022-04-03 at 11 19 04 AM" src="https://user-images.githubusercontent.com/848147/161437702-6c1d2a0b-a07d-4542-84a9-9821bace114d.png">

This is fine, because the client rendering of the server components response works just fine. However, it distracts developers and makes them think something is wrong with their application.

This PR leverages the [new`onRecoverableError` hook](https://reactjs.org/docs/react-dom-client.html#hydrateroot) to catch hydration errors. In development, we print out a message explaining that it's due to experimental bugs with a link to the Hydrogen issue. In production, nothing is printed, and the user isn't the wiser that any hydration error happened at all.

In development, the hydration error is still thrown in red above, but this is printed below:

<img width="975" alt="Screen Shot 2022-04-03 at 11 14 40 AM" src="https://user-images.githubusercontent.com/848147/161437717-a5685908-aaa9-4c90-989a-6d8465bfe753.png">

To tophat this, remove the Suspense boundary around the children inside `Layout.server.jsx`.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
