### PR TITLE
Prevent JSON parsing from prototype poisoning attacks

### DIFF
--- a/.changeset/odd-queens-pay.md
+++ b/.changeset/odd-queens-pay.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Prevent JSON parsing from prototype poisoning attacks
+Prevent JSON parsing from prototype poisoning vulnerabilities

--- a/.changeset/odd-queens-pay.md
+++ b/.changeset/odd-queens-pay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Prevent JSON parsing from prototype poisoning attacks

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -46,6 +46,7 @@ import {RenderType} from './utilities/log/log';
 import {Analytics} from './foundation/Analytics/Analytics.server';
 import {ServerAnalyticsRoute} from './foundation/Analytics/ServerAnalyticsRoute.server';
 import {getSyncSessionApi} from './foundation/session/session';
+import {parseJSON} from './utilities/parse';
 
 declare global {
   // This is provided by a Vite plugin
@@ -599,7 +600,7 @@ async function hydrate(
     componentResponse,
   }: HydratorOptions
 ) {
-  const state = JSON.parse(url.searchParams.get('state') || '{}');
+  const state = parseJSON(url.searchParams.get('state') || '{}');
 
   const {AppRSC} = buildAppRSC({
     App,

--- a/packages/hydrogen/src/foundation/Cookie/Cookie.ts
+++ b/packages/hydrogen/src/foundation/Cookie/Cookie.ts
@@ -1,5 +1,6 @@
 import {parse, stringify as stringifyCookie} from 'worktop/cookie';
 import {log} from '../../utilities/log';
+import {parseJSON} from '../../utilities/parse';
 
 export type CookieOptions = {
   /** Whether to secure the cookie so that the browser only sends it over HTTPS. Some
@@ -65,7 +66,7 @@ export class Cookie {
 
   parse(cookie: string) {
     try {
-      const data = JSON.parse(parse(cookie)[this.name]);
+      const data = parseJSON(parse(cookie)[this.name]);
       this.data = data;
     } catch (e) {
       // failure to parse cookie

--- a/packages/hydrogen/src/foundation/FileSessionStorage/FileSessionStorage.ts
+++ b/packages/hydrogen/src/foundation/FileSessionStorage/FileSessionStorage.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import {promises as fsp} from 'fs';
 import type {CookieOptions} from '../Cookie/Cookie';
 import {Logger} from '../../utilities/log';
+import {parseJSON} from '../../utilities/parse';
 
 async function wait() {
   return new Promise((resolve) => setTimeout(resolve));
@@ -104,7 +105,7 @@ async function getFile(
       const textContent = await fsp.readFile(file, {encoding: 'utf-8'});
 
       try {
-        content = JSON.parse(textContent) as SessionFile;
+        content = parseJSON(textContent) as SessionFile;
       } catch (error) {
         log.warn(`Cannot parse existing session file: ${file}`);
         content = defaultFileContent;

--- a/packages/hydrogen/src/foundation/fetchSync/client/fetchSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/client/fetchSync.ts
@@ -1,3 +1,4 @@
+import {parseJSON} from '../../../utilities/parse';
 import {suspendFunction, preloadFunction} from '../../../utilities/suspense';
 import type {FetchResponse} from '../types';
 
@@ -14,7 +15,7 @@ export function fetchSync(url: string, options?: RequestInit): FetchResponse {
 
   return {
     response,
-    json: () => JSON.parse(text),
+    json: () => parseJSON(text),
     text: () => text,
   };
 }

--- a/packages/hydrogen/src/foundation/fetchSync/server/fetchSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/server/fetchSync.ts
@@ -1,3 +1,4 @@
+import {parseJSON} from '../../../utilities/parse';
 import {type HydrogenUseQueryOptions, useQuery} from '../../useQuery/hooks';
 import type {FetchResponse} from '../types';
 
@@ -35,7 +36,7 @@ export function fetchSync(
 
   return {
     response,
-    json: () => JSON.parse(data),
+    json: () => parseJSON(data),
     text: () => data,
   };
 }

--- a/packages/hydrogen/src/foundation/useUrl/useUrl.ts
+++ b/packages/hydrogen/src/foundation/useUrl/useUrl.ts
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import {RSC_PATHNAME} from '../../constants';
+import {parseJSON} from '../../utilities/parse';
 import {useLocation} from '../Router/BrowserRouter.client';
 import {useEnvContext, META_ENV_SSR} from '../ssr-interop';
 
@@ -13,7 +14,7 @@ export function useUrl(): URL {
     );
 
     if (serverUrl.pathname === RSC_PATHNAME) {
-      const state = JSON.parse(serverUrl.searchParams.get('state') || '{}');
+      const state = parseJSON(serverUrl.searchParams.get('state') || '{}');
 
       const parsedUrl = `${serverUrl.origin}${state.pathname ?? ''}${
         state.search ?? ''

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
@@ -7,6 +7,7 @@ import {hashKey} from '../../utilities/hash';
 import {HelmetData as HeadData} from 'react-helmet-async';
 import {RSC_PATHNAME} from '../../constants';
 import {SessionSyncApi} from '../../foundation/session/session';
+import {parseJSON} from '../../utilities/parse';
 
 export type PreloadQueryEntry = {
   key: QueryKey;
@@ -203,7 +204,7 @@ function getInitFromNodeRequest(request: any) {
 
 function normalizeUrl(rawUrl: string) {
   const url = new URL(rawUrl);
-  const state = JSON.parse(url.searchParams.get('state') ?? '');
+  const state = parseJSON(url.searchParams.get('state') ?? '');
   const normalizedUrl = new URL(state?.pathname ?? '', url.origin);
   normalizedUrl.search = state?.search;
 

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -10,6 +10,7 @@ import {sendMessageToClient} from '../../utilities/devtools';
 import {fetchSync} from '../../foundation/fetchSync/server/fetchSync';
 import {META_ENV_SSR} from '../../foundation/ssr-interop';
 import {getStorefrontApiRequestHeaders} from '../../utilities/storefrontApi';
+import {parseJSON} from '../../utilities/parse';
 
 export interface UseShopQueryResponse<T> {
   /** The data returned by the query. */
@@ -21,7 +22,7 @@ export interface UseShopQueryResponse<T> {
 // https://spec.graphql.org/June2018/#sec-Response-Format
 const shouldCacheResponse = ([body]: [any, Response]) => {
   try {
-    return !JSON.parse(body)?.errors;
+    return !parseJSON(body)?.errors;
   } catch {
     // If we can't parse the response, then assume
     // an error and don't cache the response

--- a/packages/hydrogen/src/utilities/parse.ts
+++ b/packages/hydrogen/src/utilities/parse.ts
@@ -1,0 +1,7 @@
+export function parseJSON(json: any) {
+  if (String(json).includes('__proto__')) return JSON.parse(json, noproto);
+  return JSON.parse(json);
+}
+function noproto(k: string, v: string) {
+  if (k !== '__proto__') return v;
+}

--- a/packages/hydrogen/src/utilities/parseMetafieldValue/parseMetafieldValue.ts
+++ b/packages/hydrogen/src/utilities/parseMetafieldValue/parseMetafieldValue.ts
@@ -1,5 +1,6 @@
 import type {Metafield} from '../../storefront-api-types';
 import type {PartialDeep} from 'type-fest';
+import {parseJSON} from '../parse';
 
 /**
  * The `parseMetafieldValue` function parses a [Metafield](https://shopify.dev/api/storefront/reference/common-objects/metafield)'s `value` from a string into a sensible type corresponding to the [Metafield](https://shopify.dev/api/storefront/reference/common-objects/metafield)'s `type`.
@@ -24,7 +25,7 @@ export function parseMetafieldValue(metafield: PartialDeep<Metafield>) {
     case 'dimension':
     case 'volume':
     case 'rating':
-      return JSON.parse(metafield.value);
+      return parseJSON(metafield.value);
     case 'color':
     case 'single_line_text_field':
     case 'multi_line_text_field':

--- a/packages/hydrogen/src/utilities/tests/metafields.ts
+++ b/packages/hydrogen/src/utilities/tests/metafields.ts
@@ -3,6 +3,7 @@ import faker from 'faker';
 import type {Metafield} from '../../storefront-api-types';
 import {ParsedMetafield, Rating} from '../../types';
 import type {PartialDeep} from 'type-fest';
+import {parseJSON} from '../parse';
 
 export type MetafieldType =
   | 'single_line_text_field'
@@ -165,7 +166,7 @@ export function getParsedMetafield(
     case 'dimension':
     case 'volume':
     case 'rating':
-      field.value = JSON.parse(rawField.value) as Rating;
+      field.value = parseJSON(rawField.value) as Rating;
       break;
     case 'color':
     case 'single_line_text_field':


### PR DESCRIPTION
### Description

Hydrogen's JSON parsing is currently vulnerable to prototype poisoning on the server (no concern in the browser). The attack involves including `__proto__` in a JSON request. If we directly use `JSON.parse`, any property defined inside `__proto__` will become a part of the object.

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
