### PR TITLE
Add "view on stackblitz" buttons to templates

### DIFF
--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -9,18 +9,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish latest release to Stackblitz
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@v2
-        with:
-          ref: 'v1.x-2022-07'
-      - name: Rename gitignore
-        run: |
-          mv templates/template-hydrogen-default/_gitignore templates/template-hydrogen-default/.gitignore
-      - name: Push to stackblitz branch
-        run: |
-          git show-ref
-          git config user.email "hydrogen@shopify.com"
-          git config user.name "Hydrogen Bot"
-          git commit -am "Update Stackblitz branch"
-          git push origin HEAD:stackblitz --force
+    strategy:
+      matrix:
+        template: ['template-hydrogen-default', 'template-hydrogen-hello-world']
+      steps:
+        - name: Checkout the code
+          uses: actions/checkout@v2
+          with:
+            ref: 'v1.x-2022-07'
+        - name: Rename gitignore
+          run: |
+            mv templates/${{ matrix.template }}/_gitignore templates/${{ matrix.template }}/.gitignore
+        - name: Remove cross-env
+          run: |
+            sed -i.bak 's/cross-env LOCAL_DEV=true //' templates/${{ matrix.template }}/package.json
+        - name: Push to stackblitz branch
+          run: |
+            git show-ref
+            git config user.email "hydrogen@shopify.com"
+            git config user.name "Hydrogen Bot"
+            git commit -am "Update Stackblitz branch"
+            git push origin HEAD:stackblitz --force

--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -12,21 +12,21 @@ jobs:
     strategy:
       matrix:
         template: ['template-hydrogen-default', 'template-hydrogen-hello-world']
-      steps:
-        - name: Checkout the code
-          uses: actions/checkout@v2
-          with:
-            ref: 'v1.x-2022-07'
-        - name: Rename gitignore
-          run: |
-            mv templates/${{ matrix.template }}/_gitignore templates/${{ matrix.template }}/.gitignore
-        - name: Remove cross-env
-          run: |
-            sed -i.bak 's/cross-env LOCAL_DEV=true //' templates/${{ matrix.template }}/package.json
-        - name: Push to stackblitz branch
-          run: |
-            git show-ref
-            git config user.email "hydrogen@shopify.com"
-            git config user.name "Hydrogen Bot"
-            git commit -am "Update Stackblitz branch"
-            git push origin HEAD:stackblitz --force
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          ref: 'v1.x-2022-07'
+      - name: Rename gitignore
+        run: |
+          mv templates/${{ matrix.template }}/_gitignore templates/${{ matrix.template }}/.gitignore
+      - name: Remove cross-env
+        run: |
+          sed -i.bak 's/cross-env LOCAL_DEV=true //' templates/${{ matrix.template }}/package.json
+      - name: Push to stackblitz branch
+        run: |
+          git show-ref
+          git config user.email "hydrogen@shopify.com"
+          git config user.name "Hydrogen Bot"
+          git commit -am "Update ${{ matrix.template }} on Stackblitz branch"
+          git push origin HEAD:stackblitz --force

--- a/templates/template-hydrogen-default/README.md
+++ b/templates/template-hydrogen-default/README.md
@@ -4,6 +4,8 @@ Hydrogen is a React framework and SDK that you can use to build fast and dynamic
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
 
+[Run this template on Stackblitz](https://stackblitz.com/github/Shopify/hydrogen/tree/main/templates/template-hydrogen-default)
+
 ## What's in this template
 
 - Styling with [Tailwind](https://tailwindcss.com/)

--- a/templates/template-hydrogen-default/README.md
+++ b/templates/template-hydrogen-default/README.md
@@ -4,7 +4,7 @@ Hydrogen is a React framework and SDK that you can use to build fast and dynamic
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
 
-[Run this template on Stackblitz](https://stackblitz.com/github/Shopify/hydrogen/tree/main/templates/template-hydrogen-default)
+[Run this template on Stackblitz](https://hydrogen.new)
 
 ## What's in this template
 

--- a/templates/template-hydrogen-default/README.md
+++ b/templates/template-hydrogen-default/README.md
@@ -4,7 +4,7 @@ Hydrogen is a React framework and SDK that you can use to build fast and dynamic
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
 
-[Run this template on Stackblitz](https://hydrogen.new)
+[Run this template on Stackblitz](https://stackblitz.com/github/Shopify/hydrogen/tree/stackblitz/templates/template-hydrogen-default)
 
 ## What's in this template
 

--- a/templates/template-hydrogen-hello-world/README.md
+++ b/templates/template-hydrogen-hello-world/README.md
@@ -4,7 +4,7 @@ Hydrogen is a React framework and SDK that you can use to build fast and dynamic
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
 
-[Run this template on Stackblitz](https://stackblitz.com/github/Shopify/hydrogen/tree/main/templates/template-hydrogen-hello-world)
+[Run this template on Stackblitz](https://stackblitz.com/github/Shopify/hydrogen/tree/stackblitz/templates/template-hydrogen-hello-world)
 
 ## Getting started
 

--- a/templates/template-hydrogen-hello-world/README.md
+++ b/templates/template-hydrogen-hello-world/README.md
@@ -1,8 +1,10 @@
-# Hydrogen App
+# Minimal Hydrogen App
 
 Hydrogen is a React framework and SDK that you can use to build fast and dynamic Shopify custom storefronts.
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
+
+[Run this template on Stackblitz](https://stackblitz.com/github/Shopify/hydrogen/tree/main/templates/template-hydrogen-hello-world)
 
 ## Getting started
 

--- a/templates/template-hydrogen-hello-world/package.json
+++ b/templates/template-hydrogen-hello-world/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "vite": "^2.9.0",
     "@shopify/cli": "1.0.9",
-    "@shopify/cli-hydrogen": "2.0.0"
+    "@shopify/cli-hydrogen": "2.0.0",
+    "cross-env": "^7.0.3"
   },
   "dependencies": {
     "@shopify/hydrogen": "^0.18.0",

--- a/templates/template-hydrogen-hello-world/package.json
+++ b/templates/template-hydrogen-hello-world/package.json
@@ -12,8 +12,7 @@
   "devDependencies": {
     "vite": "^2.9.0",
     "@shopify/cli": "1.0.9",
-    "@shopify/cli-hydrogen": "2.0.0",
-    "cross-env": "^7.0.3"
+    "@shopify/cli-hydrogen": "2.0.0"
   },
   "dependencies": {
     "@shopify/hydrogen": "^0.18.0",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Does what it says. 

### Additional context

The `hello-world` template is missing the `cross-env` dependency so this template doesn't work (on stackblitz or anywhere), but will when this PR merges.

More information on the links I add can be found in the [stackblitz docs](https://developer.stackblitz.com/docs/platform/importing-projects/).

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
