### PR TITLE
Support optional `priority` prop on Image component

### DIFF
--- a/.changeset/sour-horses-confess.md
+++ b/.changeset/sour-horses-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+[#1245](https://github.com/Shopify/hydrogen/pull/1245) - Support optional `priority` prop on Image component. When `true`, the image will be eagerly loaded. Defaults to `false`.

--- a/docs/components/primitive/image.md
+++ b/docs/components/primitive/image.md
@@ -77,7 +77,7 @@ export default function ExternalImageWithLoader() {
 | height         | <code>height</code>                              | The integer value for the height of the image. This is a required prop when `src` is present.                                                                                                        |
 | loader?        | <code>(props: ImageLoaderOptions): string</code> | A custom function that generates the image URL. Parameters passed into this function includes `src` and an `options` object that contains the provided `width`, `height` and `loaderOptions` values. |
 | loaderOptions? | <code>ImageLoaderOptions['options']</code>       | An object of `loader` function options. For example, if the `loader` function requires a `scale` option, then the value can be a property of the `loaderOptions` object (for example, `{scale: 2}`). |
-| loading? | <code>string</code>       | A string that indicates how the browser should [load an image](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
+| priority? | <code>boolean</code>       | When true, the image will be eagerly loaded. Defaults to `false`. Should only be used when the image is visible above the fold. For more information refer to [Image Element Loading Attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
 
 ## Component type
 

--- a/docs/components/primitive/image.md
+++ b/docs/components/primitive/image.md
@@ -77,7 +77,7 @@ export default function ExternalImageWithLoader() {
 | height         | <code>height</code>                              | The integer value for the height of the image. This is a required prop when `src` is present.                                                                                                        |
 | loader?        | <code>(props: ImageLoaderOptions): string</code> | A custom function that generates the image URL. Parameters passed into this function includes `src` and an `options` object that contains the provided `width`, `height` and `loaderOptions` values. |
 | loaderOptions? | <code>ImageLoaderOptions['options']</code>       | An object of `loader` function options. For example, if the `loader` function requires a `scale` option, then the value can be a property of the `loaderOptions` object (for example, `{scale: 2}`). |
-| priority? | <code>boolean</code>       | When true, the image will be eagerly loaded. Defaults to `false`. Should only be used when the image is visible above the fold. For more information refer to [Image Element Loading Attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
+| priority? | <code>boolean</code>       | Whether the image will be immediately loaded. Defaults to `false`. This prop should be used only when the image is visible above the fold. For more information, refer to the [Image Embed element's loading attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
 
 ## Component type
 

--- a/docs/components/primitive/image.md
+++ b/docs/components/primitive/image.md
@@ -77,7 +77,7 @@ export default function ExternalImageWithLoader() {
 | height         | <code>height</code>                              | The integer value for the height of the image. This is a required prop when `src` is present.                                                                                                        |
 | loader?        | <code>(props: ImageLoaderOptions): string</code> | A custom function that generates the image URL. Parameters passed into this function includes `src` and an `options` object that contains the provided `width`, `height` and `loaderOptions` values. |
 | loaderOptions? | <code>ImageLoaderOptions['options']</code>       | An object of `loader` function options. For example, if the `loader` function requires a `scale` option, then the value can be a property of the `loaderOptions` object (for example, `{scale: 2}`). |
-| loading? | <code>string</code>       | A string that indicates how the browser should load an image. [Image `loading` Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
+| loading? | <code>string</code>       | A string that indicates how the browser should [load an image](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
 
 ## Component type
 

--- a/docs/components/primitive/image.md
+++ b/docs/components/primitive/image.md
@@ -77,6 +77,7 @@ export default function ExternalImageWithLoader() {
 | height         | <code>height</code>                              | The integer value for the height of the image. This is a required prop when `src` is present.                                                                                                        |
 | loader?        | <code>(props: ImageLoaderOptions): string</code> | A custom function that generates the image URL. Parameters passed into this function includes `src` and an `options` object that contains the provided `width`, `height` and `loaderOptions` values. |
 | loaderOptions? | <code>ImageLoaderOptions['options']</code>       | An object of `loader` function options. For example, if the `loader` function requires a `scale` option, then the value can be a property of the `loaderOptions` object (for example, `{scale: 2}`). |
+| loading? | <code>string</code>       | A string that indicates how the browser should load an image. [Image `loading` Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).   |
 
 ## Component type
 

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -17,8 +17,8 @@ export interface BaseImageProps {
    * then the value can be a property of the `loaderOptions` object (for example, `{scale: 2}`).
    */
   loaderOptions?: ImageLoaderOptions['options'];
-  /** 
-   * Whether the image will be immediately loaded. Defaults to `false`. This prop should be used only when 
+  /**
+   * Whether the image will be immediately loaded. Defaults to `false`. This prop should be used only when
    * the image is visible above the fold. For more information, refer to the
    * [Image Embed element's loading attribute](https://developer.mozilla.org/enUS/docs/Web/HTML/Element/img#attr-loading).
    */

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -18,9 +18,10 @@ export interface BaseImageProps {
    */
   loaderOptions?: ImageLoaderOptions['options'];
   /** 
-   * A string that indicates how the browser should [load an image](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).
+   * When true, the image will be eagerly loaded. Defaults to `false`. Should only be used when 
+   * the image is visible above the fold. For more information refer to [Image Element Loading Attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).
    */
-  loading?: string
+  priority?: boolean
 }
 
 interface MediaImagePropsBase extends BaseImageProps {
@@ -61,7 +62,7 @@ export function Image(props: ImageProps) {
     height,
     loader,
     loaderOptions,
-    loading,
+    priority,
     ...passthroughProps
   } = props;
 
@@ -85,7 +86,7 @@ export function Image(props: ImageProps) {
         loaderOptions,
         id,
         alt,
-        loading,
+        priority,
       })
     : {
         src,
@@ -94,7 +95,7 @@ export function Image(props: ImageProps) {
         width,
         height,
         loader,
-        loading,
+        priority,
         loaderOptions: {width, height, ...loaderOptions},
       };
 
@@ -106,7 +107,7 @@ export function Image(props: ImageProps) {
   return (
     <img
       id={imgProps.id ?? ''}
-      loading={imgProps.loading ?? 'lazy'}
+      loading={priority ? 'eager' : 'lazy'}
       alt={imgProps.alt ?? ''}
       {...passthroughProps}
       src={srcPath}
@@ -121,7 +122,7 @@ function convertShopifyImageData({
   data,
   options,
   loader,
-  loading,
+  priority,
   loaderOptions,
   id: propId,
   alt,
@@ -139,6 +140,6 @@ function convertShopifyImageData({
     height,
     loader: loader ? loader : shopifyImageLoader,
     loaderOptions: {...options, ...loaderOptions},
-    loading
+    priority,
   };
 }

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -18,8 +18,9 @@ export interface BaseImageProps {
    */
   loaderOptions?: ImageLoaderOptions['options'];
   /** 
-   * When true, the image will be eagerly loaded. Defaults to `false`. Should only be used when 
-   * the image is visible above the fold. For more information refer to [Image Element Loading Attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).
+   * Whether the image will be immediately loaded. Defaults to `false`. This prop should be used only when 
+   * the image is visible above the fold. For more information, refer to the
+   * [Image Embed element's loading attribute](https://developer.mozilla.org/enUS/docs/Web/HTML/Element/img#attr-loading).
    */
   priority?: boolean;
 }

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -17,6 +17,11 @@ export interface BaseImageProps {
    * then the value can be a property of the `loaderOptions` object (for example, `{scale: 2}`).
    */
   loaderOptions?: ImageLoaderOptions['options'];
+  /** 
+   * A string that indicates how the browser should load an image.  
+   * [Img Loading Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading)
+   */
+  loading?: string
 }
 
 interface MediaImagePropsBase extends BaseImageProps {
@@ -57,6 +62,7 @@ export function Image(props: ImageProps) {
     height,
     loader,
     loaderOptions,
+    loading,
     ...passthroughProps
   } = props;
 
@@ -80,6 +86,7 @@ export function Image(props: ImageProps) {
         loaderOptions,
         id,
         alt,
+        loading,
       })
     : {
         src,
@@ -88,6 +95,7 @@ export function Image(props: ImageProps) {
         width,
         height,
         loader,
+        loading,
         loaderOptions: {width, height, ...loaderOptions},
       };
 
@@ -99,7 +107,7 @@ export function Image(props: ImageProps) {
   return (
     <img
       id={imgProps.id ?? ''}
-      loading="lazy"
+      loading={imgProps.loading ?? 'lazy'}
       alt={imgProps.alt ?? ''}
       {...passthroughProps}
       src={srcPath}
@@ -114,6 +122,7 @@ function convertShopifyImageData({
   data,
   options,
   loader,
+  loading,
   loaderOptions,
   id: propId,
   alt,
@@ -131,5 +140,6 @@ function convertShopifyImageData({
     height,
     loader: loader ? loader : shopifyImageLoader,
     loaderOptions: {...options, ...loaderOptions},
+    loading
   };
 }

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -21,7 +21,7 @@ export interface BaseImageProps {
    * When true, the image will be eagerly loaded. Defaults to `false`. Should only be used when 
    * the image is visible above the fold. For more information refer to [Image Element Loading Attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).
    */
-  priority?: boolean
+  priority?: boolean;
 }
 
 interface MediaImagePropsBase extends BaseImageProps {
@@ -107,7 +107,7 @@ export function Image(props: ImageProps) {
   return (
     <img
       id={imgProps.id ?? ''}
-      loading={priority ? 'eager' : 'lazy'}
+      loading={imgProps.priority ? 'eager' : 'lazy'}
       alt={imgProps.alt ?? ''}
       {...passthroughProps}
       src={srcPath}

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -18,8 +18,7 @@ export interface BaseImageProps {
    */
   loaderOptions?: ImageLoaderOptions['options'];
   /** 
-   * A string that indicates how the browser should load an image.  
-   * [Img Loading Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading)
+   * A string that indicates how the browser should [load an image](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading).
    */
   loading?: string
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

By default all `img` tags rendered using the `Image` component provided by Hydrogen have a `loading` attribute of `lazy`. This is not ideal for images that are above the fold as it can/will delay the FCP (image below)

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/17521434/167731354-164231ff-0db0-45fd-842e-475910d697be.png">

This pull request adds `loading` as a prop that can be passed to any image/media component with a fallback to the lazy default. Currently specifying this property using `passThroughProps` results in two `loading` attributes on the `img` element––the browser takes the first and lazily loads the image.

_This same functionality is covered (much better) by the proposal in #1223. However, Shopify is pushing Plus Merchants to build on Hydrogen prior to the production-ready rollout of the framework and this will/is affect(ing) anyone going to/already in production :)._

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
