### PR TITLE
 fix: React warning for fetchpriority casing

### DIFF
--- a/.changeset/serious-mayflies-sleep.md
+++ b/.changeset/serious-mayflies-sleep.md
@@ -2,4 +2,4 @@
 'create-hydrogen-app': patch
 ---
 
-Changing the casing on the fetchpolicy attribute to all lowercase.
+Changing the casing on the fetchpriority attribute to all lowercase on Gallery images to prevent a React warning.

--- a/.changeset/serious-mayflies-sleep.md
+++ b/.changeset/serious-mayflies-sleep.md
@@ -1,0 +1,5 @@
+---
+'create-hydrogen-app': patch
+---
+
+Changing the casing on the fetchpolicy attribute to all lowercase.

--- a/examples/template-hydrogen-default/src/components/Gallery.client.jsx
+++ b/examples/template-hydrogen-default/src/components/Gallery.client.jsx
@@ -30,7 +30,7 @@ export default function Gallery() {
       tabIndex="-1"
     >
       <Image
-        fetchPriority="high"
+        fetchpriority="high"
         data={selectedVariant.image}
         className="w-[80vw] md:w-full h-full md:h-auto object-cover object-center flex-shrink-0 md:flex-shrink-none snap-start md:col-span-2 border border-gray-200 rounded-lg"
       />
@@ -47,7 +47,7 @@ export default function Gallery() {
             key={med.id || med.image.id}
             className="w-[80vw] md:w-auto h-full md:h-auto object-cover object-center transition-all snap-start border border-gray-200 flex-shrink-0 rounded-lg"
             data={med}
-            fetchPriority="low"
+            fetchpriority="low"
             options={{
               height: '485',
               crop: 'center',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Noticed a warning in the console that I had missed earlier when adding the `fetchpriority` attribute to the Gallery component images.


### Additional context


> Warning: React does not recognize the `fetchPriority` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fetchpriority` instead. If you accidentally passed it from a parent component, remove it from the DOM element.


### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
