### PR TITLE
Don't consider examples part of the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "packageManager": "yarn@1.22.17",
   "workspaces": [
-    "examples/*",
     "templates/*",
     "packages/*",
     "packages/playground/*"


### PR DESCRIPTION
We don't want to bloat our monorepo install time with each example we add.