### PR TITLE
Fix encoding of CSS Modules to solve hydration errors

### DIFF
--- a/.changeset/little-bees-eat.md
+++ b/.changeset/little-bees-eat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix encoding of quotes in CSS Modules which caused hydration errors

--- a/examples/css-modules/src/routes/index.module.css
+++ b/examples/css-modules/src/routes/index.module.css
@@ -2,5 +2,5 @@
   padding: 1em;
   border: 2px solid black;
   background: #efefef;
-  content: "";
+  content: '';
 }

--- a/examples/css-modules/src/routes/index.module.css
+++ b/examples/css-modules/src/routes/index.module.css
@@ -2,4 +2,5 @@
   padding: 1em;
   border: 2px solid black;
   background: #efefef;
+  content: "";
 }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -26,9 +26,9 @@ export default function cssModulesRsc() {
         if (id.includes('.module.') && cssMap.has(id)) {
           return code.replace(
             /export default .*$/gms,
-            `import React from 'react'; export const StyleTag = () => React.createElement('style', {}, \`${cssMap.get(
-              id
-            )}\`);`
+            `import React from 'react'; export const StyleTag = () => React.createElement('style', {dangerouslySetInnerHTML: {__html: ${JSON.stringify(
+              cssMap.get(id)
+            )}}});`
           );
         }
       },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1056 

We were passing contents of `<style>` tags to React as children. React will escape values like quotes. This caused hydration errors between the server and the client.

This new approach uses my personal favorite property in all of React history, `dangerouslySetInnerHTML` + `JSON.stringify()`.

This solves the hydration errors.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
