### PR TITLE
Fix scroll restoration when server props are changed

### DIFF
--- a/.changeset/tiny-bats-sip.md
+++ b/.changeset/tiny-bats-sip.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix scroll restoration when server props are changed


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1141

This adds an additional state to only fire the scroll restoration logic when a location has changed, not when `pending` has changed.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
