### PR TITLE
Restore scroll position on browser navigation

### DIFF
--- a/.changeset/green-vans-report.md
+++ b/.changeset/green-vans-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Restore scroll position when navigating using the back and forward buttons.

--- a/packages/hydrogen/src/components/Link/tests/Link.test.tsx
+++ b/packages/hydrogen/src/components/Link/tests/Link.test.tsx
@@ -69,6 +69,7 @@ describe('<Link />', () => {
       try {
         expect(args()).toEqual({
           pathname: '/products/hydrogen',
+          search: '',
         });
         done();
       } catch (e) {

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -6,7 +6,10 @@ import React, {
   useState,
   FC,
   useEffect,
+  useLayoutEffect,
+  useCallback,
 } from 'react';
+import type {ServerState} from '../ServerStateProvider';
 import {META_ENV_SSR} from '../ssr-interop';
 import {useServerState} from '../useServerState';
 
@@ -17,8 +20,8 @@ type RouterContextValue = {
 
 export const RouterContext = createContext<RouterContextValue | {}>({});
 
-let currentPath = '';
 let isFirstLoad = true;
+const positions: Record<string, number> = {};
 
 export const BrowserRouter: FC<{history?: BrowserHistory}> = ({
   history: pHistory,
@@ -30,30 +33,22 @@ export const BrowserRouter: FC<{history?: BrowserHistory}> = ({
   const [location, setLocation] = useState(history.location);
 
   const {pending, serverState, setServerState} = useServerState();
+  useScrollRestoration(location, pending, serverState);
 
-  useEffect(() => {
-    // The app has just loaded
-    if (isFirstLoad) isFirstLoad = false;
-    // A navigation event has just happened
-    else if (!pending && currentPath !== serverState.pathname) {
-      window.scrollTo(0, 0);
-    }
-
-    currentPath = serverState.pathname;
-  }, [pending]);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     const unlisten = history.listen(({location: newLocation}) => {
+      positions[location.key] = window.scrollY;
+
       setServerState({
         pathname: newLocation.pathname,
-        search: location.search || undefined,
+        search: location.search || '',
       });
 
       setLocation(newLocation);
     });
 
     return () => unlisten();
-  }, [history]);
+  }, [history, location]);
 
   return (
     <RouterContext.Provider
@@ -79,4 +74,82 @@ export function useRouter() {
 
 export function useLocation() {
   return useRouter().location;
+}
+
+/**
+ * Run a callback before browser unload.
+ */
+function useBeforeUnload(callback: () => any): void {
+  React.useEffect(() => {
+    window.addEventListener('beforeunload', callback);
+    return () => {
+      window.removeEventListener('beforeunload', callback);
+    };
+  }, [callback]);
+}
+
+function useScrollRestoration(
+  location: Location,
+  pending: boolean,
+  serverState: ServerState
+) {
+  /**
+   * Browsers have an API for scroll restoration. We wait for the page to load first,
+   * in case the browser is able to restore scroll position automatically, and then
+   * set it to manual mode.
+   */
+  useEffect(() => {
+    window.history.scrollRestoration = 'manual';
+  }, []);
+
+  /**
+   * If the page is reloading, allow the browser to handle its own scroll restoration.
+   */
+  useBeforeUnload(
+    useCallback(() => {
+      window.history.scrollRestoration = 'auto';
+    }, [])
+  );
+
+  useLayoutEffect(() => {
+    // The app has just loaded
+    if (isFirstLoad) {
+      isFirstLoad = false;
+      return;
+    }
+
+    const position = positions[location.key];
+
+    /**
+     * When serverState gets updated, `pending` is true while the fetch is in progress.
+     * When that resolves, the serverState is updated. We should wait until the internal
+     * location pointer and serverState match, and pending is false, to do any scrolling.
+     */
+    const finishedNavigating =
+      !pending &&
+      location.pathname === serverState.pathname &&
+      location.search === serverState.search;
+
+    if (!finishedNavigating) {
+      return;
+    }
+
+    // If there is a location hash, scroll to it
+    if (location.hash) {
+      const element = document.querySelector(location.hash);
+      if (element) {
+        element.scrollIntoView();
+        return;
+      }
+    }
+
+    // If we have a matching position, scroll to it
+    if (position) {
+      window.scrollTo(0, position);
+      return;
+    }
+
+    // Scroll to the top of new pages
+    window.scrollTo(0, 0);
+  }, [location, pending, serverState]);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This solves an issue where when you navigate to a new page in Hydrogen, it scrolls you to the top of the page, even for back button/etc. This is misaligned with native browser features, which restore the previous scroll position when you click back.

This PR also fixes #1010 

### Additional context

Inspired by Remix, we track a list of positions when the route changes, and we restore the position if there is a match.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
