### PR TITLE
[Hydrogen docs]: add references to video in file_reference block

### DIFF
--- a/docs/components/primitive/metafield.md
+++ b/docs/components/primitive/metafield.md
@@ -37,26 +37,26 @@ export function Product({product}) {
 
 When no `children` prop is provided, the `Metafield` component renders the following defaults:
 
-| Metafield `type`         | Output                                                                                                                                                                                     |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `date`                   | A `span` containing the date from [`toLocaleDateString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) with the shop's locale. |
-| `date_time`              | A `span` containing the date from [`toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) with the shop's locale.         |
-| `boolean`                | A `span` containing "true" or "false" as a string.                                                                                                                                         |
-| `number_integer`         | A `span` containing the integer.                                                                                                                                                           |
-| `number_decimal`         | A `span` containing the number.                                                                                                                                                            |
-| `json`                   | A `span` containing the JSON object as a string.                                                                                                                                           |
-| `weight`                 | A `span` containing a string of the localized weight using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).      |
-| `dimension`              | A `span` containing a string of the localized dimension using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).   |
-| `volume`                 | A `span` containing a string of the localized volume using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).      |
-| `rating`                 | A `span` containing a string of the rating value.                                                                                                                                          |
-| `color`                  | A `span` containing the color value as a string.                                                                                                                                           |
-| `single_line_text_field` | A `span` component with the text.                                                                                                                                                          |
-| `multi_line_text_field`  | A `div` component with the text, and `as="span"`.                                                                                                                                          |
-| `product_reference`      | A `span` containing the product reference GID.                                                                                                                                             |
-| `file_reference`         | An `Image` component when the file reference is of type `MediaImage`, or a `span` containing the file reference GID for other file types.                                                  |
-| `page_reference`         | A `span` containing the page reference GID.                                                                                                                                                |
-| `variant_reference`      | A `span` containing the variant reference GID.                                                                                                                                             |
-| `url`                    | An `a` tag with the `href` corresponding to the URL and the label corresponding to the URL.                                                                                                |
+| Metafield `type`         | Output                                                                                                                                                                                                    |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `date`                   | A `span` containing the date from [`toLocaleDateString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) with the shop's locale.                |
+| `date_time`              | A `span` containing the date from [`toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) with the shop's locale.                        |
+| `boolean`                | A `span` containing "true" or "false" as a string.                                                                                                                                                        |
+| `number_integer`         | A `span` containing the integer.                                                                                                                                                                          |
+| `number_decimal`         | A `span` containing the number.                                                                                                                                                                           |
+| `json`                   | A `span` containing the JSON object as a string.                                                                                                                                                          |
+| `weight`                 | A `span` containing a string of the localized weight using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).                     |
+| `dimension`              | A `span` containing a string of the localized dimension using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).                  |
+| `volume`                 | A `span` containing a string of the localized volume using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat).                     |
+| `rating`                 | A `span` containing a string of the rating value.                                                                                                                                                         |
+| `color`                  | A `span` containing the color value as a string.                                                                                                                                                          |
+| `single_line_text_field` | A `span` component with the text.                                                                                                                                                                         |
+| `multi_line_text_field`  | A `div` component with the text, and `as="span"`.                                                                                                                                                         |
+| `product_reference`      | A `span` containing the product reference GID.                                                                                                                                                            |
+| `file_reference`         | An `Image` component when the file reference is of type `MediaImage`, a `Video` component when the file reference is of type `Video`, or a `span` containing the file reference GID for other file types. |
+| `page_reference`         | A `span` containing the page reference GID.                                                                                                                                                               |
+| `variant_reference`      | A `span` containing the variant reference GID.                                                                                                                                                            |
+| `url`                    | An `a` tag with the `href` corresponding to the URL and the label corresponding to the URL.                                                                                                               |
 
 ## Render props
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

- part of [#338708](https://github.com/Shopify/shopify/issues/338708)
- add a reference that videos can be accessed from metafields

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- similar example from [liquid docs](https://shopify.dev/api/liquid/objects/metafield#metafield-value) for reference

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
