### PR TITLE
Add custom user agents for disabling streaming

### DIFF
--- a/.changeset/flat-flies-relate.md
+++ b/.changeset/flat-flies-relate.md
@@ -1,3 +1,11 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Hydrogen disables streaming and instead buffer renders the whole page for bot user agents.
+Now you can add custom user agents within `hydrogen.config.js` by adding a `botUserAgents` property:
+
+```ts
 import {CookieSessionStorage} from '@shopify/hydrogen';
 import {defineConfig} from '@shopify/hydrogen/config';
 
@@ -9,8 +17,6 @@ export default defineConfig({
     storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
     storefrontApiVersion: '2022-07',
   },
-  session: CookieSessionStorage('__session', {
-    expires: new Date(1749343178614),
-  }),
   botUserAgents: ['custom bot'],
 });
+```

--- a/.changeset/flat-flies-relate.md
+++ b/.changeset/flat-flies-relate.md
@@ -2,8 +2,7 @@
 '@shopify/hydrogen': patch
 ---
 
-Hydrogen disables streaming and instead buffer renders the whole page for bot user agents.
-Now you can add custom user agents within `hydrogen.config.js` by adding a `botUserAgents` property:
+You can now easily disable streaming on any page conditionally with the `enableStreaming` option inside `hydrogen.config.js`:
 
 ```ts
 import {CookieSessionStorage} from '@shopify/hydrogen';
@@ -17,6 +16,8 @@ export default defineConfig({
     storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
     storefrontApiVersion: '2022-07',
   },
-  botUserAgents: ['custom bot'],
+  enableStreaming: (req) => req.headers.get('user-agent') !== 'custom bot',
 });
 ```
+
+By default all pages are stream rendered except for SEO bots. There shouldn't be many reasons to disable streaming, unless there is a custom bot not covered by Hydrogen's bot detection.

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -199,7 +199,9 @@ export default defineConfig({
 
 ### `enableStreaming`
 
-By default, all routes in Hydrogen are stream rendered. Stream rendering is automatically disabled when the user agent is a bot. It is necessary for all content to be immmediately available to bots for SEO. Sometimes you might want to manually disable streaming for a specific page. A common use case is a custom bot that is not recognized by Hydrogen's bot dectection algorithm. You can disable streaming for a custom bot with the `enableStreaming` configuration property:
+By default, all routes in Hydrogen are stream rendered. Stream rendering is automatically disabled when the user agent is a bot. 
+
+Content should be immediately available to bots for SEO purposes. However, you might want to manually disable streaming for a specific page. A common use case is disabling streaming for a custom bot that's not recognized by Hydrogen's bot detection algorithm. You can disable streaming for a custom bot with the `enableStreaming` configuration property:
 
 {% codeblock file, filename: 'hydrogen.config.ts' %}
 
@@ -212,7 +214,8 @@ export default defineConfig({
 
 {% endcodeblock %}
 
-Note: there are performance benefits to streaming. You should not completely disable streaming for all your storefront's routes!
+> Tip:
+> There are [performance benefits](https://shopify.dev/custom-storefronts/hydrogen/best-practices/performance) to streaming. You shouldn't completely disable streaming for all of your storefront's routes.
 
 ## Changing the configuration file location
 

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -45,6 +45,7 @@ The following groupings of configuration properties can exist in Hydrogen:
 - [`shopify`](#shopify)
 - [`session`](#session)
 - [`serverAnalyticsConnectors`](#serveranalyticsconnectors)
+- [`enableStreaming`](#enablestreaming)
 
 ### `routes`
 
@@ -195,6 +196,23 @@ export default defineConfig({
 ```
 
 {% endcodeblock %}
+
+### `enableStreaming`
+
+By default, all routes in Hydrogen are stream rendered. Stream rendering is automatically disabled when the user agent is a bot. It is necessary for all content to be immmediately available to bots for SEO. Sometimes you might want to manually disable streaming for a specific page. A common use case is a custom bot that is not recognized by Hydrogen's bot dectection algorithm. You can disable streaming for a custom bot with the `enableStreaming` configuration property:
+
+{% codeblock file, filename: 'hydrogen.config.ts' %}
+
+```tsx
+import {PerformanceMetricsServerAnalyticsConnector} from '@shopify/hydrogen';
+export default defineConfig({
+  enableStreaming: (req) => req.headers.get('user-agent') !== 'custom bot',
+});
+```
+
+{% endcodeblock %}
+
+Note: there are performance benefits to streaming. You should not completely disable streaming for all your storefront's routes!
 
 ## Changing the configuration file location
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -159,7 +159,11 @@ export const renderHydrogen = (App: any, hydrogenConfig?: HydrogenConfig) => {
     }
 
     const isStreamable =
-      !isBotUA(url, request.headers.get('user-agent')) &&
+      !isBotUA(
+        url,
+        request.headers.get('user-agent'),
+        hydrogenConfig.botUserAgents
+      ) &&
       (!!streamableResponse || (await isStreamingSupported()));
 
     let template =

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -159,11 +159,10 @@ export const renderHydrogen = (App: any, hydrogenConfig?: HydrogenConfig) => {
     }
 
     const isStreamable =
-      !isBotUA(
-        url,
-        request.headers.get('user-agent'),
-        hydrogenConfig.botUserAgents
-      ) &&
+      (hydrogenConfig.enableStreaming
+        ? hydrogenConfig.enableStreaming(request)
+        : true) &&
+      !isBotUA(url, request.headers.get('user-agent')) &&
       (!!streamableResponse || (await isStreamingSupported()));
 
     let template =

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -74,7 +74,7 @@ export type HydrogenConfig = {
   shopify?: ShopifyConfig | ShopifyConfigFetcher;
   serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>;
   session?: (log: Logger) => SessionStorageAdapter;
-  botUserAgents?: Array<string>;
+  enableStreaming?: (request: Request) => boolean;
 };
 
 export type ClientHandlerConfig = {

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -74,6 +74,7 @@ export type HydrogenConfig = {
   shopify?: ShopifyConfig | ShopifyConfigFetcher;
   serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>;
   session?: (log: Logger) => SessionStorageAdapter;
+  botUserAgents?: Array<string>;
 };
 
 export type ClientHandlerConfig = {

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -74,7 +74,7 @@ export type HydrogenConfig = {
   shopify?: ShopifyConfig | ShopifyConfigFetcher;
   serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>;
   session?: (log: Logger) => SessionStorageAdapter;
-  enableStreaming?: (request: Request) => boolean;
+  enableStreaming?: (request: ServerComponentRequest) => boolean;
 };
 
 export type ClientHandlerConfig = {

--- a/packages/hydrogen/src/utilities/bot-ua.ts
+++ b/packages/hydrogen/src/utilities/bot-ua.ts
@@ -59,8 +59,16 @@ const botUARegex = new RegExp(botUserAgents.join('|'), 'i');
 /**
  * Determines if the request is from a bot, using the URL and User Agent
  */
-export function isBotUA(url: URL, userAgent: string | null): boolean {
+export function isBotUA(
+  url: URL,
+  userAgent: string | null,
+  customUserAgents: Array<string> | null = null
+): boolean {
   return (
-    url.searchParams.has('_bot') || (!!userAgent && botUARegex.test(userAgent))
+    url.searchParams.has('_bot') ||
+    (!!userAgent && botUARegex.test(userAgent)) ||
+    (!!userAgent &&
+      !!customUserAgents &&
+      new RegExp(customUserAgents.join('|'), 'i').test(userAgent))
   );
 }

--- a/packages/hydrogen/src/utilities/bot-ua.ts
+++ b/packages/hydrogen/src/utilities/bot-ua.ts
@@ -59,16 +59,8 @@ const botUARegex = new RegExp(botUserAgents.join('|'), 'i');
 /**
  * Determines if the request is from a bot, using the URL and User Agent
  */
-export function isBotUA(
-  url: URL,
-  userAgent: string | null,
-  customUserAgents: Array<string> | null = null
-): boolean {
+export function isBotUA(url: URL, userAgent: string | null): boolean {
   return (
-    url.searchParams.has('_bot') ||
-    (!!userAgent && botUARegex.test(userAgent)) ||
-    (!!userAgent &&
-      !!customUserAgents &&
-      new RegExp(customUserAgents.join('|'), 'i').test(userAgent))
+    url.searchParams.has('_bot') || (!!userAgent && botUARegex.test(userAgent))
   );
 }

--- a/packages/playground/server-components/hydrogen.config.js
+++ b/packages/playground/server-components/hydrogen.config.js
@@ -12,5 +12,7 @@ export default defineConfig({
   session: CookieSessionStorage('__session', {
     expires: new Date(1749343178614),
   }),
-  botUserAgents: ['custom bot'],
+  enableStreaming: (req) => {
+    return req.headers.get('user-agent') !== 'custom bot';
+  },
 });

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -140,6 +140,30 @@ export default async function testCases({
     expect(body).toContain('>footer!<');
   });
 
+  it('buffers HTML for custom bot', async () => {
+    const response = await fetch(getServerUrl() + '/stream', {
+      headers: {
+        'user-agent': 'custom bot',
+      },
+    });
+    const streamedChunks = [];
+
+    // This fetch response is not standard but a node-fetch polyfill.
+    // Therefore, the body is not a ReadableStream but a Node Readable.
+    // @ts-ignore
+    for await (const chunk of response.body) {
+      streamedChunks.push(chunk.toString());
+    }
+
+    expect(streamedChunks.length).toEqual(1); // Did not stream because it's a bot
+
+    const body = streamedChunks.join('');
+    expect(body).toContain('var __flight=[];');
+    expect(body).toContain('__flight.push(`S1:"react.suspense"');
+    expect(body).toContain('<div c="5">');
+    expect(body).toContain('>footer!<');
+  });
+
   it('streams the RSC response', async () => {
     const response = await fetch(
       getServerUrl() +

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -158,8 +158,6 @@ export default async function testCases({
     expect(streamedChunks.length).toEqual(1); // Did not stream because it's a bot
 
     const body = streamedChunks.join('');
-    expect(body).toContain('var __flight=[];');
-    expect(body).toContain('__flight.push(`S1:"react.suspense"');
     expect(body).toContain('<div c="5">');
     expect(body).toContain('>footer!<');
   });


### PR DESCRIPTION
Hydrogen disables streaming and instead buffer renders the whole page for bot user agents.
You can now disable streaming conditionally based on the request:

```ts
import {CookieSessionStorage} from '@shopify/hydrogen';
import {defineConfig} from '@shopify/hydrogen/config';

export default defineConfig({
  routes: import.meta.globEager('./src/routes/**/*.server.[jt](s|sx)'),
  shopify: {
    defaultLocale: 'en-us',
    storeDomain: 'hydrogen-preview.myshopify.com',
    storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
    storefrontApiVersion: '2022-07',
  },
  enableStreaming: req => req.headers.get('user-agent') !== 'custom bot',
});
```