### PR TITLE
Improve client component discovery

### DIFF
--- a/.changeset/neat-flies-yawn.md
+++ b/.changeset/neat-flies-yawn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improve the way client components are discovered in order to reduce bundle sizes.

--- a/packages/hydrogen/src/framework/plugin.ts
+++ b/packages/hydrogen/src/framework/plugin.ts
@@ -46,13 +46,10 @@ export default (pluginOptions: HydrogenVitePluginOptions = {}) => {
         ...[hydrogenUiPath].filter(Boolean),
       ],
       isServerComponentImporterAllowed(importer: string, source: string) {
-        // Always allow the entry server (e.g. App.server.jsx) to be imported
-        // in other files such as worker.js or server.js.
-        const entryServer =
-          process.env.HYDROGEN_SERVER_ENTRY || HYDROGEN_DEFAULT_SERVER_ENTRY;
-
         return (
-          source.includes(entryServer) ||
+          // Always allow the entry server (e.g. App.server.jsx) to be imported
+          // in other files such as worker.js or server.js.
+          source.includes(HYDROGEN_DEFAULT_SERVER_ENTRY) ||
           // TODO update this after handleEvent is replaced with handleRequest
           /(index|entry-server|hydrogen\.config)\.[jt]s/.test(importer) ||
           // Support importing server components for testing

--- a/packages/hydrogen/src/framework/plugin.ts
+++ b/packages/hydrogen/src/framework/plugin.ts
@@ -1,36 +1,20 @@
 import type {HydrogenVitePluginOptions} from '../types';
 import hydrogenConfig from './plugins/vite-plugin-hydrogen-config';
 import type {Plugin} from 'vite';
-import hydrogenMiddleware, {
-  HYDROGEN_DEFAULT_SERVER_ENTRY,
-} from './plugins/vite-plugin-hydrogen-middleware';
+import hydrogenMiddleware from './plugins/vite-plugin-hydrogen-middleware';
 import hydrogenClientMiddleware from './plugins/vite-plugin-hydrogen-client-middleware';
 import platformEntry from './plugins/vite-plugin-platform-entry';
-// @ts-ignore
-import rsc from '@shopify/hydrogen/vendor/react-server-dom-vite/plugin';
+import rsc from './plugins/vite-plugin-hydrogen-rsc';
 import ssrInterop from './plugins/vite-plugin-ssr-interop';
 import purgeQueryCache from './plugins/vite-plugin-purge-query-cache';
 import hydrationAutoImport from './plugins/vite-plugin-hydration-auto-import';
 import inspect from 'vite-plugin-inspect';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 import cssModulesRsc from './plugins/vite-plugin-css-modules-rsc';
 
 export default (pluginOptions: HydrogenVitePluginOptions = {}) => {
-  let hydrogenUiPath;
-
-  try {
-    hydrogenUiPath = path.join(
-      // eslint-disable-next-line node/no-missing-require
-      path.dirname(require.resolve('@shopify/hydrogen-ui/client'))
-    );
-  } catch (error) {
-    // hydrogen-ui isn't installed, so don't worry about it
-  }
-
   return [
     process.env.VITE_INSPECT && inspect(),
-
     hydrogenConfig(),
     hydrogenClientMiddleware(),
     hydrogenMiddleware(pluginOptions),
@@ -38,26 +22,7 @@ export default (pluginOptions: HydrogenVitePluginOptions = {}) => {
     hydrationAutoImport(),
     ssrInterop(),
     cssModulesRsc(),
-    rsc({
-      clientComponentPaths: [
-        path.join(
-          path.dirname(require.resolve('@shopify/hydrogen/package.json'))
-        ),
-        ...[hydrogenUiPath].filter(Boolean),
-      ],
-      isServerComponentImporterAllowed(importer: string, source: string) {
-        return (
-          // Always allow the entry server (e.g. App.server.jsx) to be imported
-          // in other files such as worker.js or server.js.
-          source.includes(HYDROGEN_DEFAULT_SERVER_ENTRY) ||
-          // TODO update this after handleEvent is replaced with handleRequest
-          /(index|entry-server|hydrogen\.config)\.[jt]s/.test(importer) ||
-          // Support importing server components for testing
-          // TODO: revisit this when RSC splits into two bundles
-          /\.test\.[tj]sx?$/.test(importer)
-        );
-      },
-    }),
+    rsc(),
     platformEntry(),
     pluginOptions.purgeQueryCacheOnBuild && purgeQueryCache(),
   ] as Plugin[];

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -6,7 +6,10 @@ export default () => {
     output: {},
   };
 
-  if (process.env.WORKER) {
+  const isWorker =
+    Boolean(process.env.WORKER) && process.env.WORKER !== 'undefined';
+
+  if (isWorker) {
     /**
      * By default, SSR dedupe logic gets bundled which runs `require('module')`.
      * We don't want this in our workers runtime, because `require` is not supported.
@@ -52,8 +55,8 @@ export default () => {
          * Tell Vite to bundle everything when we're building for Workers.
          * Otherwise, bundle RSC plugin as a workaround to apply the vendor alias above.
          */
-        noExternal: Boolean(process.env.WORKER) || [/react-server-dom-vite/],
-        target: process.env.WORKER ? 'webworker' : 'node',
+        noExternal: isWorker || [/react-server-dom-vite/],
+        target: isWorker ? 'webworker' : 'node',
       },
 
       // Reload when updating local Hydrogen lib
@@ -95,7 +98,7 @@ export default () => {
 
       define: {
         __DEV__: env.mode !== 'production',
-        __WORKER__: !!process.env.WORKER,
+        __WORKER__: isWorker,
       },
 
       envPrefix: ['VITE_', 'PUBLIC_'],

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -6,7 +6,8 @@ import {hydrogenMiddleware, graphiqlMiddleware} from '../middleware';
 import type {HydrogenVitePluginOptions} from '../../types';
 import {InMemoryCache} from '../cache/in-memory';
 
-export const HYDROGEN_DEFAULT_SERVER_ENTRY = '/src/App.server';
+export const HYDROGEN_DEFAULT_SERVER_ENTRY =
+  process.env.HYDROGEN_SERVER_ENTRY || '/src/App.server';
 
 const virtualModuleId = 'virtual:hydrogen-config';
 const virtualProxyModuleId = virtualModuleId + ':proxy';
@@ -73,10 +74,7 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
             dev: true,
             indexTemplate: getIndexTemplate,
             getServerEntrypoint: () =>
-              server.ssrLoadModule(
-                process.env.HYDROGEN_SERVER_ENTRY ||
-                  HYDROGEN_DEFAULT_SERVER_ENTRY
-              ),
+              server.ssrLoadModule(HYDROGEN_DEFAULT_SERVER_ENTRY),
             devServer: server,
             cache: pluginOptions?.devCache
               ? (new InMemoryCache() as unknown as Cache)

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-rsc.ts
@@ -1,0 +1,39 @@
+// @ts-ignore
+import reactServerDomVite from '@shopify/hydrogen/vendor/react-server-dom-vite/plugin';
+import {HYDROGEN_DEFAULT_SERVER_ENTRY} from './vite-plugin-hydrogen-middleware';
+import {createServer} from 'vite';
+
+export default function () {
+  return reactServerDomVite({
+    isServerComponentImporterAllowed(importer: string, source: string) {
+      return (
+        // Always allow the entry server (e.g. App.server.jsx) to be imported
+        // in other files such as worker.js or server.js.
+        source.includes(HYDROGEN_DEFAULT_SERVER_ENTRY) ||
+        /(index|entry-server|hydrogen\.config)\.[jt]s/.test(importer) ||
+        // Support importing server components for testing
+        // TODO: revisit this when RSC splits into two bundles
+        /\.test\.[tj]sx?$/.test(importer)
+      );
+    },
+    async findClientComponentsForClientBuild() {
+      // In client build, we create a local server to discover client compoents.
+      const server = await createServer({server: {middlewareMode: 'ssr'}});
+
+      await Promise.all([
+        // Load server entry to discover client components early
+        server.ssrLoadModule(HYDROGEN_DEFAULT_SERVER_ENTRY),
+        // Route globs are placed in hydrogen.config.js and need to
+        // be loaded to discover client components in routes
+        server.ssrLoadModule('virtual:hydrogen-config:proxy'),
+      ]);
+
+      await server.close();
+
+      // At this point, the server has loaded all the components in the module graph
+      return Array.from(server.moduleGraph.fileToModulesMap.keys()).filter(
+        (item) => /\.client\.[jt]sx?$/.test(item)
+      );
+    },
+  });
+}

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-rsc.ts
@@ -18,7 +18,10 @@ export default function () {
     },
     async findClientComponentsForClientBuild() {
       // In client build, we create a local server to discover client compoents.
-      const server = await createServer({server: {middlewareMode: 'ssr'}});
+      const server = await createServer({
+        clearScreen: false,
+        server: {middlewareMode: 'ssr'},
+      });
 
       await Promise.all([
         // Load server entry to discover client components early

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-rsc.ts
@@ -34,9 +34,7 @@ export default function () {
       await server.close();
 
       // At this point, the server has loaded all the components in the module graph
-      return Array.from(server.moduleGraph.fileToModulesMap.keys()).filter(
-        (item) => /\.client\.[jt]sx?$/.test(item)
-      );
+      return reactServerDomVite.findClientComponentsFromServer(server);
     },
   });
 }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -48,10 +48,7 @@ export default () => {
     transform(code, id) {
       if (normalizePath(id).includes('/hydrogen/dist/esnext/platforms/')) {
         code = code
-          .replace(
-            '__SERVER_ENTRY__',
-            process.env.HYDROGEN_SERVER_ENTRY || HYDROGEN_DEFAULT_SERVER_ENTRY
-          )
+          .replace('__SERVER_ENTRY__', HYDROGEN_DEFAULT_SERVER_ENTRY)
           .replace(
             '__INDEX_TEMPLATE__',
             normalizePath(

--- a/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
@@ -17,7 +17,80 @@ var vite = require('vite');
 var fs = require('fs');
 var path = require('path');
 
-// $FlowFixMe[module-missing]
+function _unsupportedIterableToArray(o, minLen) {
+  if (!o) return;
+  if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+  var n = Object.prototype.toString.call(o).slice(8, -1);
+  if (n === "Object" && o.constructor) n = o.constructor.name;
+  if (n === "Map" || n === "Set") return Array.from(o);
+  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+}
+
+function _arrayLikeToArray(arr, len) {
+  if (len == null || len > arr.length) len = arr.length;
+
+  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+
+  return arr2;
+}
+
+function _createForOfIteratorHelper(o, allowArrayLike) {
+  var it;
+
+  if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) {
+    if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") {
+      if (it) o = it;
+      var i = 0;
+
+      var F = function () {};
+
+      return {
+        s: F,
+        n: function () {
+          if (i >= o.length) return {
+            done: true
+          };
+          return {
+            done: false,
+            value: o[i++]
+          };
+        },
+        e: function (e) {
+          throw e;
+        },
+        f: F
+      };
+    }
+
+    throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var normalCompletion = true,
+      didErr = false,
+      err;
+  return {
+    s: function () {
+      it = o[Symbol.iterator]();
+    },
+    n: function () {
+      var step = it.next();
+      normalCompletion = step.done;
+      return step;
+    },
+    e: function (e) {
+      didErr = true;
+      err = e;
+    },
+    f: function () {
+      try {
+        if (!normalCompletion && it.return != null) it.return();
+      } finally {
+        if (didErr) throw err;
+      }
+    }
+  };
+}
+
 var rscViteFileRE = /\/react-server-dom-vite.js/;
 function ReactFlightVitePlugin() {
   var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
@@ -29,19 +102,38 @@ function ReactFlightVitePlugin() {
       isClientComponent = _ref$isClientComponen === void 0 ? function (id) {
     return /\.client\.[jt]sx?($|\?)/.test(id);
   } : _ref$isClientComponen,
-      findClientComponentsForDev = _ref.findClientComponentsForDev,
       findClientComponentsForClientBuild = _ref.findClientComponentsForClientBuild;
 
   var config;
   var server;
-  var timeout;
+  var invalidateTimeout;
   var absoluteImporterPath;
-  var discoveredClientComponents = [];
 
-  if (!findClientComponentsForDev) {
-    findClientComponentsForDev = function () {
-      return Array.from(server.moduleGraph.fileToModulesMap.keys()).filter(isClientComponent);
+  function invalidateImporter() {
+    clearTimeout(invalidateTimeout);
+    invalidateTimeout = setTimeout(function () {
+      return server.watcher.emit('change', absoluteImporterPath);
+    }, 100);
+  }
+
+  function wrapIfClientComponent(id) {
+    var handle = function (isClient) {
+      if (!isClient) return null;
+
+      if (server) {
+        var moduleNode = server.moduleGraph.getModuleById(id);
+
+        if (!moduleNode.__isClientComponent) {
+          moduleNode.__isClientComponent = true;
+          if (absoluteImporterPath) invalidateImporter();
+        }
+      }
+
+      return proxyClientComponent(id.split('?')[0]);
     };
+
+    var tmp = isClientComponent(id);
+    return typeof tmp === 'boolean' ? handle(tmp) : tmp.then(handle);
   }
 
   return {
@@ -50,54 +142,25 @@ function ReactFlightVitePlugin() {
     configureServer: function (_server) {
       server = _server;
     },
-    configResolved: async function (_config) {
+    configResolved: function (_config) {
       config = _config; // By pushing this plugin at the end of the existing array,
       // we enforce running it *after* Vite resolves import.meta.glob.
 
       config.plugins.push(hashImportsPlugin);
-
-      if (config.command === 'build' && !config.build.ssr) {
-        if (findClientComponentsForClientBuild) {
-          discoveredClientComponents = await findClientComponentsForClientBuild(config);
-        } else {
-          throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
-        }
-      }
     },
-    resolveId: async function (source, importer) {
+    resolveId: function (source, importer) {
       if (!importer) return null;
       /**
        * Throw errors when non-Server Components try to load Server Components.
        */
 
-      if (/\.server(\.[jt]sx?)?$/.test(source) && !(/(\.server\.[jt]sx?|entry-server\.[jt]sx?|index\.html)$/.test(importer) || isServerComponentImporterAllowed(importer, source))) {
+      if (/\.server(\.[jt]sx?)?$/.test(source) && !(/(\.server\.[jt]sx?|index\.html)$/.test(importer) || isServerComponentImporterAllowed(importer, source))) {
         throw new Error("Cannot import " + source + " from \"" + importer + "\". " + 'By react-server convention, .server.js files can only be imported from other .server.js files. ' + 'That way nobody accidentally sends these to the client by indirectly importing it.');
       }
     },
-    load: async function (id) {
+    load: function (id) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      if (!options.ssr) return null; // Wrapped components won't match this becase they end in ?no-proxy
-
-      if (isClientComponent(id) && !/[&?]no-proxy($|&)/.test(id)) {
-        // Refresh the list of discovered client components
-        // every time a new one is processed.
-        if (config.command === 'serve') {
-          clearTimeout(timeout);
-          timeout = setTimeout(async function () {
-            discoveredClientComponents = findClientComponentsForDev ? await findClientComponentsForDev(config, server) : [];
-
-            if (absoluteImporterPath) {
-              // Signal Vite that this file needs to be
-              // refreshed both in server and browser.
-              server.watcher.emit('change', absoluteImporterPath);
-            }
-          }, 100);
-        }
-
-        return proxyClientComponent(id);
-      }
-
-      return null;
+      return options.ssr && shouldCheckClientComponent(id) ? wrapIfClientComponent(id) : null;
     },
     transform: function (code, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -113,7 +176,6 @@ function ReactFlightVitePlugin() {
        */
       if (rscViteFileRE.test(id)) {
         var INJECTING_RE = /\{\s*__INJECTED_CLIENT_IMPORTERS__[:\s]*null[,\s]*\}\s*;/;
-        absoluteImporterPath = id.split('?')[0];
 
         if (options && options.ssr) {
           // In SSR, directly use components already discovered by RSC
@@ -121,16 +183,29 @@ function ReactFlightVitePlugin() {
           return code.replace(INJECTING_RE, 'globalThis.__COMPONENT_INDEX');
         }
 
-        var importerPath = path.dirname(id);
-        var importers = discoveredClientComponents.map(function (absolutePath) {
-          return vite.normalizePath(path.relative(importerPath, absolutePath));
-        });
-        var injectedGlobs = "Object.assign(Object.create(null), " + importers.map(function (glob) {
-          return (// Mark the globs to modify the result after Vite resolves them.
-            "/* HASH_BEGIN */ " + ("import.meta.glob('" + vite.normalizePath(glob) + "') /* HASH_END */")
-          );
-        }).join(', ') + ");";
-        return code.replace(INJECTING_RE, injectedGlobs);
+        var injectGlobs = function (clientComponents) {
+          var importerPath = path.dirname(id);
+          var importers = clientComponents.map(function (absolutePath) {
+            return vite.normalizePath(path.relative(importerPath, absolutePath));
+          });
+          var injectedGlobs = "Object.assign(Object.create(null), " + importers.map(function (glob) {
+            return (// Mark the globs to modify the result after Vite resolves them.
+              "/* HASH_BEGIN */ " + ("import.meta.glob('" + vite.normalizePath(glob) + "') /* HASH_END */")
+            );
+          }).join(', ') + ");";
+          return code.replace(INJECTING_RE, injectedGlobs);
+        };
+
+        if (config.command === 'serve') {
+          absoluteImporterPath = id.split('?')[0];
+          return injectGlobs(findClientComponentsForDev(server));
+        }
+
+        if (!findClientComponentsForClientBuild) {
+          throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
+        }
+
+        return findClientComponentsForClientBuild(config).then(injectGlobs);
       }
     }
   };
@@ -189,6 +264,36 @@ async function proxyClientComponent(filepath, src) {
   });
   return proxyCode;
 }
+
+function shouldCheckClientComponent(id) {
+  return /\.[jt]sx?($|\?)/.test(id) && !/[&?]no-proxy($|&)/.test(id);
+}
+
+function findClientComponentsForDev(server) {
+  var clientComponents = []; // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+
+  var _iterator = _createForOfIteratorHelper(server.moduleGraph.fileToModulesMap.values()),
+      _step;
+
+  try {
+    for (_iterator.s(); !(_step = _iterator.n()).done;) {
+      var set = _step.value;
+      var clientModule = Array.from(set).find(function (moduleNode) {
+        return moduleNode.__isClientComponent;
+      });
+      if (clientModule) clientComponents.push(clientModule.file);
+    }
+  } catch (err) {
+    _iterator.e(err);
+  } finally {
+    _iterator.f();
+  }
+
+  return clientComponents;
+} // This can be used in custom findClientComponentsForClientBuild implementations
+
+
+ReactFlightVitePlugin.findClientComponentsFromServer = findClientComponentsForDev;
 var hashImportsPlugin = {
   name: 'vite-plugin-react-server-components-hash-imports',
   enforce: 'post',

--- a/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
@@ -205,7 +205,8 @@ function ReactFlightVitePlugin() {
           throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
         }
 
-        return findClientComponentsForClientBuild(config).then(injectGlobs);
+        var tmp = findClientComponentsForClientBuild(config);
+        return Array.isArray(tmp) ? injectGlobs(tmp) : tmp.then(injectGlobs);
       }
     }
   };
@@ -290,10 +291,8 @@ function findClientComponentsForDev(server) {
   }
 
   return clientComponents;
-} // This can be used in custom findClientComponentsForClientBuild implementations
+}
 
-
-ReactFlightVitePlugin.findClientComponentsFromServer = findClientComponentsForDev;
 var hashImportsPlugin = {
   name: 'vite-plugin-react-server-components-hash-imports',
   enforce: 'post',
@@ -308,6 +307,8 @@ var hashImportsPlugin = {
       });
     }
   }
-};
+}; // This can be used in custom findClientComponentsForClientBuild implementations
+
+ReactFlightVitePlugin.findClientComponentsFromServer = findClientComponentsForDev;
 
 module.exports = ReactFlightVitePlugin;

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
@@ -65,6 +65,8 @@ function wrapInClientProxy(_ref) {
   var moduleRef = createModuleReference(id, value, name, isDefault);
 
   var get = function (target, prop, receiver) {
+    if (prop === '$$unwrappedValue') return value;
+    if (prop === '$$moduleReference') return moduleRef;
     return Reflect.get(isRsc() ? moduleRef : target, prop, receiver);
   };
 

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
@@ -13,7 +13,80 @@ import { normalizePath, transformWithEsbuild } from 'vite';
 import { promises } from 'fs';
 import path from 'path';
 
-// $FlowFixMe[module-missing]
+function _unsupportedIterableToArray(o, minLen) {
+  if (!o) return;
+  if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+  var n = Object.prototype.toString.call(o).slice(8, -1);
+  if (n === "Object" && o.constructor) n = o.constructor.name;
+  if (n === "Map" || n === "Set") return Array.from(o);
+  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+}
+
+function _arrayLikeToArray(arr, len) {
+  if (len == null || len > arr.length) len = arr.length;
+
+  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+
+  return arr2;
+}
+
+function _createForOfIteratorHelper(o, allowArrayLike) {
+  var it;
+
+  if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) {
+    if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") {
+      if (it) o = it;
+      var i = 0;
+
+      var F = function () {};
+
+      return {
+        s: F,
+        n: function () {
+          if (i >= o.length) return {
+            done: true
+          };
+          return {
+            done: false,
+            value: o[i++]
+          };
+        },
+        e: function (e) {
+          throw e;
+        },
+        f: F
+      };
+    }
+
+    throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var normalCompletion = true,
+      didErr = false,
+      err;
+  return {
+    s: function () {
+      it = o[Symbol.iterator]();
+    },
+    n: function () {
+      var step = it.next();
+      normalCompletion = step.done;
+      return step;
+    },
+    e: function (e) {
+      didErr = true;
+      err = e;
+    },
+    f: function () {
+      try {
+        if (!normalCompletion && it.return != null) it.return();
+      } finally {
+        if (didErr) throw err;
+      }
+    }
+  };
+}
+
 var rscViteFileRE = /\/react-server-dom-vite.js/;
 function ReactFlightVitePlugin() {
   var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
@@ -25,19 +98,38 @@ function ReactFlightVitePlugin() {
       isClientComponent = _ref$isClientComponen === void 0 ? function (id) {
     return /\.client\.[jt]sx?($|\?)/.test(id);
   } : _ref$isClientComponen,
-      findClientComponentsForDev = _ref.findClientComponentsForDev,
       findClientComponentsForClientBuild = _ref.findClientComponentsForClientBuild;
 
   var config;
   var server;
-  var timeout;
+  var invalidateTimeout;
   var absoluteImporterPath;
-  var discoveredClientComponents = [];
 
-  if (!findClientComponentsForDev) {
-    findClientComponentsForDev = function () {
-      return Array.from(server.moduleGraph.fileToModulesMap.keys()).filter(isClientComponent);
+  function invalidateImporter() {
+    clearTimeout(invalidateTimeout);
+    invalidateTimeout = setTimeout(function () {
+      return server.watcher.emit('change', absoluteImporterPath);
+    }, 100);
+  }
+
+  function wrapIfClientComponent(id) {
+    var handle = function (isClient) {
+      if (!isClient) return null;
+
+      if (server) {
+        var moduleNode = server.moduleGraph.getModuleById(id);
+
+        if (!moduleNode.__isClientComponent) {
+          moduleNode.__isClientComponent = true;
+          if (absoluteImporterPath) invalidateImporter();
+        }
+      }
+
+      return proxyClientComponent(id.split('?')[0]);
     };
+
+    var tmp = isClientComponent(id);
+    return typeof tmp === 'boolean' ? handle(tmp) : tmp.then(handle);
   }
 
   return {
@@ -46,54 +138,25 @@ function ReactFlightVitePlugin() {
     configureServer: function (_server) {
       server = _server;
     },
-    configResolved: async function (_config) {
+    configResolved: function (_config) {
       config = _config; // By pushing this plugin at the end of the existing array,
       // we enforce running it *after* Vite resolves import.meta.glob.
 
       config.plugins.push(hashImportsPlugin);
-
-      if (config.command === 'build' && !config.build.ssr) {
-        if (findClientComponentsForClientBuild) {
-          discoveredClientComponents = await findClientComponentsForClientBuild(config);
-        } else {
-          throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
-        }
-      }
     },
-    resolveId: async function (source, importer) {
+    resolveId: function (source, importer) {
       if (!importer) return null;
       /**
        * Throw errors when non-Server Components try to load Server Components.
        */
 
-      if (/\.server(\.[jt]sx?)?$/.test(source) && !(/(\.server\.[jt]sx?|entry-server\.[jt]sx?|index\.html)$/.test(importer) || isServerComponentImporterAllowed(importer, source))) {
+      if (/\.server(\.[jt]sx?)?$/.test(source) && !(/(\.server\.[jt]sx?|index\.html)$/.test(importer) || isServerComponentImporterAllowed(importer, source))) {
         throw new Error("Cannot import " + source + " from \"" + importer + "\". " + 'By react-server convention, .server.js files can only be imported from other .server.js files. ' + 'That way nobody accidentally sends these to the client by indirectly importing it.');
       }
     },
-    load: async function (id) {
+    load: function (id) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      if (!options.ssr) return null; // Wrapped components won't match this becase they end in ?no-proxy
-
-      if (isClientComponent(id) && !/[&?]no-proxy($|&)/.test(id)) {
-        // Refresh the list of discovered client components
-        // every time a new one is processed.
-        if (config.command === 'serve') {
-          clearTimeout(timeout);
-          timeout = setTimeout(async function () {
-            discoveredClientComponents = findClientComponentsForDev ? await findClientComponentsForDev(config, server) : [];
-
-            if (absoluteImporterPath) {
-              // Signal Vite that this file needs to be
-              // refreshed both in server and browser.
-              server.watcher.emit('change', absoluteImporterPath);
-            }
-          }, 100);
-        }
-
-        return proxyClientComponent(id);
-      }
-
-      return null;
+      return options.ssr && shouldCheckClientComponent(id) ? wrapIfClientComponent(id) : null;
     },
     transform: function (code, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -109,7 +172,6 @@ function ReactFlightVitePlugin() {
        */
       if (rscViteFileRE.test(id)) {
         var INJECTING_RE = /\{\s*__INJECTED_CLIENT_IMPORTERS__[:\s]*null[,\s]*\}\s*;/;
-        absoluteImporterPath = id.split('?')[0];
 
         if (options && options.ssr) {
           // In SSR, directly use components already discovered by RSC
@@ -117,16 +179,29 @@ function ReactFlightVitePlugin() {
           return code.replace(INJECTING_RE, 'globalThis.__COMPONENT_INDEX');
         }
 
-        var importerPath = path.dirname(id);
-        var importers = discoveredClientComponents.map(function (absolutePath) {
-          return normalizePath(path.relative(importerPath, absolutePath));
-        });
-        var injectedGlobs = "Object.assign(Object.create(null), " + importers.map(function (glob) {
-          return (// Mark the globs to modify the result after Vite resolves them.
-            "/* HASH_BEGIN */ " + ("import.meta.glob('" + normalizePath(glob) + "') /* HASH_END */")
-          );
-        }).join(', ') + ");";
-        return code.replace(INJECTING_RE, injectedGlobs);
+        var injectGlobs = function (clientComponents) {
+          var importerPath = path.dirname(id);
+          var importers = clientComponents.map(function (absolutePath) {
+            return normalizePath(path.relative(importerPath, absolutePath));
+          });
+          var injectedGlobs = "Object.assign(Object.create(null), " + importers.map(function (glob) {
+            return (// Mark the globs to modify the result after Vite resolves them.
+              "/* HASH_BEGIN */ " + ("import.meta.glob('" + normalizePath(glob) + "') /* HASH_END */")
+            );
+          }).join(', ') + ");";
+          return code.replace(INJECTING_RE, injectedGlobs);
+        };
+
+        if (config.command === 'serve') {
+          absoluteImporterPath = id.split('?')[0];
+          return injectGlobs(findClientComponentsForDev(server));
+        }
+
+        if (!findClientComponentsForClientBuild) {
+          throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
+        }
+
+        return findClientComponentsForClientBuild(config).then(injectGlobs);
       }
     }
   };
@@ -185,6 +260,36 @@ async function proxyClientComponent(filepath, src) {
   });
   return proxyCode;
 }
+
+function shouldCheckClientComponent(id) {
+  return /\.[jt]sx?($|\?)/.test(id) && !/[&?]no-proxy($|&)/.test(id);
+}
+
+function findClientComponentsForDev(server) {
+  var clientComponents = []; // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+
+  var _iterator = _createForOfIteratorHelper(server.moduleGraph.fileToModulesMap.values()),
+      _step;
+
+  try {
+    for (_iterator.s(); !(_step = _iterator.n()).done;) {
+      var set = _step.value;
+      var clientModule = Array.from(set).find(function (moduleNode) {
+        return moduleNode.__isClientComponent;
+      });
+      if (clientModule) clientComponents.push(clientModule.file);
+    }
+  } catch (err) {
+    _iterator.e(err);
+  } finally {
+    _iterator.f();
+  }
+
+  return clientComponents;
+} // This can be used in custom findClientComponentsForClientBuild implementations
+
+
+ReactFlightVitePlugin.findClientComponentsFromServer = findClientComponentsForDev;
 var hashImportsPlugin = {
   name: 'vite-plugin-react-server-components-hash-imports',
   enforce: 'post',

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
@@ -201,7 +201,8 @@ function ReactFlightVitePlugin() {
           throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
         }
 
-        return findClientComponentsForClientBuild(config).then(injectGlobs);
+        var tmp = findClientComponentsForClientBuild(config);
+        return Array.isArray(tmp) ? injectGlobs(tmp) : tmp.then(injectGlobs);
       }
     }
   };
@@ -286,10 +287,8 @@ function findClientComponentsForDev(server) {
   }
 
   return clientComponents;
-} // This can be used in custom findClientComponentsForClientBuild implementations
+}
 
-
-ReactFlightVitePlugin.findClientComponentsFromServer = findClientComponentsForDev;
 var hashImportsPlugin = {
   name: 'vite-plugin-react-server-components-hash-imports',
   enforce: 'post',
@@ -304,6 +303,8 @@ var hashImportsPlugin = {
       });
     }
   }
-};
+}; // This can be used in custom findClientComponentsForClientBuild implementations
+
+ReactFlightVitePlugin.findClientComponentsFromServer = findClientComponentsForDev;
 
 export default ReactFlightVitePlugin;

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
@@ -17,22 +17,48 @@ import path from 'path';
 var rscViteFileRE = /\/react-server-dom-vite.js/;
 function ReactFlightVitePlugin() {
   var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref$clientComponentP = _ref.clientComponentPaths,
-      clientComponentPaths = _ref$clientComponentP === void 0 ? [] : _ref$clientComponentP,
       _ref$isServerComponen = _ref.isServerComponentImporterAllowed,
       isServerComponentImporterAllowed = _ref$isServerComponen === void 0 ? function (importer) {
     return false;
-  } : _ref$isServerComponen;
+  } : _ref$isServerComponen,
+      _ref$isClientComponen = _ref.isClientComponent,
+      isClientComponent = _ref$isClientComponen === void 0 ? function (id) {
+    return /\.client\.[jt]sx?($|\?)/.test(id);
+  } : _ref$isClientComponen,
+      findClientComponentsForDev = _ref.findClientComponentsForDev,
+      findClientComponentsForClientBuild = _ref.findClientComponentsForClientBuild;
 
   var config;
+  var server;
+  var timeout;
+  var absoluteImporterPath;
+  var discoveredClientComponents = [];
+
+  if (!findClientComponentsForDev) {
+    findClientComponentsForDev = function () {
+      return Array.from(server.moduleGraph.fileToModulesMap.keys()).filter(isClientComponent);
+    };
+  }
+
   return {
     name: 'vite-plugin-react-server-components',
     enforce: 'pre',
-    configResolved: function (_config) {
+    configureServer: function (_server) {
+      server = _server;
+    },
+    configResolved: async function (_config) {
       config = _config; // By pushing this plugin at the end of the existing array,
       // we enforce running it *after* Vite resolves import.meta.glob.
 
       config.plugins.push(hashImportsPlugin);
+
+      if (config.command === 'build' && !config.build.ssr) {
+        if (findClientComponentsForClientBuild) {
+          discoveredClientComponents = await findClientComponentsForClientBuild(config);
+        } else {
+          throw new Error('[react-server-dom-vite] Parameter findClientComponentsForClientBuild is required for client build');
+        }
+      }
     },
     resolveId: async function (source, importer) {
       if (!importer) return null;
@@ -48,7 +74,22 @@ function ReactFlightVitePlugin() {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       if (!options.ssr) return null; // Wrapped components won't match this becase they end in ?no-proxy
 
-      if (/\.client\.[jt]sx?$/.test(id)) {
+      if (isClientComponent(id) && !/[&?]no-proxy($|&)/.test(id)) {
+        // Refresh the list of discovered client components
+        // every time a new one is processed.
+        if (config.command === 'serve') {
+          clearTimeout(timeout);
+          timeout = setTimeout(async function () {
+            discoveredClientComponents = findClientComponentsForDev ? await findClientComponentsForDev(config, server) : [];
+
+            if (absoluteImporterPath) {
+              // Signal Vite that this file needs to be
+              // refreshed both in server and browser.
+              server.watcher.emit('change', absoluteImporterPath);
+            }
+          }, 100);
+        }
+
         return proxyClientComponent(id);
       }
 
@@ -68,6 +109,7 @@ function ReactFlightVitePlugin() {
        */
       if (rscViteFileRE.test(id)) {
         var INJECTING_RE = /\{\s*__INJECTED_CLIENT_IMPORTERS__[:\s]*null[,\s]*\}\s*;/;
+        absoluteImporterPath = id.split('?')[0];
 
         if (options && options.ssr) {
           // In SSR, directly use components already discovered by RSC
@@ -75,13 +117,9 @@ function ReactFlightVitePlugin() {
           return code.replace(INJECTING_RE, 'globalThis.__COMPONENT_INDEX');
         }
 
-        var CLIENT_COMPONENT_GLOB = '**/*.client.[jt]s?(x)';
         var importerPath = path.dirname(id);
-        var importerToRootPath = normalizePath(path.relative(importerPath, config.root));
-        var userGlob = path.join(importerToRootPath, CLIENT_COMPONENT_GLOB);
-        var importers = [userGlob];
-        clientComponentPaths.forEach(function (componentPath) {
-          importers.push(path.join(path.relative(importerPath, componentPath), CLIENT_COMPONENT_GLOB));
+        var importers = discoveredClientComponents.map(function (absolutePath) {
+          return normalizePath(path.relative(importerPath, absolutePath));
         });
         var injectedGlobs = "Object.assign(Object.create(null), " + importers.map(function (glob) {
           return (// Mark the globs to modify the result after Vite resolves them.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Now that `hydrogen.config.js` changes are merged, this PR continues #1083 with a clean commit history.

>In Hydrogen, the client components are only imported in the server App, but not in the client. This means that the browser build cannot discover client components automatically and emit chunks to download them later on demand.
To work around that, we were using Vite's `import.meta.glob('..../**/*.client.jsx')` for discovering all the client components in the working dir during browser build.
This worked and helped us move fast but it brings some problems:
>- Can only check known paths such as `src` or `node_modules/@shopify/hydrogen/dist`. Importing from 3p libs would need to provide a new path manually.
>- It creates references to all the client components matched by the glob, not only the ones that are actually used. This means it emits extra chunks that are never used, and adds some weight to the client bundle with references that are never used.
>
>This PR improves the client component discovery strategy to only use those components that are imported by the server App. In dev, it simply uses the server entry to find them. During client build, it spins up a secondary Vite server and find them  (Viteception 🤯 ).
>
>- [x] Discover components in dev.
>- [x] HMR during dev for new client components added to the file system.
>- [x] Discover components in client build (adds 1.5s to the client build).
>
>Due to #1071 , this might still be finding some unused components but it's at least a good step.
>
>This PR needs to be merged to `v1` branch once #1065 is merged

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/docs/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
