### PR TITLE
Fix preview script

### DIFF
--- a/.changeset/chatty-houses-clean.md
+++ b/.changeset/chatty-houses-clean.md
@@ -1,0 +1,23 @@
+---
+'create-hydrogen-app': patch
+---
+
+Fix issue where preview won't start without experimental-vm-modules flag. Update your package.json:
+
+```diff
+  "scripts": {
+    "dev": "shopify hydrogen dev",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx src",
+    "lint:css": "stylelint ./src/**/*.{css,sass,scss}",
+    "build": "yarn build:client && yarn build:server && yarn build:worker",
+    "build:client": "vite build --outDir dist/client --manifest",
+    "build:server": "vite build --outDir dist/server --ssr @shopify/hydrogen/platforms/node",
+    "build:worker": "cross-env WORKER=true vite build --outDir dist/worker --ssr @shopify/hydrogen/platforms/worker",
+    "serve": "node --enable-source-maps dist/server",
+    "test": "WATCH=true vitest",
+    "test:ci": "yarn build && vitest run",
+-    "preview": "shopify hydrogen preview"
++    "preview": "node --experimental-vm-modules node_modules/.bin/shopify hydrogen preview"
+  },
+```

--- a/examples/template-hydrogen-default/package.json
+++ b/examples/template-hydrogen-default/package.json
@@ -16,7 +16,7 @@
     "serve": "node --enable-source-maps dist/server",
     "test": "WATCH=true vitest",
     "test:ci": "yarn build && vitest run",
-    "preview": "shopify hydrogen preview"
+    "preview": "node --experimental-vm-modules node_modules/.bin/shopify hydrogen preview"
   },
   "prettier": "@shopify/prettier-config",
   "devDependencies": {

--- a/templates/template-hydrogen-hello-world/package.json
+++ b/templates/template-hydrogen-hello-world/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "shopify hydrogen dev",
     "build": "shopify hydrogen build",
-    "preview": "shopify hydrogen preview"
+    "preview": "node --experimental-vm-modules node_modules/.bin/shopify hydrogen preview"
   },
   "devDependencies": {
     "vite": "^2.9.0",


### PR DESCRIPTION
Fix issue where preview won't start without `--experimental-vm-modules` flag. Tested in node 16, 17, and 18. Miniflare starts up, but I get this error without the flag:

![image](https://user-images.githubusercontent.com/1566869/165150302-0348679d-1dfd-41db-8517-fe9966e53b64.png)
