### PR TITLE
Fix link prefetch

### DIFF
--- a/.changeset/modern-swans-admire.md
+++ b/.changeset/modern-swans-admire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix link prefetch mismatch due to query-string

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -163,7 +163,7 @@ function Prefetch({pathname}: {pathname: string}) {
   const newLocation = new URL(newPath, window.location.href);
   const proposedServerState = getProposedServerState({
     pathname: newLocation.pathname,
-    search: newLocation.search || undefined,
+    search: newLocation.search,
   });
   const href =
     `${RSC_PATHNAME}?state=` +

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -41,7 +41,7 @@ export const BrowserRouter: FC<{history?: BrowserHistory}> = ({
 
       setServerState({
         pathname: newLocation.pathname,
-        search: location.search || '',
+        search: location.search,
       });
 
       setLocation(newLocation);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hovering a link right now prefetches `{pathname: '...'}`, but clicking it makes a new request to `{pathname:'...', search: ''}`. We should set both `search` parameters to either `undefined` or `''`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
