### PR TITLE
New eslint rule `server-no-json-parse`

### DIFF
--- a/.alexrc.js
+++ b/.alexrc.js
@@ -15,5 +15,6 @@ module.exports = {
     'of-course',
     'special',
     'dive',
+    'attack',
   ],
 };

--- a/packages/eslint-plugin/src/configs/hydrogen.ts
+++ b/packages/eslint-plugin/src/configs/hydrogen.ts
@@ -1,8 +1,9 @@
 export default {
   plugins: ['hydrogen'],
   rules: {
-    'hydrogen/server-component-banned-hooks': 'error',
     'hydrogen/client-component-banned-hooks': 'error',
     'hydrogen/prefer-image-component': 'error',
+    'hydrogen/server-component-banned-hooks': 'error',
+    'hydrogen/server-no-json-parse': 'error',
   },
 };

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,9 +1,11 @@
 import {clientComponentBannedHooks} from './client-component-banned-hooks';
 import {serverComponentBannedHooks} from './server-component-banned-hooks';
 import {preferImageComponent} from './prefer-image-component';
+import {serverNoJsonParse} from './server-no-json-parse';
 
 export const rules: {[key: string]: any} = {
   'client-component-banned-hooks': clientComponentBannedHooks,
   'server-component-banned-hooks': serverComponentBannedHooks,
   'prefer-image-component': preferImageComponent,
+  'server-no-json-parse': serverNoJsonParse,
 };

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
@@ -2,7 +2,7 @@
 
 The Prototype Pollution attack targets the Object prototype in Javascript, leading to logical errors or potentially executing unintended code within the system. This happens if the JSON string being parsed has a `__proto__` key and that is later merged via `Object.assign`, or similar deep copying library, with another Object.
 
-Deep copying libraries often work by iterating over an object’s own properties and copying the primitives over and recursing into the own properties that are Objects. This means the properties on the supplied `__proto__` key will end up copied over to the prototype, opening the door to a potential attack vector for malicious code.
+Most deep copying libraries iterate over an object’s own properties and copy the primitives recursively into their own properties that are objects. This means the properties on the supplied `__proto__` key will get copied over to the prototype, opening the door to a potential attack vector for malicious code.
 
 ## Rule details
 

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
@@ -1,6 +1,8 @@
 # Disallow using JSON.parse() in React server component code
 
-The Prototype Pollution attack is a form of attack to the Object prototype in Javascript, leading to logical errors or potentially executing unintended code within the system. This happens if the JSON string being parsed has a `__proto__` key and that is later merged via `Object.assign`, or similar deep copying library, onto another Object. Deep copying libraries often work by iterating over an object’s own properties and copying the primitives over and recursing into the own properties that are Objects. This means the properties on the supplied `__proto__` key will end up copied over to the prototype and is a potential attack vector for malicious code.
+The Prototype Pollution attack targets the Object prototype in Javascript, leading to logical errors or potentially executing unintended code within the system. This happens if the JSON string being parsed has a `__proto__` key and that is later merged via `Object.assign`, or similar deep copying library, with another Object.
+
+Deep copying libraries often work by iterating over an object’s own properties and copying the primitives over and recursing into the own properties that are Objects. This means the properties on the supplied `__proto__` key will end up copied over to the prototype, opening the door to a potential attack vector for malicious code.
 
 ## Rule details
 

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
@@ -1,0 +1,7 @@
+# Disallow using JSON.parse() in React server component code
+
+The Prototype Pollution attack is a form of attack to the Object prototype in Javascript, leading to logical errors or potentially executing unintended code within the system. This happens if the JSON string being parsed has a `__proto__` key and that is later merged via `Object.assign`, or similar deep copying library, onto another Object. Deep copying libraries often work by iterating over an object’s own properties and copying the primitives over and recursing into the own properties that are Objects. This means the properties on the supplied `__proto__` key will end up copied over to the prototype and is a potential attack vector for malicious code.
+
+## Rule details
+
+This rule prevents using `JSON.parse` in an hydrogen API route or server component.

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
@@ -6,4 +6,4 @@ Deep copying libraries often work by iterating over an object’s own properties
 
 ## Rule details
 
-This rule prevents using `JSON.parse` in an hydrogen API route or server component.
+This rule prevents using `JSON.parse` in a Hydrogen API route or server component.

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/README.md
@@ -1,6 +1,6 @@
 # Disallow using JSON.parse() in React server component code
 
-The Prototype Pollution attack targets the Object prototype in Javascript, leading to logical errors or potentially executing unintended code within the system. This happens if the JSON string being parsed has a `__proto__` key and that is later merged via `Object.assign`, or similar deep copying library, with another Object.
+The [prototype pollution](https://learn.snyk.io/lessons/prototype-pollution/javascript/) attack targets the object prototype in Javascript, leading to logical errors or potentially executing unintended code within the system. Prototype pollution happens if the JSON string being parsed has a `__proto__` key that's merged using `Object.assign`. It can also occur if a similar deep copying library is merged with another object.
 
 Most deep copying libraries iterate over an object’s own properties and copy the primitives recursively into their own properties that are objects. This means the properties on the supplied `__proto__` key will get copied over to the prototype, opening the door to a potential attack vector for malicious code.
 

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/index.ts
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/index.ts
@@ -1,0 +1,1 @@
+export {serverNoJsonParse} from './server-no-json-parse';

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/server-no-json-parse.ts
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/server-no-json-parse.ts
@@ -1,0 +1,47 @@
+import {AST_NODE_TYPES} from '@typescript-eslint/types';
+
+import {
+  createRule,
+  isServerComponentFile,
+  insideReactComponent,
+  insideAPIRoute,
+} from '../../utilities';
+
+export const serverNoJsonParse = createRule({
+  name: `hydrogen/${__dirname}`,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer using the `Image` component instead of HTML `img` tags',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    messages: {
+      serverNoJsonParse: 'Do not use JSON.parse() on the server.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ExpressionStatement(node) {
+        if (
+          node.expression.type === AST_NODE_TYPES.CallExpression &&
+          node.expression.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.expression.callee.object.type === AST_NODE_TYPES.Identifier &&
+          node.expression.callee.property.type === AST_NODE_TYPES.Identifier &&
+          node.expression.callee.object.name === 'JSON' &&
+          node.expression.callee.property.name === 'parse' &&
+          isServerComponentFile(context.getFilename()) &&
+          (insideReactComponent(node) || insideAPIRoute(node))
+        ) {
+          context.report({
+            node,
+            messageId: 'serverNoJsonParse',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/server-no-json-parse.ts
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/server-no-json-parse.ts
@@ -13,7 +13,7 @@ export const serverNoJsonParse = createRule({
     type: 'suggestion',
     docs: {
       description:
-        'Prefer using the `Image` component instead of HTML `img` tags',
+        'JSON.parse() should not be used in server-side code due to security concerns.',
       category: 'Best Practices',
       recommended: 'warn',
     },

--- a/packages/eslint-plugin/src/rules/server-no-json-parse/tests/server-no-json-parse.test.ts
+++ b/packages/eslint-plugin/src/rules/server-no-json-parse/tests/server-no-json-parse.test.ts
@@ -1,0 +1,101 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {AST_NODE_TYPES} from '@typescript-eslint/types';
+import {serverNoJsonParse} from '../server-no-json-parse';
+import dedent from 'dedent';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+function error() {
+  return {
+    type: AST_NODE_TYPES.ExpressionStatement,
+    messageId: 'serverNoJsonParse' as const,
+  };
+}
+
+ruleTester.run('hydrogen/server-no-json-parse', serverNoJsonParse, {
+  valid: [
+    {
+      code: dedent`
+        function SomeComponent() {
+          JSON.parse(someUnsafeJSONObject);
+          return null
+        }
+      `,
+    },
+    {
+      code: dedent`
+        function SomeComponent() {
+          return null
+        }
+      `,
+      filename: 'some-component.server.tsx',
+    },
+    {
+      code: dedent`
+        function SomeComponent() {
+          return null
+        }
+      `,
+      filename: 'some-component.server.tsx',
+    },
+    {
+      code: dedent`
+        JSON.parse(someUnsafeJSONObject);
+
+        export async function api() {
+          return {}
+        }
+      `,
+      filename: 'some-component.server.tsx',
+    },
+    {
+      code: dedent`
+        JSON.parse(someUnsafeJSONObject);
+
+        export function SomeComponent() {
+          return {}
+        }
+      `,
+      filename: 'some-component.server.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        function SomeComponent() {
+          JSON.parse(someUnsafeJSONObject);
+          return null
+        }
+      `,
+      errors: [error()],
+      filename: 'some-component.server.tsx',
+    },
+    {
+      code: dedent`
+        export async function api() {
+          JSON.parse(someUnsafeJSONObject);
+          return null
+        }
+      `,
+      errors: [error()],
+      filename: 'some-component.server.tsx',
+    },
+    {
+      code: dedent`
+        export async function api() {
+          JSON.parse(someUnsafeJSONObject);
+          return null
+        }
+      `,
+      errors: [error()],
+      filename: 'some-component.server.tsx',
+    },
+  ],
+});


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is an idea and is still a work in progress. I'm opening this PR to start a discussion and gauge how folks feel about it (this was an easy one to put code together and talk about in PR form).

### Additional context

The backstory is from [this PR](https://github.com/Shopify/hydrogen/pull/1242) and talks around providing something to prevent developers from opening themselves up to prototype poisoning attacks when using `JSON.parse`. Some questions:

- Do we want to introduce something like this? Does what I have cover all the bases?
- Should we suggest an alternative? We'd expose a utility within hydrogen and replace the code automatically via `suggestions` (same as what we do with raw `img` tags and the `Image` component).
- We could also suggest they use a third-party module for JSON parsing rather than supply one (above point).

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
