### PR TITLE
Fix `useUrl` in RSC

### DIFF
--- a/.changeset/two-masks-crash.md
+++ b/.changeset/two-masks-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Do not call client exported functions during RSC.

--- a/packages/hydrogen/src/foundation/useUrl/useUrl.ts
+++ b/packages/hydrogen/src/foundation/useUrl/useUrl.ts
@@ -7,8 +7,6 @@ import {useEnvContext, META_ENV_SSR} from '../ssr-interop';
  * The `useUrl` hook retrieves the current URL in a server or client component.
  */
 export function useUrl(): URL {
-  const location = useLocation();
-
   if (META_ENV_SSR) {
     const serverUrl = new URL(useEnvContext((req) => req.url));
 
@@ -29,5 +27,6 @@ export function useUrl(): URL {
    * We return a `URL` object instead of passing through `location` because
    * the URL object contains important info like hostname, etc.
    */
+  const location = useLocation();
   return useMemo(() => new URL(window.location.href), [location]);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`useUrl` was modified in #1082 to make it reactive by calling `useLocation` internally. This function, however, should not be called during RSC because it is exported from a client component (it throws errors with the latest Vite<>RSC plugin updates).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
