### PR TITLE
Add ErrorBoundary for client analytics

### DIFF
--- a/.changeset/two-socks-pretend.md
+++ b/.changeset/two-socks-pretend.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix Hydrogen to not die when client analytics fails to load. Analytics might fail to load due to client-side adblockers.
+Fix Hydrogen to not hard fail when client analytics doesn't load. Analytics might fail to load due to client-side adblockers.

--- a/.changeset/two-socks-pretend.md
+++ b/.changeset/two-socks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix Hydrogen to not die when client analytics fails to load. Analytics might fail to load due to client-side adblockers.

--- a/packages/hydrogen/src/foundation/Analytics/Analytics.server.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/Analytics.server.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import * as React from 'react';
 import {useServerAnalytics} from './hook';
 import {Analytics as AnalyticsClient} from './Analytics.client';
 import {useServerRequest} from '../ServerRequestProvider';
+import AnalyticsErrorBoundary from '../AnalyticsErrorBoundary.client';
 
 const DELAY_KEY = 'analytics-delay';
 
@@ -41,5 +42,9 @@ export function Analytics() {
   });
 
   const analyticsData = useServerAnalytics();
-  return <AnalyticsClient analyticsDataFromServer={analyticsData} />;
+  return (
+    <AnalyticsErrorBoundary>
+      <AnalyticsClient analyticsDataFromServer={analyticsData} />
+    </AnalyticsErrorBoundary>
+  );
 }

--- a/packages/hydrogen/src/foundation/AnalyticsErrorBoundary.client.tsx
+++ b/packages/hydrogen/src/foundation/AnalyticsErrorBoundary.client.tsx
@@ -1,0 +1,19 @@
+import React, {ReactNode} from 'react';
+import {ErrorBoundary} from 'react-error-boundary';
+
+export default function AnalyticsErrorBoundary({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  // Analytics fail to load, most likely due to an ad blocker
+  return (
+    <ErrorBoundary
+      fallbackRender={() => {
+        return null;
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/packages/hydrogen/src/foundation/AnalyticsErrorBoundary.client.tsx
+++ b/packages/hydrogen/src/foundation/AnalyticsErrorBoundary.client.tsx
@@ -1,4 +1,5 @@
-import React, {ReactNode} from 'react';
+import React from 'react';
+import type {ReactNode} from 'react';
 import {ErrorBoundary} from 'react-error-boundary';
 
 export default function AnalyticsErrorBoundary({


### PR DESCRIPTION
Fix Hydrogen to not die when client analytics fails to load. Analytics might fail to load due to client-side adblockers.

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
