### PR TITLE
Make metafields optional within the ProductProvider. Fixes #1127

### DIFF
--- a/.changeset/twelve-moles-vanish.md
+++ b/.changeset/twelve-moles-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Make metafields optional within the ProductProvider. Fixes #1127

--- a/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductProvider/ProductProvider.client.tsx
@@ -29,7 +29,7 @@ export function ProductProvider({
   data: product,
   initialVariantId,
 }: ProductProviderProps) {
-  const metafields = useParsedMetafields(product.metafields);
+  const metafields = useParsedMetafields(product.metafields || {});
 
   // @ts-expect-error The types here are broken on main, need to come back and fix them sometime
   const providerValue = useMemo<ProductContextType>(() => {

--- a/packages/hydrogen/src/hooks/useParsedMetafields/useParsedMetafields.ts
+++ b/packages/hydrogen/src/hooks/useParsedMetafields/useParsedMetafields.ts
@@ -11,7 +11,6 @@ export function useParsedMetafields(
   /** A [MetafieldConnection](https://shopify.dev/api/storefront/reference/common-objects/metafieldconnection). */
   metafields?: PartialDeep<MetafieldConnection>
 ) {
-  metafields?.edges?.[0]?.node;
   return useMemo(() => {
     if (!metafields) {
       throw new Error(`'useParsedMetafields' needs metafields`);

--- a/templates/template-hydrogen-default/src/components/ProductDetails.client.jsx
+++ b/templates/template-hydrogen-default/src/components/ProductDetails.client.jsx
@@ -111,7 +111,7 @@ function ProductPrices() {
 export default function ProductDetails({product}) {
   const initialVariant = flattenConnection(product.variants)[0];
 
-  const productMetafields = useParsedMetafields(product.metafields);
+  const productMetafields = useParsedMetafields(product.metafields || {});
   const sizeChartMetafield = productMetafields.find(
     (metafield) =>
       metafield.namespace === 'my_fields' && metafield.key === 'size_chart',


### PR DESCRIPTION
Resolves #1127