### PR TITLE
Fix CLI tailwind config not being found in dev and build commands

### DIFF
--- a/.changeset/soft-snakes-explain.md
+++ b/.changeset/soft-snakes-explain.md
@@ -1,0 +1,5 @@
+---
+'create-hydrogen-app': patch
+---
+
+Support running the vite dev server from outside of root director by resolving the tailwind configuration from the directory of the hydrogen app being run.

--- a/examples/template-hydrogen-default/postcss.config.js
+++ b/examples/template-hydrogen-default/postcss.config.js
@@ -1,6 +1,10 @@
+const path = require('path');
+
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: {
+      config: path.join(__dirname, 'tailwind.config.js'),
+    },
     autoprefixer: {},
   },
 };

--- a/examples/template-hydrogen-default/tailwind.config.js
+++ b/examples/template-hydrogen-default/tailwind.config.js
@@ -1,5 +1,10 @@
+const path = require('path');
+
 module.exports = {
-  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  content: [
+    path.join(__dirname, './index.html'),
+    path.join(__dirname, './src/**/*.{js,jsx,ts,tsx}'),
+  ],
   theme: {
     extend: {
       typography: (theme) => ({


### PR DESCRIPTION
### Description

Support running the vite dev server from outside of root directory by resolving the tailwind configuration from the directory of the hydrogen app being run (instead of `process.cwd`).

### Additional context

Related to https://github.com/Shopify/shopify-cli-next/pull/62

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
