### PR TITLE
ci: add Netlify deployment workflow

### DIFF
--- a/.github/deployments/netlify/netlify.toml
+++ b/.github/deployments/netlify/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+publish = "dist/client"
+command = "echo 'Already built; skipping'"
+
+[dev]
+framework = "#static"

--- a/.github/deployments/netlify/vite.config.js
+++ b/.github/deployments/netlify/vite.config.js
@@ -1,0 +1,14 @@
+import {defineConfig} from 'vite';
+import hydrogen from '@shopify/hydrogen/plugin';
+import netlifyPlugin from '@netlify/hydrogen-platform/plugin';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [hydrogen(), netlifyPlugin()],
+  optimizeDeps: {include: ['@headlessui/react']},
+  test: {
+    globals: true,
+    testTimeout: 10000,
+    hookTimeout: 10000,
+  },
+});

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -55,3 +55,53 @@ jobs:
       - name: Run health check
         run: |
           yarn ts-node scripts/health-check.ts https://template-default.hydrogen-devs.workers.dev/
+  deploy_netlify:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'shopify' }}
+    name: Deploy to Netlify
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install the packages
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Build Hydrogen
+        run: yarn workspace @shopify/hydrogen build
+
+      - name: Make updates for Netlify Edge Functions runtime
+        working-directory: ./templates/template-hydrogen-default
+        run: |
+          cp ../../.github/deployments/netlify/* .
+          yarn add @netlify/hydrogen-platform
+
+      - name: Build for Netlify Functions
+        working-directory: ./templates/template-hydrogen-default
+        run: |
+          yarn build:client
+          yarn cross-env WORKER=true vite build --ssr @netlify/hydrogen-platform/handler
+
+      - name: Install Netlify CLI
+        run: |
+          yarn global add netlify-cli
+
+      - name: Deploy to Netlify
+        id: netlify-deploy
+        working-directory: ./templates/template-hydrogen-default
+        run: |
+          netlify deploy --build --json | jq -r '.deploy_url' > deploy.txt
+          echo "::set-output name=deploy-url::$(cat deploy.txt)"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1
+
+      - name: Run health check
+        run: |
+          yarn ts-node scripts/health-check.ts ${{steps.netlify-deploy.outputs.deploy-url}}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds an additional task to the Deployments workflow, deploying a site to Netlify. This can help to avoid regressions similar to the asset path one that was recently fixed. See this comment: https://github.com/netlify/hydrogen-platform/pull/14#issuecomment-1118725916 from @benjaminsehl 

This will require a site to be created on Netlify (no need to link it to this repo, because it will be deployed manually), and the secrets added to this repo:

- `NETLIFY_AUTH_TOKEN`: [Personal access tokens](https://app.netlify.com/user/applications#personal-access-tokens) > New access token
- `NETLIFY_SITE_ID`: team page > your site > Settings > Site details > Site information > Site ID

 I have tested this on my own fork, and you can see [the test run here](https://github.com/ascorbic/hydrogen/runs/6423408331?check_suite_focus=true).
The existing healthcheck script doesn't really check much, but it's a start, but it would be good to add real e2e tests for all deploy targets.

### Additional context

In the future it may be better to link this repo directly to Netlify and deploy it in CI as usual.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
