### PR TITLE
Allow line breaks inside script tags

### DIFF
--- a/.changeset/eleven-tips-accept.md
+++ b/.changeset/eleven-tips-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Support script tags in index.html that contain line breaks

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -7,7 +7,7 @@ export function stripScriptsFromTemplate(template: string) {
   const bootstrapModules = [] as string[];
 
   const scripts = template.matchAll(
-    /<script.+?src="(?<script>([^"]+?))".*?><\/script>/g
+    /<script.+?src="(?<script>([^"]+?))".*?><\/script>/gs
   );
 
   for (const match of scripts) {

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -7,7 +7,7 @@ export function stripScriptsFromTemplate(template: string) {
   const bootstrapModules = [] as string[];
 
   const scripts = template.matchAll(
-    /<script.+?src="(?<script>([^"]+?))".*?><\/script>/gs
+    /<script\n*?.+?src="(?<script>([^"]+?))"\n*.*?><\/script>/g
   );
 
   for (const match of scripts) {

--- a/packages/hydrogen/src/utilities/tests/template.test.ts
+++ b/packages/hydrogen/src/utilities/tests/template.test.ts
@@ -46,4 +46,26 @@ describe('getScriptsFromTemplate', () => {
     expect(bootstrapScripts).toHaveLength(0);
     expect(bootstrapModules).toHaveLength(0);
   });
+
+  it('identifies scripts with line breaks in them', () => {
+    const template = `<html><head>
+      <script src="/foo.js"></script>
+    </head>
+    <body>
+      <script src="/bar.js"></script>
+      <script src="/module.js"
+              type="module"></script>
+    </body></html>`;
+
+    const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
+      stripScriptsFromTemplate(template);
+
+    expect(noScriptTemplate).not.toMatch('<script');
+
+    expect(bootstrapScripts).toHaveLength(2);
+    expect(bootstrapScripts[0]).toBe('/foo.js');
+
+    expect(bootstrapModules).toHaveLength(1);
+    expect(bootstrapModules[0]).toBe('/module.js');
+  });
 });

--- a/packages/hydrogen/src/utilities/tests/template.test.ts
+++ b/packages/hydrogen/src/utilities/tests/template.test.ts
@@ -22,6 +22,28 @@ describe('getScriptsFromTemplate', () => {
     expect(bootstrapModules[0]).toBe('/module.js');
   });
 
+  it('identifies scripts and modules in a template even with script tag in head', () => {
+    const template = `<html><head>
+      <script type="module">
+        var foo = 'bar';
+      </script>
+      <script src="/foo.js"></script>
+    </head>
+    <body>
+      <script src="/bar.js"></script>
+      <script src="/module.js" type="module"></script>
+    </body></html>`;
+
+    const {bootstrapScripts, bootstrapModules} =
+      stripScriptsFromTemplate(template);
+
+    expect(bootstrapScripts).toHaveLength(2);
+    expect(bootstrapScripts[0]).toBe('/foo.js');
+
+    expect(bootstrapModules).toHaveLength(1);
+    expect(bootstrapModules[0]).toBe('/module.js');
+  });
+
   it('identifies varying orders of attributes in script tags', () => {
     const template = `<html><body>
       <script type="module" src="/src/entry-client.tsx"></script>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1052 

We add the `s` regex flag to consider new line characters in the `.+` matchers.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
