### PR TITLE
Build chunks are inside assets folder

### DIFF
--- a/.changeset/angry-coats-cheat.md
+++ b/.changeset/angry-coats-cheat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Build chunks are inside assets folder

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -23,7 +23,7 @@ export default () => {
      */
     rollupOptions.output = {
       ...rollupOptions.output,
-      chunkFileNames: '[hash].js',
+      chunkFileNames: 'assets/[hash].js',
     };
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

File obfuscation change accidentally change the assets location. This PR is to change that back.

Reference:
* https://github.com/netlify/hydrogen-platform/pull/14

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
