### PR TITLE
externalize jsx-runtime and get it working in the dev package

### DIFF
--- a/examples/template-hydrogen-default/vite.config.js
+++ b/examples/template-hydrogen-default/vite.config.js
@@ -6,7 +6,7 @@ import shopifyConfig from './shopify.config';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [hydrogen(shopifyConfig)],
-  optimizeDeps: {include: ['@headlessui/react']},
+  optimizeDeps: {include: ['@headlessui/react', 'react/jsx-runtime']},
   test: {
     globals: true,
     testTimeout: 10000,

--- a/examples/template-hydrogen-default/vite.config.js
+++ b/examples/template-hydrogen-default/vite.config.js
@@ -6,7 +6,7 @@ import shopifyConfig from './shopify.config';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [hydrogen(shopifyConfig)],
-  optimizeDeps: {include: ['@headlessui/react', 'react/jsx-runtime']},
+  optimizeDeps: {include: ['@headlessui/react']},
   test: {
     globals: true,
     testTimeout: 10000,

--- a/packages/hydrogen-ui/README.md
+++ b/packages/hydrogen-ui/README.md
@@ -1,0 +1,17 @@
+# Hydrogen-UI
+
+## Implementation Notes
+
+### jsx-runtime
+
+If you see an error that says something like `Uncaught ReferenceError: module is not defined`, it's likely because of an issue with [Vite and react/jsx-runtime](https://github.com/vitejs/vite/issues/6215).
+
+The solution is to add `'react/jsx-runtime'` to your Vite config's `optimizeDeps` array; see the `template-hydrogen-default` package for an example.
+
+### Jest
+
+Until [Jest can correctly resolve package.exports](https://github.com/facebook/jest/issues/9771), here's a workaround:
+
+- Add the [`enhanced-resolve`](https://www.npmjs.com/package/enhanced-resolve) npm package
+- Add a new file and copy the code found in the `_export_map_resolver.js` file [here](https://github.com/ceramicnetwork/js-dag-jose/commit/51750b4266bc57ae56af05e0899acf38c519799b#diff-3f698d0dc0e17487612dbe228105aa820683a2eb38343929c1c45d9a8aa479f8)
+- Add the `resolver` field to your Jest config, and point it to that file you just created. [Here's](https://github.com/ceramicnetwork/js-dag-jose/commit/51750b4266bc57ae56af05e0899acf38c519799b#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R55) an example

--- a/packages/hydrogen-ui/README.md
+++ b/packages/hydrogen-ui/README.md
@@ -4,9 +4,9 @@
 
 ### jsx-runtime
 
-If you see an error that says something like `Uncaught ReferenceError: module is not defined`, it's likely because of an issue with [Vite and react/jsx-runtime](https://github.com/vitejs/vite/issues/6215).
+If you're using Vite and not using our plugin, and there is an error that says something like `Uncaught ReferenceError: module is not defined`, it's likely because of an issue with [Vite and react/jsx-runtime](https://github.com/vitejs/vite/issues/6215).
 
-The solution is to add `'react/jsx-runtime'` to your Vite config's `optimizeDeps` array; see the `template-hydrogen-default` package for an example.
+The solution is to add `'react/jsx-runtime'` to your Vite config's `optimizeDeps.include` array.
 
 ### Jest
 

--- a/packages/hydrogen-ui/vite.config.ts
+++ b/packages/hydrogen-ui/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     target: ['node16', 'chrome96', 'firefox94', 'safari14', 'edge96'],
     rollupOptions: {
       // don't bundle these packages into our lib
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
       // the true entry points to the bundles
       input: ['./src/index.client.ts', './src/index.server.ts'],
     },

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -70,6 +70,8 @@ export default () => {
           'react',
           'react-dom/client',
           'react-server-dom-vite/client-proxy',
+          // https://github.com/vitejs/vite/issues/6215
+          'react/jsx-runtime',
         ],
       },
 


### PR DESCRIPTION
Before this change, we were creating a local version of the jsx-runtime file in the hydrogen-ui package: here's some screenshots showing the local import and the dist folder after building:

<img width="384" alt="Screen Shot 2022-04-12 at 4 14 55 PM" src="https://user-images.githubusercontent.com/3054066/163063801-93e64f7c-7b00-4f35-8c4e-423042c898e2.png">

<img width="306" alt="Screen Shot 2022-04-12 at 4 14 39 PM" src="https://user-images.githubusercontent.com/3054066/163063755-cba6a595-2084-469d-8b0e-da4bac8cabb5.png">

However, I believe the jsx-runtime library should be found during the app's buildtime (not hydrogen-ui's buildtime), so we want to externalize it. In doing so, there appears to be an issue with [Vite's built-in React plugin](https://github.com/vitejs/vite/issues/6215), so we need to help it out by adding it to the `optimizeDeps` array. So I documented that as well. 

For reference, here's what it looks like after these change:

<img width="375" alt="Screen Shot 2022-04-12 at 4 19 06 PM" src="https://user-images.githubusercontent.com/3054066/163064130-cb232e50-b889-4f3f-b019-75eb7905e710.png">

<img width="189" alt="Screen Shot 2022-04-12 at 4 19 02 PM" src="https://user-images.githubusercontent.com/3054066/163064138-1f1f8248-f40b-4719-ad91-f0128c028e2c.png">

Looks better!
