### PR TITLE
Obfuscate chunk filename on production build

### DIFF
--- a/.changeset/unlucky-crabs-fry.md
+++ b/.changeset/unlucky-crabs-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Obfuscate chunk filename on production build

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -1,6 +1,32 @@
 import {Plugin} from 'vite';
 
 export default () => {
+  let rollupOptions: any = {
+    output: {},
+  };
+
+  if (process.env.WORKER) {
+    /**
+     * By default, SSR dedupe logic gets bundled which runs `require('module')`.
+     * We don't want this in our workers runtime, because `require` is not supported.
+     */
+    rollupOptions.output.format = 'es';
+  }
+
+  if (!process.env.LOCAL_DEV) {
+    /**
+     * Ofuscate production asset name - To prevent ad blocker logics that blocks
+     * certain files due to how it is named.
+     *
+     * Ofuscation is done by base64 encoding of the filename
+     */
+    rollupOptions.output.chunkFileNames = (chunkInfo: any) => {
+      return `assets/${Buffer.from(chunkInfo.name).toString(
+        'base64'
+      )}.[hash].js`;
+    };
+  }
+
   return {
     name: 'vite-plugin-hydrogen-config',
     config: async (config, env) => ({
@@ -16,17 +42,9 @@ export default () => {
       build: {
         minify: config.build?.minify ?? 'esbuild',
         sourcemap: true,
-        /**
-         * By default, SSR dedupe logic gets bundled which runs `require('module')`.
-         * We don't want this in our workers runtime, because `require` is not supported.
-         */
-        rollupOptions: process.env.WORKER
-          ? {
-              output: {
-                format: 'es',
-              },
-            }
-          : {},
+        rollupOptions: config.build?.rollupOptions
+          ? Object.assign(rollupOptions, config.build.rollupOptions)
+          : rollupOptions,
       },
 
       ssr: {

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -1,7 +1,7 @@
 import {Plugin} from 'vite';
 
 export default () => {
-  let rollupOptions: any = {
+  const rollupOptions: any = {
     output: {},
   };
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -1,7 +1,8 @@
 import {Plugin} from 'vite';
+import type {BuildOptions} from 'vite';
 
 export default () => {
-  const rollupOptions: any = {
+  const rollupOptions: BuildOptions['rollupOptions'] = {
     output: {},
   };
 
@@ -10,20 +11,18 @@ export default () => {
      * By default, SSR dedupe logic gets bundled which runs `require('module')`.
      * We don't want this in our workers runtime, because `require` is not supported.
      */
-    rollupOptions.output.format = 'es';
+    rollupOptions.output = {
+      format: 'es',
+    };
   }
 
   if (!process.env.LOCAL_DEV) {
     /**
      * Ofuscate production asset name - To prevent ad blocker logics that blocks
      * certain files due to how it is named.
-     *
-     * Ofuscation is done by base64 encoding of the filename
      */
-    rollupOptions.output.chunkFileNames = (chunkInfo: any) => {
-      return `assets/${Buffer.from(chunkInfo.name).toString(
-        'base64'
-      )}.[hash].js`;
+    rollupOptions.output = {
+      chunkFileNames: '[hash].js',
     };
   }
 


### PR DESCRIPTION
Fix https://github.com/Shopify/hydrogen/issues/1084

### Description

Obfuscate chunk filename on production build - Some ad blockers blocks certain files simply due to how it is named.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
