### PR TITLE
Update turbo and instructions for developing `dev`

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -15,6 +15,16 @@ yarn
 yarn dev
 ```
 
+To develop against a template, open a new terminal window or tab and choose from the available templates:
+
+- templates/template-hydrogen-default
+- templates/template-hydrogen-hello-world
+
+```bash
+cd templates/template-hydrogen-default
+yarn dev
+```
+
 Visit the dev environment at http://localhost:3000.
 
 To make changes to the Demo Store template, edit the files in `templates/template-hydrogen-default`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "dev": "yarn turbo run dev --parallel --filter=hydrogen-ui --filter=@shopify/hydrogen",
+    "dev": "yarn turbo run dev --parallel --filter=@shopify/hydrogen-ui --filter=@shopify/hydrogen",
     "build": "yarn turbo run build",
     "lint": "run-p lint:js lint:language",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx packages/*/src",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "dev": "cross-env LOCAL_DEV=true yarn turbo run dev --parallel",
+    "dev": "yarn turbo run dev --parallel --filter=hydrogen-ui --filter=@shopify/hydrogen",
     "build": "yarn turbo run build",
     "lint": "run-p lint:js lint:language",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx packages/*/src",
@@ -65,7 +65,7 @@
     "sirv": "^1.0.12",
     "ts-jest": "^26.5.4",
     "ts-node": "^10.2.1",
-    "turbo": "^1.1.2",
+    "turbo": "^1.2.8",
     "type-fest": "^2.12.0",
     "typescript": "^4.6.2",
     "vite": "^2.9.0",

--- a/packages/create-hydrogen-app/index.js
+++ b/packages/create-hydrogen-app/index.js
@@ -132,7 +132,7 @@ async function init() {
    * we add for use in the monorepo (LOCAL_DEV).
    */
   for (const scriptName of ['dev']) {
-    const match = pkg.scripts[scriptName].match(/(vite( .*)?)$/);
+    const match = pkg.scripts[scriptName].match(/(shopify( .*)?)$/);
     if (match) {
       pkg.scripts[scriptName] = match[0];
     }

--- a/templates/template-hydrogen-default/package.json
+++ b/templates/template-hydrogen-default/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "shopify hydrogen dev",
+    "dev": "cross-env LOCAL_DEV=true shopify hydrogen dev",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx src",
     "lint:css": "stylelint ./src/**/*.{css,sass,scss}",

--- a/templates/template-hydrogen-hello-world/package.json
+++ b/templates/template-hydrogen-hello-world/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "shopify hydrogen dev",
+    "dev": "cross-env LOCAL_DEV=true shopify hydrogen dev",
     "build": "shopify hydrogen build",
     "preview": "shopify hydrogen preview"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -13,8 +13,7 @@
       "outputs": []
     },
     "dev": {
-      "cache": false,
-      "dependsOn": ["@shopify/hydrogen#build"]
+      "cache": false
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12286,83 +12286,89 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbo-darwin-64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.1.2.tgz#b129aaf538821de78d5e2129495c553627174650"
-  integrity sha512-rua17HnVvAqAU54gVfiQoH7cfopOqANv+yI6NtxLMD8aFfX2cJ9m8SSvH2v2vCaToNDW6OnTkdqDKQpqIHzbCw==
+turbo-darwin-64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.2.8.tgz#c5924410087c936d1b029125a5b6352e4883b212"
+  integrity sha512-W46D05e1EUBE5TpRYjAHZXvR01EGhY8AcZUZa1mQCLmOb/W3knS1jHDAMEfXoPuDhdlolejEcbSHFCmqFRQ6OQ==
 
-turbo-darwin-arm64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.1.2.tgz#07a783ad2e3e8af600ae7406cc4062ff56ac0351"
-  integrity sha512-otqSQNYDyKg0KqB3NM0BI4oiRPKdJkUE/XBn8dcUS+zeRLrL00XtaM0eSwynZs1tb6zU/Y+SPMSBRygD1TCOnw==
+turbo-darwin-arm64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.2.8.tgz#68489df33d216fde27666a83244578a444760b73"
+  integrity sha512-hDcbQzUnKDa5j+MPnt8hbhcENeGD+dxee9O8LkRUGgHFQzqME0YVZsRDwwMCnpRSmr9ZlvZYQJPRELhBdary9Q==
 
-turbo-freebsd-64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.1.2.tgz#9e22abf04ec2298f205a57b5c9ce14e22844baf3"
-  integrity sha512-2nxwVDTAM0DtIQ2i3UOfEsQLF7vp+XZ/b9SKtiHxz710fXvdyuGivYI25axDdcBn8kQ45rnbUnarF1aW8CMGgg==
+turbo-freebsd-64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.2.8.tgz#ec25a38c603d6a166174d46dbf9d75c3bead7fa4"
+  integrity sha512-Bd91gNJ9QdsJOjGTpY0YYIa/BIS9BP21gKcpcjZHl4pRpPHraeT9M+RYtpv9bWH3BUWYf0HUzfagOHubrkKq+g==
 
-turbo-freebsd-arm64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.1.2.tgz#6095c9012881225a5fdfb55362defa12f24b1f8e"
-  integrity sha512-ro1Ah96yzgzyT0BJe1mceAqxPxi0pUwzAvN3IKVpMqi4hYkT3aRbzDCaSxzyC6let2Al/NUsgHnbAv38OF2Xkw==
+turbo-freebsd-arm64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.2.8.tgz#e03f36f91d87322bfac861c6e62fdd9b0114ae20"
+  integrity sha512-T+fVnbZNFfQ990F8xazsC16EkV98PkQy091NDKYqbYD6C+PtyV6VpAXX61XDzw01JVJ0GxH/8eiLNttP5lfmnA==
 
-turbo-linux-32@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.1.2.tgz#4726e533d6966172b6bc4a960524ec2eb61adaab"
-  integrity sha512-HKBsETxQMVaf/DJwMg7pypPbGA6KEu0gEf9C8o2aPJvwMPBYgNsNaU08Xizuh5xzEQTzpbIWfQyqdNgMV4RG3Q==
+turbo-linux-32@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.2.8.tgz#2259e2336767549e43826ac26f7da78b24851a85"
+  integrity sha512-wdhssIJQJfYPz9x4XTWZQSRI0mbzsU0Qf3+4kM2XeGsP9k4mi+1g+4PbGutOLBzIWd9OY619dXz/ut43RWqepA==
 
-turbo-linux-64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.1.2.tgz#dfe7f3a4c91acecdb84ecab330acee06857e568e"
-  integrity sha512-IklKsOklcRHIWkTzKg95BQ6jgJ53kLvRMrp8yqzlvZprkWdiyhAgUxrUTTHOOTce2XA3+jdN2+MwixG44uY2vg==
+turbo-linux-64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.2.8.tgz#a43e4a1be81ec5d9ca0bebeedbab27d22f35c8fd"
+  integrity sha512-9OZhxejgl8qQptTUdGnvNXJeFD+I6xF5jkW/tzu5sY9XcdtVvGJ5S4nXYbzG9kPgg4sC6I2gajMCb1l3f5jxSA==
 
-turbo-linux-arm64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.1.2.tgz#c39b6c50657fa0e82627407c86a5c43f19598e2b"
-  integrity sha512-3kS6sk2lOtuBBqkcL+yeGqD1yew4UZ1o7XUcbDD8UPwhF2kAfK7Qs0vTJw4lnO1scjhihkoTrmXM7yozvjf4/w==
+turbo-linux-arm64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.2.8.tgz#02c7ef3ea69df82a775d152517fef499a3655277"
+  integrity sha512-S7Xu5mhEiTOQNVSaERdCEwWn3IdY0hBIBSoU6TNPD8uIR1jw8r2oV/v/hyuNRRbUfq7as+5tmVXW+RXY/dSkEA==
 
-turbo-linux-arm@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.1.2.tgz#2f51f93a3aa144b8ba25d7b0e3c53ea186a0e9dd"
-  integrity sha512-CNbaTvRozq7H/5jpy9OZlzJ6BkeEXF+nF2n9dHiUrbAXd3nq84Qt9odcQJmGnexP19YS9w6l3tIHncX4BgwtqA==
+turbo-linux-arm@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.2.8.tgz#973f801b656a400e88a5bfd07de114591dbad9fc"
+  integrity sha512-RFLScvJPiuVoTDl83iCFNhXICi+F26A0dhBRaOdD9xP5CjcRTS7ITrPpfiELZ/oQzDdZpk3kD+6MxJPtWxoUkg==
 
-turbo-linux-mips64le@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.1.2.tgz#f52b7f410ac289d4e539f108679d2324aa5e271e"
-  integrity sha512-CDoXVIlW43C6KLgYxe13KkG8h6DswXHxbTVHiZdOwRQ56j46lU+JOVpLoh6wpQGcHvj58VEiypZBRTGVFMeogw==
+turbo-linux-mips64le@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.2.8.tgz#d3b13be537dd9ece62cf5d4455a9b98ea52402c0"
+  integrity sha512-JXakBXqVhQrNwwe9t/qw1XowTxKuwv4zh3XVjIX4lKrIPjZZq4XRb3zjLRmtNK7MOV9VZ6Tg6JGc87CNYtp2eA==
 
-turbo-linux-ppc64le@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.1.2.tgz#18d08d3414075d0dcb4be83ca837dda508313996"
-  integrity sha512-xPVMHoiOJE/qI63jSOXwYIUFQXLdstxDV6fLnRxvq0QnJNxgTKq+mLUeE8M4LDVh1bdqHLcfk/HmyQ6+X1XVkQ==
+turbo-linux-ppc64le@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.2.8.tgz#245d2d214a2de9a76b6557474b5e504b34fb7b0a"
+  integrity sha512-GBFcyV6y+KHmBCylJmk9/b8YO7O5jknWf3Radva3YYcfihzn7gm6pCWd17ML28ZLMEvJfWEtbHrU4gDFk+k7Mw==
 
-turbo-windows-32@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.1.2.tgz#96033019094bcb091647d6063c3c9b8e83d0acbe"
-  integrity sha512-Gj1yvPE0aMDSOxGVSBaecLnwsVDT1xX8U0dtLrg52TYY2jlaci0atjHKr9nTFuX7z8uwAf6PopwdriGoCeT3ng==
+turbo-windows-32@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.2.8.tgz#4ccc52150138c4de1d0adff5ffbf154bc51d26fe"
+  integrity sha512-z6FSmbPDtDxz0vDbP5Odd1wJx7aACtxQ8XvIRB5sR+dvSCW40RZZLh9LTjWb49y3l7YsnqVdjEE0/bTu56M7hQ==
 
-turbo-windows-64@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.1.2.tgz#8eb3f77ab7e04b077752ae2204114c82e5c74697"
-  integrity sha512-0Ncx/iKhnKrdAU8hJ+8NUcF9jtFr8KoW5mMWfiFzy+mgUbVKbpzWT2eoGR6zJExedQsRvYOejbEX5iihbnj5bA==
+turbo-windows-64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.2.8.tgz#03e353c34c6aff312665e41d9e3ad25f41b51d6d"
+  integrity sha512-RiIy6ZfuEquje7k53DXNI9zR34AN5/8JJwZLnVhPzdqYdth9EXROS9pOKNNnYEvcWoG34xbgISezsxTXzcHVAA==
 
-turbo@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.1.2.tgz#751b9651dc3ebe469898db76afab6405666ad0ff"
-  integrity sha512-3ViHKyAkaBKNKwHASTa1zkVT3tVVhQNLrpxBS7LoN+794ouQUYmy6lf0rTqzG3iTZHtIDwC+piZSdTl4XjEVMg==
+turbo-windows-arm64@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.2.8.tgz#3710e92bb99d76e62cf3928650710a892157e101"
+  integrity sha512-usARU7a51r8bY+Z6d7bO3N+97x2C4d2PftbDQaTTBuHQCdbYoZSKhiTPTJfrij8FaxVWjtfoTBxlTCh3mzuNOQ==
+
+turbo@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.2.8.tgz#e2cc53eb62797a22cd6b7b34f47a4494a4793110"
+  integrity sha512-Ms5ZvRlTjl3RF+ccWuGK2Gzgm4Zvr6mtaNwtBJR48u8gcDRjg1eSrpkwvCD+ENEVeQ39MxKjNS51ZYPIBnnhUw==
   optionalDependencies:
-    turbo-darwin-64 "1.1.2"
-    turbo-darwin-arm64 "1.1.2"
-    turbo-freebsd-64 "1.1.2"
-    turbo-freebsd-arm64 "1.1.2"
-    turbo-linux-32 "1.1.2"
-    turbo-linux-64 "1.1.2"
-    turbo-linux-arm "1.1.2"
-    turbo-linux-arm64 "1.1.2"
-    turbo-linux-mips64le "1.1.2"
-    turbo-linux-ppc64le "1.1.2"
-    turbo-windows-32 "1.1.2"
-    turbo-windows-64 "1.1.2"
+    turbo-darwin-64 "1.2.8"
+    turbo-darwin-arm64 "1.2.8"
+    turbo-freebsd-64 "1.2.8"
+    turbo-freebsd-arm64 "1.2.8"
+    turbo-linux-32 "1.2.8"
+    turbo-linux-64 "1.2.8"
+    turbo-linux-arm "1.2.8"
+    turbo-linux-arm64 "1.2.8"
+    turbo-linux-mips64le "1.2.8"
+    turbo-linux-ppc64le "1.2.8"
+    turbo-windows-32 "1.2.8"
+    turbo-windows-64 "1.2.8"
+    turbo-windows-arm64 "1.2.8"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We've found that running both the `dev` for hydrogen framework and hydrogen UI + every template option is not ideal.

Instead, we should use turbo to run the dev for the framework + UI and let the developer decide which template they want to develop against.

This PR updates turbo to use the new `filter` functionality, and it updates the instructions to tell the developer to open a separate terminal tab to develop the template.