### PR TITLE
Avoid duplicating style tags from CSS Modules

### DIFF
--- a/.changeset/eleven-planets-thank.md
+++ b/.changeset/eleven-planets-thank.md
@@ -1,0 +1,27 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Support for CSS Modules has been improved. It now behaves closer to the default behavior in Vite where styles are collected automatically.
+
+Remove the `StyleTag` component that was needed before:
+
+```diff
+export default function MyComponent() {
+  return (
+    <div>
+-      <myStyles.StyleTag />
+      <h1>Title</h1>
+    </div>
+  );
+}
+```
+
+Optionally, update your wildcard imports to default or named imports:
+
+```diff
+-import * as myStyles from './my.module.css';
++import myStyles from './my.module.css';
+// Or
++import {red, gren, blue} from './my.module.css';
+```

--- a/.changeset/eleven-planets-thank.md
+++ b/.changeset/eleven-planets-thank.md
@@ -23,5 +23,5 @@ Optionally, update your wildcard imports to default or named imports:
 -import * as myStyles from './my.module.css';
 +import myStyles from './my.module.css';
 // Or
-+import {red, gren, blue} from './my.module.css';
++import {red, green, blue} from './my.module.css';
 ```

--- a/.changeset/gorgeous-pots-tie.md
+++ b/.changeset/gorgeous-pots-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+CSS Modules used in server and client components are now only included once in the response (no duplicated style tags).

--- a/docs/framework/css-support.md
+++ b/docs/framework/css-support.md
@@ -86,18 +86,38 @@ If you don't want to build with Tailwind's library and instead want to write you
 
 ## CSS Modules
 
-Hydrogen includes a [Vite plugin](https://vitejs.dev/guide/features.html#css-modules) that collects styles for each CSS Module and exports them to a `StyleTag` component. To use CSS Modules in your Hydrogen app, you must render the style tag in the component along with your styles:
+Hydrogen includes a [Vite plugin](https://vitejs.dev/guide/features.html#css-modules) that collects styles for each CSS Module in your components. CSS Modules can be imported in both client and server components.
 
 {% codeblock file, filename: 'src/components/Hello.client.jsx' %}
 
 ```js
 import styles from './styles.module.css';
 
-export default MyComponent() {
+export default function MyComponent() {
   return (
     <div className={styles.wrapper}>
-      // A style is rendered inline
-      <styles.StyleTag />
+      <p>Hello</p>
+    </div>
+  );
+}
+```
+
+{% endcodeblock %}
+
+The CSS Module will be inlined in a `<style>` tag before your component.
+Currently, this tag is only added automatically for the default export in the file. If you want to render the styles in other named exports, you must do it manually by rendering `<styles.StyleTag />`:
+
+{% codeblock file, filename: 'src/components/Hello.client.jsx' %}
+
+```jsx
+import styles from './styles.module.css';
+
+export default MyComponent() {...}
+
+export function MyNamedComponent() {
+  return (
+    <div className={styles.wrapper}>
+      <styles.StyleTag /> 
       <p>Hello</p>
     </div>
   );

--- a/docs/framework/css-support.md
+++ b/docs/framework/css-support.md
@@ -91,7 +91,7 @@ Hydrogen includes a [Vite plugin](https://vitejs.dev/guide/features.html#css-mod
 {% codeblock file, filename: 'src/components/Hello.client.jsx' %}
 
 ```js
-import * as styles from './styles.module.css';
+import styles from './styles.module.css';
 
 export default MyComponent() {
   return (

--- a/docs/framework/css-support.md
+++ b/docs/framework/css-support.md
@@ -104,8 +104,7 @@ export default function MyComponent() {
 
 {% endcodeblock %}
 
-The CSS Module will be inlined in a `<style>` tag before your component.
-Currently, this tag is only added automatically for the default export in the file. If you want to render the styles in other named exports, you must do it manually by rendering `<styles.StyleTag />`:
+The CSS Module is inlined in a `<style>` tag before your component. Currently, this tag is only added automatically for the default export in the file. If you want to render the styles in other named exports, then you must do it manually by rendering `<styles.StyleTag />`:
 
 {% codeblock file, filename: 'src/components/Hello.client.jsx' %}
 

--- a/examples/css-modules/hydrogen.config.js
+++ b/examples/css-modules/hydrogen.config.js
@@ -1,7 +1,7 @@
 import {defineConfig} from '@shopify/hydrogen/config';
 
 export default defineConfig({
-  routes: import.meta.globEager('./routes/**/*.server.[jt](s|sx)'),
+  routes: import.meta.globEager('./src/routes/**/*.server.[jt](s|sx)'),
   shopify: {
     storeDomain: 'hydrogen-preview.myshopify.com',
     storefrontToken: '3b580e70970c4528da70c98e097c2fa0',

--- a/examples/css-modules/src/components/Hello.client.jsx
+++ b/examples/css-modules/src/components/Hello.client.jsx
@@ -1,4 +1,4 @@
-import * as styles from './hello.module.css';
+import styles from './hello.module.css';
 
 export default function Hello() {
   return (

--- a/examples/css-modules/src/components/Hello.client.jsx
+++ b/examples/css-modules/src/components/Hello.client.jsx
@@ -3,7 +3,6 @@ import styles from './hello.module.css';
 export default function Hello() {
   return (
     <div>
-      <styles.StyleTag />
       <p className={styles.hello}>Hello</p>
     </div>
   );

--- a/examples/css-modules/src/routes/index.server.jsx
+++ b/examples/css-modules/src/routes/index.server.jsx
@@ -4,9 +4,10 @@ import styles from './index.module.css';
 export default function Index() {
   return (
     <div className={styles.wrapper}>
-      <styles.StyleTag />
-      <h1>Hi</h1>
-      <Hello />
+      <>
+        <h1>Hi</h1>
+        <Hello />
+      </>
     </div>
   );
 }

--- a/examples/css-modules/src/routes/index.server.jsx
+++ b/examples/css-modules/src/routes/index.server.jsx
@@ -1,5 +1,5 @@
 import Hello from '../components/Hello.client';
-import * as styles from './index.module.css';
+import styles from './index.module.css';
 
 export default function Index() {
   return (

--- a/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
+++ b/packages/hydrogen/src/framework/Hydration/ServerComponentRequest.server.ts
@@ -60,6 +60,7 @@ export class ServerComponentRequest extends Request {
     router: RouterContextData;
     buyerIpHeader?: string;
     session?: SessionSyncApi;
+    cssModules?: string[];
     [key: string]: any;
   };
 
@@ -93,6 +94,7 @@ export class ServerComponentRequest extends Request {
         normalizedRscUrl: this.normalizedUrl,
       },
       preloadQueries: new Map(),
+      cssModules: [],
     };
     this.cookies = this.parseCookies();
   }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -23,7 +23,7 @@ export default function cssModulesRsc() {
         // Place this plugin before react-refresh to
         // modify files before JSX is compiled.
         // @ts-ignore
-        config.plugins.unshift(autoStyleTagPlugin());
+        config.plugins.unshift(autoStyleTagPlugin(config));
       },
       transform(code, id) {
         if (cssModuleRE.test(id)) {
@@ -37,9 +37,10 @@ export default function cssModulesRsc() {
       transform(code, id) {
         if (id.includes('.module.') && cssMap.has(id)) {
           const key = path.relative(config.root, id.split('?')[0]);
+
           return (
             `import React from 'react';` +
-            `export const StyleTag = () => React.createElement('style', {dangerouslySetInnerHTML: {__html: ${JSON.stringify(
+            `export const StyleTag = (props) => React.createElement('style', {...props, 'data-module': '${key}', dangerouslySetInnerHTML: {__html: ${JSON.stringify(
               cssMap.get(id)
             )}}});` +
             `\nStyleTag.key = '${key}';\n` +
@@ -51,10 +52,10 @@ export default function cssModulesRsc() {
   ] as Plugin[];
 }
 
-function autoStyleTagPlugin() {
+function autoStyleTagPlugin(config: ResolvedConfig) {
   return {
     name: 'css-modules-auto-style-tag',
-    transform(code, id) {
+    transform(code, id, options) {
       id = id.split('?')[0];
 
       if (
@@ -67,7 +68,8 @@ function autoStyleTagPlugin() {
           })
         ) &&
         cssModuleRE.test(code) &&
-        code.includes('export default')
+        code.includes('export default') &&
+        !code.includes('__ApplyStyleTags')
       ) {
         const s = new MagicString(code);
 
@@ -100,11 +102,10 @@ function autoStyleTagPlugin() {
         // 2. Wrap default export in a new component that includes the style tags
         s.replace(/export default/gm, 'const __defaultExport = ');
         s.append(
-          `\nconst __ApplyStyleTags = function (props) {\n` +
-            `  return <>{__styleTags.map(ST => <ST key={ST.key} />)}<__defaultExport {...props} /></>;` +
-            `\n}\n\n` +
-            `Object.defineProperty(__ApplyStyleTags, 'name', {value: 'ApplyStyleTags_' + (__defaultExport.name || '')});\n` +
-            `export default __ApplyStyleTags;`
+          generateDefaultExport(
+            path.relative(config.root, id),
+            Boolean(options?.ssr)
+          )
         );
 
         return {
@@ -114,4 +115,40 @@ function autoStyleTagPlugin() {
       }
     },
   } as Plugin;
+}
+
+function generateDefaultExport(rendererId: string, isServer: boolean) {
+  let code = '';
+
+  if (isServer) {
+    code += `\nimport {useEnvContext} from '@shopify/hydrogen/dist/esnext/foundation/ssr-interop';\n`;
+  }
+
+  code += `\nconst __ApplyStyleTags = function (props) {\n`;
+  code += `  const renderer = '${rendererId}';\n  let styleTags = [];`;
+
+  if (isServer) {
+    // In the server, do not render style tags that have already been registered in the current request.
+    code += `  const cssModules = useEnvContext((req) => req.ctx.cssModules);\n`;
+    code += `  styleTags = __styleTags.filter(ST => !cssModules.includes(ST.key));\n`;
+    // Register the new style tags that are rendered in this component.
+    code += `  cssModules.push(...styleTags.map(ST => ST.key));\n`;
+  } else {
+    // In the client, only render the style tags if they don't exist in the DOM yet, or if they do
+    // but the renderer is the current component (hydrating an SSRed style tag).
+    code += `  const cssModules = Array.from(document.querySelectorAll('style[data-module]')).reduce((acc, el) => { acc[el.dataset.module] = el.dataset.renderer; return acc; }, {});\n`;
+    code += `  styleTags = __styleTags.filter(ST => !cssModules[ST.key] || cssModules[ST.key] === renderer);\n`;
+  }
+
+  // Return a fragment with all the style tags and the original component
+  code +=
+    `  return <>{styleTags.map(ST => <ST key={ST.key} data-renderer={renderer} />)}<__defaultExport {...props} /></>;` +
+    `\n}\n`;
+
+  // Append original component name to the new export for debugging
+  code += `Object.defineProperty(__ApplyStyleTags, 'name', {value: 'ApplyStyleTags_' + (__defaultExport.name || '')});\n`;
+
+  code += `export default __ApplyStyleTags;`;
+
+  return code;
 }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -48,6 +48,23 @@ export default function cssModulesRsc() {
           );
         }
       },
+      renderChunk(code, chunk) {
+        if (
+          chunk.facadeModuleId &&
+          /\.client\.[jt]sx/.test(chunk.facadeModuleId)
+        ) {
+          const mods = Object.keys(chunk.modules || {});
+          if (
+            mods.some((m) => cssModuleRE.test(m) && /[?&]used(&|$)/.test(m))
+          ) {
+            // Client components that import CSS modules will preload them
+            // in the browser. By clearing this metadata, the module won't
+            // be preloaded since it is already inlined as a style tag.
+            // @ts-ignore
+            chunk.viteMetadata?.importedCss?.clear();
+          }
+        }
+      },
     },
   ] as Plugin[];
 }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -100,9 +100,11 @@ function autoStyleTagPlugin() {
         // 2. Wrap default export in a new component that includes the style tags
         s.replace(/export default/gm, 'const __defaultExport = ');
         s.append(
-          `\nexport default function ApplyStyleTags(props) {\n` +
+          `\nconst __ApplyStyleTags = function (props) {\n` +
             `  return <>{__styleTags.map(ST => <ST key={ST.key} />)}<__defaultExport {...props} /></>;` +
-            `\n}`
+            `\n}\n\n` +
+            `Object.defineProperty(__ApplyStyleTags, 'name', {value: 'ApplyStyleTags_' + (__defaultExport.name || '')});\n` +
+            `export default __ApplyStyleTags;`
         );
 
         return {

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -66,7 +66,8 @@ function autoStyleTagPlugin() {
             ext: path.extname(id),
           })
         ) &&
-        cssModuleRE.test(code)
+        cssModuleRE.test(code) &&
+        code.includes('export default')
       ) {
         const s = new MagicString(code);
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -24,11 +24,11 @@ export default function cssModulesRsc() {
       enforce: 'post',
       transform(code, id) {
         if (id.includes('.module.') && cssMap.has(id)) {
-          return code.replace(
-            /export default .*$/gms,
+          return (
             `import React from 'react'; export const StyleTag = () => React.createElement('style', {dangerouslySetInnerHTML: {__html: ${JSON.stringify(
               cssMap.get(id)
-            )}}});`
+            )}}});` +
+            code.replace(/export default \{/gs, `export default {\n  StyleTag,`)
           );
         }
       },

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-css-modules-rsc.ts
@@ -1,4 +1,9 @@
-import {type Plugin} from 'vite';
+import type {Plugin, ResolvedConfig} from 'vite';
+import {HYDROGEN_DEFAULT_SERVER_ENTRY} from './vite-plugin-hydrogen-middleware';
+import MagicString from 'magic-string';
+import path from 'path';
+
+const cssModuleRE = /\.module\.(s?css|sass|less|stylus)/;
 
 export default function cssModulesRsc() {
   // 1. Original CSS module: `.myStyle { color: red; }`
@@ -6,15 +11,22 @@ export default function cssModulesRsc() {
   // 3. CSS module after 'post' Vite transforms: `export const myStyle = 'myStyle_hashedXYZ';`
 
   let cssMap = new Map();
+  let config: ResolvedConfig;
 
   return [
     {
       name: 'css-modules-rsc',
-      configResolved() {
+      configResolved(_config) {
+        config = _config;
         cssMap = new Map();
+
+        // Place this plugin before react-refresh to
+        // modify files before JSX is compiled.
+        // @ts-ignore
+        config.plugins.unshift(autoStyleTagPlugin());
       },
       transform(code, id) {
-        if (/\.module\.(s?css|sass|less)/.test(id)) {
+        if (cssModuleRE.test(id)) {
           cssMap.set(id, code);
         }
       },
@@ -24,14 +36,79 @@ export default function cssModulesRsc() {
       enforce: 'post',
       transform(code, id) {
         if (id.includes('.module.') && cssMap.has(id)) {
+          const key = path.relative(config.root, id.split('?')[0]);
           return (
-            `import React from 'react'; export const StyleTag = () => React.createElement('style', {dangerouslySetInnerHTML: {__html: ${JSON.stringify(
+            `import React from 'react';` +
+            `export const StyleTag = () => React.createElement('style', {dangerouslySetInnerHTML: {__html: ${JSON.stringify(
               cssMap.get(id)
             )}}});` +
+            `\nStyleTag.key = '${key}';\n` +
             code.replace(/export default \{/gs, `export default {\n  StyleTag,`)
           );
         }
       },
     },
   ] as Plugin[];
+}
+
+function autoStyleTagPlugin() {
+  return {
+    name: 'css-modules-auto-style-tag',
+    transform(code, id) {
+      id = id.split('?')[0];
+
+      if (
+        /\.[jt]sx$/.test(id) &&
+        !id.endsWith(HYDROGEN_DEFAULT_SERVER_ENTRY) &&
+        !id.endsWith(
+          path.format({
+            name: HYDROGEN_DEFAULT_SERVER_ENTRY,
+            ext: path.extname(id),
+          })
+        ) &&
+        cssModuleRE.test(code)
+      ) {
+        const s = new MagicString(code);
+
+        // 1. Gather style tags in an array
+        let styleCount = 0;
+        s.prepend(`const __styleTags = [];\n`);
+        s.replace(
+          /^import\s+(.+?)\s+from\s+['"]([^'"]+?\.module\.[^'"]+?)['"]/gm,
+          (all, statements, from) => {
+            if (!cssModuleRE.test(from)) {
+              return all;
+            }
+
+            if (statements.startsWith('{')) {
+              // Add default import
+              const replacement = `__style${styleCount++}, {`;
+              statements = statements.replace('{', replacement);
+              all = all.replace('{', replacement);
+            }
+
+            const defaultImport = statements
+              .split(',')[0]
+              .replace(/\*\s+as\s+/, '')
+              .trim();
+
+            return all + `; __styleTags.push(${defaultImport}.StyleTag)`;
+          }
+        );
+
+        // 2. Wrap default export in a new component that includes the style tags
+        s.replace(/export default/gm, 'const __defaultExport = ');
+        s.append(
+          `\nexport default function ApplyStyleTags(props) {\n` +
+            `  return <>{__styleTags.map(ST => <ST key={ST.key} />)}<__defaultExport {...props} /></>;` +
+            `\n}`
+        );
+
+        return {
+          code: s.toString(),
+          map: s.generateMap({file: id, source: id}),
+        };
+      }
+    },
+  } as Plugin;
 }

--- a/packages/playground/server-components/src/components/CssModules.client.jsx
+++ b/packages/playground/server-components/src/components/CssModules.client.jsx
@@ -1,0 +1,9 @@
+import styles from '../style.module.css';
+
+export default function CssModulesClient() {
+  return (
+    <div data-test="client" className={styles.red}>
+      hi
+    </div>
+  );
+}

--- a/packages/playground/server-components/src/routes/css-modules.server.jsx
+++ b/packages/playground/server-components/src/routes/css-modules.server.jsx
@@ -1,0 +1,14 @@
+import {red} from '../style.module.css';
+import CssModulesClient from '../components/CssModules.client';
+
+export default function CssModules() {
+  return (
+    <>
+      <h1>CSS Modules</h1>
+      <div data-test="server" className={red}>
+        something
+      </div>
+      <CssModulesClient />
+    </>
+  );
+}

--- a/packages/playground/server-components/src/style.module.css
+++ b/packages/playground/server-components/src/style.module.css
@@ -1,0 +1,3 @@
+.red {
+    color: red;
+}

--- a/packages/playground/server-components/src/style.module.css
+++ b/packages/playground/server-components/src/style.module.css
@@ -1,3 +1,3 @@
 .red {
-    color: red;
+  color: red;
 }

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -199,6 +199,23 @@ export default async function testCases({
     expect(body).toEqual('User-agent: *\nDisallow: /admin\n');
   });
 
+  it('adds style tags for CSS modules', async () => {
+    await page.goto(getServerUrl() + '/css-modules');
+    expect(await page.textContent('h1')).toContain('CSS Modules');
+
+    // Same class for the same style
+    const className = await page.getAttribute('[data-test=server]', 'class');
+    expect(className).toMatch(/^_red_/);
+    expect(await page.getAttribute('[data-test=client]', 'class')).toEqual(
+      className
+    );
+
+    // Style tag is present in DOM
+    expect(await page.textContent('style')).toEqual(
+      `.${className} {\n    color: red;\n}`
+    );
+  });
+
   describe('HMR', () => {
     if (isBuild) return;
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -199,7 +199,7 @@ export default async function testCases({
     expect(body).toEqual('User-agent: *\nDisallow: /admin\n');
   });
 
-  it('adds style tags for CSS modules', async () => {
+  it.only('adds style tags for CSS modules', async () => {
     await page.goto(getServerUrl() + '/css-modules');
     expect(await page.textContent('h1')).toContain('CSS Modules');
 
@@ -212,7 +212,7 @@ export default async function testCases({
 
     // Style tag is present in DOM
     expect(await page.textContent('style')).toEqual(
-      `.${className} {\n    color: red;\n}`
+      `.${className} {\n  color: red;\n}\n`
     );
   });
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -199,7 +199,7 @@ export default async function testCases({
     expect(body).toEqual('User-agent: *\nDisallow: /admin\n');
   });
 
-  it.only('adds style tags for CSS modules', async () => {
+  it('adds style tags for CSS modules', async () => {
     await page.goto(getServerUrl() + '/css-modules');
     expect(await page.textContent('h1')).toContain('CSS Modules');
 
@@ -210,7 +210,8 @@ export default async function testCases({
       className
     );
 
-    // Style tag is present in DOM
+    // Style tag is present in DOM, and it's unique
+    expect(await page.$$('style[data-module]')).toHaveLength(1);
     expect(await page.textContent('style')).toEqual(
       `.${className} {\n  color: red;\n}\n`
     );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

More improvements to the CSS Modules, this time to avoid duplicating styles when the same module is used more than once in the same request. There's some Vite magic going on here, please test it locally and try to break it if you have time.

@9001-Sols can you check if this removes the duplicated style tags in your project?

### Additional context

The logic works as follows:
Say we have component "A" and "B". Both of them render a CSS module "X".
1. During SSR: A is rendered before B so it adds X to the output. When B renders, it sees that X is already consumed in the current request and skips it.
2. During hydration: A checks the DOM and sees that X is serialized (by A itself in the server). It renders X in order to fulfill hydration. When B hydrates, it finds X in the DOM but also that it's been added by a different component, so it skips rendering X.

Apart from that, this should also prevent Vite from downloading the styles again as separate files since we already have them inlined in the responses.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
