### PR TITLE
Remove old changeset to unblock release

### DIFF
--- a/.changeset/empty-yaks-burn.md
+++ b/.changeset/empty-yaks-burn.md
@@ -1,5 +1,0 @@
----
-'template-hydrogen-default': patch
----
-
-Isolated E2E tests


### PR DESCRIPTION
Manually clearing out this changeset because it is causing the [deployment GH action to fail](https://github.com/Shopify/hydrogen/actions/runs/2098196600). 