### PR TITLE
Add fetch priority attributes to Gallery component images

### DIFF
--- a/examples/template-hydrogen-default/src/components/Gallery.client.jsx
+++ b/examples/template-hydrogen-default/src/components/Gallery.client.jsx
@@ -30,6 +30,7 @@ export default function Gallery() {
       tabIndex="-1"
     >
       <Image
+        fetchPriority="high"
         data={selectedVariant.image}
         className="w-[80vw] md:w-full h-full md:h-auto object-cover object-center flex-shrink-0 md:flex-shrink-none snap-start md:col-span-2 border border-gray-200 rounded-lg"
       />
@@ -46,6 +47,7 @@ export default function Gallery() {
             key={med.id || med.image.id}
             className="w-[80vw] md:w-auto h-full md:h-auto object-cover object-center transition-all snap-start border border-gray-200 flex-shrink-0 rounded-lg"
             data={med}
+            fetchPriority="low"
             options={{
               height: '485',
               crop: 'center',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adding `high` for the selected variant image and `low` for all others to reduce the LCP on the details page. This is supported in Chrome Canary and coming in version 101.

According to many of the articles I was reading, we should use this feature sparingly and trust the browser defaults rather than over-optimize. However the `<Gallery />` seemed like the perfect use-case to test this feature for prioritizing some image requests over others to improve overall LCP. I'd like to take a closer look at the metrics before and after these code changes and come to some conclusions on what we might do to guide developers interested in performance optimization (in the Dev Tools, Docs, TypeScript, ESLint, etc...).

### Additional context

https://wicg.github.io/priority-hints/#img

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
