### PR TITLE
Fixes #1165 by making a missing alt tag a console warning

### DIFF
--- a/.changeset/rude-moons-watch.md
+++ b/.changeset/rude-moons-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Only warn in console on missing Model3D alt tag, do not throw error

--- a/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
+++ b/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
@@ -121,7 +121,7 @@ interface ModelViewerProps {
   onSceneGraphReady?: (event: Event) => void;
 }
 
-type PropsWeControl = 'src' | 'alt' | 'poster';
+type PropsWeControl = 'src' | 'poster';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -287,7 +287,9 @@ export function ModelViewer<TTag extends ElementType>(
   }
 
   if (!data.alt) {
-    console.warn(`<ModelViewer/> requires the 'data.alt' prop for accessibility`);
+    console.warn(
+      `<ModelViewer/> requires the 'data.alt' prop for accessibility`
+    );
   }
 
   return (

--- a/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
+++ b/packages/hydrogen/src/components/ModelViewer/ModelViewer.client.tsx
@@ -287,7 +287,7 @@ export function ModelViewer<TTag extends ElementType>(
   }
 
   if (!data.alt) {
-    throw new Error(`<ModelViewer/> requires the 'data.alt' prop`);
+    console.warn(`<ModelViewer/> requires the 'data.alt' prop for accessibility`);
   }
 
   return (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Fixes #1165 

### Description

When you use `<ModelViewer />` or `<MediaFile />` today, and the 3D asset you're providing has not yet had an `alt` tag set in the Shopify admin, Hydrogen will break. As this is not something within our control, and any ecommerce merchandiser could upload a 3D model and forget to add an alt tag, we should not throw an error and instead (I propose) provide a console warning that this is missing.

<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context
- Is this the right way to go about this?
- I noticed on line 124 there was a type defined: `type PropsWeControl = 'src' | 'alt' | 'poster';`, should that change too?

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
