### PR TITLE
Fix scroll restoration on page transitions

### DIFF
--- a/.changeset/fifty-rivers-travel.md
+++ b/.changeset/fifty-rivers-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix the scroll restoration on page transitions

--- a/packages/hydrogen/src/components/Link/tests/Link.test.tsx
+++ b/packages/hydrogen/src/components/Link/tests/Link.test.tsx
@@ -80,7 +80,7 @@ describe('<Link />', () => {
 
     setTimeout(() => {
       try {
-        expect(setServerProps).toHaveBeenCalledWith({
+        expect(setServerProps.mock.calls[0][0]()).toStrictEqual({
           pathname: '/products/hydrogen',
           search: '',
         });


### PR DESCRIPTION
Test by scrolling down on the home page. Click a product. The page should not scroll to the top until after the new page loads.