### PR TITLE
Use new storefront API headers in queryShop API helper

### DIFF
--- a/.changeset/kind-buses-exist.md
+++ b/.changeset/kind-buses-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Properly set buyer IP and secret token for API Route queryShop helper

--- a/packages/hydrogen/src/constants.ts
+++ b/packages/hydrogen/src/constants.ts
@@ -1,3 +1,10 @@
 export const RSC_PATHNAME = '/__rsc';
 export const EVENT_PATHNAME = '/__event';
 export const EVENT_PATHNAME_REGEX = new RegExp(`^${EVENT_PATHNAME}\/`);
+export const OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE =
+  'SHOPIFY_STOREFRONT_API_SECRET_TOKEN';
+export const STOREFRONT_API_SECRET_TOKEN_HEADER =
+  'Shopify-Storefront-Private-Token';
+export const STOREFRONT_API_PUBLIC_TOKEN_HEADER =
+  'X-Shopify-Storefront-Access-Token';
+export const STOREFRONT_API_BUYER_IP_HEADER = 'Shopify-Storefront-Buyer-IP';

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -9,6 +9,7 @@ import {injectGraphQLTracker} from '../../utilities/graphql-tracker';
 import {sendMessageToClient} from '../../utilities/devtools';
 import {fetchSync} from '../../foundation/fetchSync/server/fetchSync';
 import {META_ENV_SSR} from '../../foundation/ssr-interop';
+import {getStorefrontApiRequestHeaders} from '../../utilities/storefrontApi';
 
 export interface UseShopQueryResponse<T> {
   /** The data returned by the query. */
@@ -175,26 +176,12 @@ function useCreateShopRequest(body: string) {
   const {storeDomain, storefrontToken, storefrontApiVersion} = useShop();
 
   const request = useServerRequest();
-  const secretToken =
-    typeof Oxygen !== 'undefined'
-      ? Oxygen?.env?.SHOPIFY_STOREFRONT_API_SECRET_TOKEN
-      : null;
   const buyerIp = request.getBuyerIp();
 
-  const extraHeaders = {} as Record<string, any>;
-
-  /**
-   * Only pass one type of storefront token at a time.
-   */
-  if (secretToken) {
-    extraHeaders['Shopify-Storefront-Private-Token'] = secretToken;
-  } else {
-    extraHeaders['X-Shopify-Storefront-Access-Token'] = storefrontToken;
-  }
-
-  if (buyerIp) {
-    extraHeaders['Shopify-Storefront-Buyer-IP'] = buyerIp;
-  }
+  const extraHeaders = getStorefrontApiRequestHeaders({
+    buyerIp,
+    storefrontToken,
+  });
 
   return {
     key: [storeDomain, storefrontApiVersion, body],

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -1,9 +1,10 @@
 import {ImportGlobEagerOutput, ShopifyConfig} from '../types';
 import {matchPath} from './matchPath';
 import {getLoggerWithContext, logServerResponse} from '../utilities/log/';
-import {ServerComponentRequest} from '../framework/Hydration/ServerComponentRequest.server';
+import type {ServerComponentRequest} from '../framework/Hydration/ServerComponentRequest.server';
 import type {ASTNode} from 'graphql';
 import {fetchBuilder, graphqlRequestBody} from './fetch';
+import {getStorefrontApiRequestHeaders} from './storefrontApi';
 
 let memoizedRoutes: Array<HydrogenApiRoute> = [];
 let memoizedPages: ImportGlobEagerOutput = {};
@@ -123,18 +124,23 @@ interface QueryShopArgs {
   query: ASTNode | string;
   /** An object of the variables for the GraphQL query. */
   variables?: Record<string, any>;
-  /** A string corresponding to a valid locale identifier like `en-us` used to make the request. */
-  locale?: string;
 }
 
-function queryShopBuilder(shopifyConfig: ShopifyConfig) {
+function queryShopBuilder(
+  shopifyConfig: ShopifyConfig,
+  request: ServerComponentRequest
+) {
   return async function queryShop<T>({
     query,
     variables,
-    locale,
   }: QueryShopArgs): Promise<T> {
-    const {storeDomain, storefrontApiVersion, storefrontToken, defaultLocale} =
-      shopifyConfig;
+    const {storeDomain, storefrontApiVersion, storefrontToken} = shopifyConfig;
+    const buyerIp = request.getBuyerIp();
+
+    const extraHeaders = getStorefrontApiRequestHeaders({
+      buyerIp,
+      storefrontToken,
+    });
 
     const fetcher = fetchBuilder<T>(
       `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
@@ -142,9 +148,8 @@ function queryShopBuilder(shopifyConfig: ShopifyConfig) {
         method: 'POST',
         body: graphqlRequestBody(query, variables),
         headers: {
-          'X-Shopify-Storefront-Access-Token': storefrontToken,
-          'Accept-Language': (locale as string) ?? defaultLocale,
           'Content-Type': 'application/json',
+          ...extraHeaders,
         },
       }
     );
@@ -154,7 +159,7 @@ function queryShopBuilder(shopifyConfig: ShopifyConfig) {
 }
 
 export async function renderApiRoute(
-  request: Request,
+  request: ServerComponentRequest,
   route: ApiRouteMatch,
   shopifyConfig: ShopifyConfig
 ): Promise<Response | Request> {
@@ -164,7 +169,7 @@ export async function renderApiRoute(
   try {
     response = await route.resource(request, {
       params: route.params,
-      queryShop: queryShopBuilder(shopifyConfig),
+      queryShop: queryShopBuilder(shopifyConfig, request),
     });
 
     if (!(response instanceof Response || response instanceof Request)) {

--- a/packages/hydrogen/src/utilities/storefrontApi.ts
+++ b/packages/hydrogen/src/utilities/storefrontApi.ts
@@ -1,0 +1,36 @@
+import {
+  OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE,
+  STOREFRONT_API_SECRET_TOKEN_HEADER,
+  STOREFRONT_API_PUBLIC_TOKEN_HEADER,
+  STOREFRONT_API_BUYER_IP_HEADER,
+} from '../constants';
+
+export function getStorefrontApiRequestHeaders({
+  buyerIp,
+  storefrontToken,
+}: {
+  buyerIp?: string | null;
+  storefrontToken: string;
+}) {
+  const headers = {} as Record<string, any>;
+
+  const secretToken =
+    typeof Oxygen !== 'undefined'
+      ? Oxygen?.env?.[OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE]
+      : null;
+
+  /**
+   * Only pass one type of storefront token at a time.
+   */
+  if (secretToken) {
+    headers[STOREFRONT_API_SECRET_TOKEN_HEADER] = secretToken;
+  } else {
+    headers[STOREFRONT_API_PUBLIC_TOKEN_HEADER] = storefrontToken;
+  }
+
+  if (buyerIp) {
+    headers[STOREFRONT_API_BUYER_IP_HEADER] = buyerIp;
+  }
+
+  return headers;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I forgot to add this in #1024 

Also removes `Accept-Language` header, since that now lives in a `inContext` directive #1028 

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
