### PR TITLE
Adds ability to add more than one cookie per response

### DIFF
--- a/.changeset/fuzzy-jeans-tickle.md
+++ b/.changeset/fuzzy-jeans-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Adds ability to add multiple cookies in one response

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -819,7 +819,10 @@ function getResponseOptions(
 ) {
   const responseInit = {} as ResponseOptions;
   // @ts-ignore
-  responseInit.headers = Object.fromEntries(headers.entries());
+  for (const key of headers.keys()) {
+    // @ts-ignore
+    responseInit.headers[key] = headers.raw()[key];
+  }
 
   if (error) {
     responseInit.status = 500;

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -818,11 +818,17 @@ function getResponseOptions(
   error?: Error
 ) {
   const responseInit = {} as ResponseOptions;
+
   // @ts-ignore
-  for (const key of headers.keys()) {
-    // @ts-ignore
-    responseInit.headers[key] = headers.raw()[key];
-  }
+  responseInit.headers = Object.fromEntries(headers.entries());
+
+  // @ts-ignore
+  const rawHeaders = headers.raw();
+  const setCookieKey = Object.keys(rawHeaders).find(
+    (key) => key.toLowerCase() === 'set-cookie'
+  );
+
+  responseInit.headers['set-cookie'] = rawHeaders[setCookieKey];
 
   if (error) {
     responseInit.status = 500;

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -830,6 +830,8 @@ function getResponseOptions(
 
   // @ts-ignore
   const rawHeaders = headers.raw();
+  // Warning! Headers.raw is non-standard and might disappear in undici or newer versions of node-fetch
+  // See: https://github.com/whatwg/fetch/issues/973
   const setCookieKey = Object.keys(rawHeaders).find(
     (key) => key.toLowerCase() === 'set-cookie'
   );

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -934,10 +934,6 @@ function postRequestTasks(
 function getHeaders(rawHeaders: Record<string, String | Array<String>> = {}) {
   const headers = new Headers();
 
-  if (!headers) {
-    return new Headers();
-  }
-
   for (const [key, values] of Object.entries(rawHeaders)) {
     // values doesn't have an array prototype, so instanceof doesn't work.
     // Check for .splice instead

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -184,11 +184,11 @@ export default async function testCases({
     expect(response.status).toEqual(201);
     // statusText cannot be modified in workers
     expect(response.statusText).toEqual(isWorker ? 'Created' : 'hey');
-
     expect(response.headers.get('Accept-Encoding')).toBe('deflate, gzip');
-    expect(response.headers.get('Set-Cookie')).toBe(
-      'hello=world, hello2=world2'
-    );
+    expect(response.headers.raw()['set-cookie']).toEqual([
+      'hello=world',
+      'hello2=world2',
+    ]);
   });
 
   it('uses the provided custom body', async () => {


### PR DESCRIPTION
### Description

This is necessary because the only way to set multiple cookies reliably from node is by writing a header like this:
```
{'set-cookie': ['foo=bar', 'bar=baz']}
```

We need to use `headers.raw()` which is currently provided by `node-fetch`, so that we can access the unserialized array and set it on the response. Otherwise `node-fetch`'s implementation of `Headers`, which used by hydrogen, will serialize the array into a comma separated string.

Makes me think that now [that fetch is part of Node v16](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#add-fetch-api) and v18 this may stop being a problem (I haven't confirmed this yet), but while `node-fetch`'s Response is in use, it's best to use `headers.raw()` instead for this purpose.

### Additional context

This fixes this minor bug https://github.com/Shopify/hydrogen/issues/1138 which [we need](https://github.com/Shopify/brochure2/issues/34157) for our brochure site so we can set our attribution and other cookies in one response.

This behavior of node-fetch is described in its readme here: https://github.com/node-fetch/node-fetch#extract-set-cookie-header

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
