### PR TITLE
Revert "Remove flight chunk"

### DIFF
--- a/.changeset/moody-planes-perform.md
+++ b/.changeset/moody-planes-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Reverts [#1272](https://github.com/Shopify/hydrogen/pull/1272) and properly escapes terminating script sequences

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -216,7 +216,7 @@ async function render(
 ) {
   const state = {pathname: url.pathname, search: url.search};
 
-  const {AppSSR} = buildAppSSR(
+  const {AppSSR, rscReadable} = buildAppSSR(
     {
       App,
       log,
@@ -233,9 +233,10 @@ async function render(
     return template;
   }
 
-  let html = await renderToBufferedString(AppSSR, {log, nonce}).catch(
-    onErrorShell
-  );
+  let [html, flight] = await Promise.all([
+    renderToBufferedString(AppSSR, {log, nonce}).catch(onErrorShell),
+    bufferReadableStream(rscReadable.getReader()).catch(() => null),
+  ]);
 
   const {headers, status, statusText} = getResponseOptions(componentResponse);
 
@@ -260,6 +261,18 @@ async function render(
   headers.set(CONTENT_TYPE, HTML_CONTENT_TYPE);
 
   html = applyHtmlHead(html, request.ctx.head, template);
+
+  if (flight) {
+    html = html.replace(
+      '</body>',
+      () =>
+        `${flightContainer({
+          init: true,
+          nonce,
+          chunk: flight as string,
+        })}</body>`
+    );
+  }
 
   postRequestTasks('ssr', status, request, componentResponse);
 
@@ -307,7 +320,13 @@ async function stream(
   const rscToScriptTagReadable = new ReadableStream({
     start(controller) {
       log.trace('rsc start chunks');
-      bufferReadableStream(rscReadable.getReader()).then(() => {
+      let init = true;
+      const encoder = new TextEncoder();
+      bufferReadableStream(rscReadable.getReader(), (chunk) => {
+        const scriptTag = flightContainer({init, chunk, nonce});
+        controller.enqueue(encoder.encode(scriptTag));
+        init = false;
+      }).then(() => {
         log.trace('rsc finish chunks');
         return controller.close();
       });
@@ -837,6 +856,33 @@ async function createNodeWriter() {
   const streamImport = __WORKER__ ? '' : 'stream';
   const {PassThrough} = await import(streamImport);
   return new PassThrough() as InstanceType<typeof PassThroughType>;
+}
+
+function flightContainer({
+  init,
+  chunk,
+  nonce,
+}: {
+  chunk?: string;
+  init?: boolean;
+  nonce?: string;
+}) {
+  let script = `<script${nonce ? ` nonce="${nonce}"` : ''}>`;
+  if (init) {
+    script += 'var __flight=[];';
+  }
+
+  if (chunk) {
+    const normalizedChunk = chunk
+      // 1. Duplicate the escape char (\) for already escaped characters (e.g. \n or \").
+      .replace(/\\/g, String.raw`\\`)
+      // 2. Escape existing backticks to allow wrapping the whole thing in `...`.
+      .replace(/`/g, String.raw`\``);
+
+    script += `__flight.push(\`${normalizedChunk}\`)`;
+  }
+
+  return script + '</script>';
 }
 
 function postRequestTasks(

--- a/packages/hydrogen/src/framework/Hydration/rsc.ts
+++ b/packages/hydrogen/src/framework/Hydration/rsc.ts
@@ -10,7 +10,37 @@ import {
 } from '@shopify/hydrogen/vendor/react-server-dom-vite';
 import {RSC_PATHNAME} from '../../constants';
 
+declare global {
+  // eslint-disable-next-line no-var
+  var __flight: Array<string>;
+}
+
 let rscReader: ReadableStream | null;
+
+if (globalThis.__flight && __flight.length > 0) {
+  const contentLoaded = new Promise((resolve) =>
+    document.addEventListener('DOMContentLoaded', resolve)
+  );
+
+  try {
+    rscReader = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        const write = (chunk: string) => {
+          controller.enqueue(encoder.encode(chunk));
+          return 0;
+        };
+
+        __flight.forEach(write);
+        __flight.push = write;
+
+        contentLoaded.then(() => controller.close());
+      },
+    });
+  } catch (_) {
+    // Old browser, will try a new hydration request later
+  }
+}
 
 function createResponseCache() {
   return new Map<string, any>();

--- a/packages/playground/server-components/src/components/Passthrough.client.jsx
+++ b/packages/playground/server-components/src/components/Passthrough.client.jsx
@@ -1,0 +1,3 @@
+export default function Passthrough({children}) {
+  return children;
+}

--- a/packages/playground/server-components/src/routes/escaping.server.jsx
+++ b/packages/playground/server-components/src/routes/escaping.server.jsx
@@ -1,0 +1,11 @@
+import Passthrough from '../components/Passthrough.client';
+
+export default function Escaping() {
+  return (
+    <Passthrough
+      prop="</script><script>document.body = ''</script>"
+      // eslint-disable-next-line react/no-children-prop
+      children="</script><script>alert('hi')</script>"
+    />
+  );
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -37,10 +37,8 @@ export default async function testCases({
     expect(await page.textContent('body')).toContain('About');
     expect(await page.textContent('.count')).toBe('Count is 0');
 
-    // await page.click('.increase');
-    // // TODO: Fix test flakiness
-    // await new Promise((res) => setTimeout(res, 1000));
-    // expect(await page.textContent('.count')).toBe('Count is 1');
+    await page.click('.increase');
+    expect(await page.textContent('.count')).toBe('Count is 1');
   });
 
   it('renders `<ShopifyProvider>` dynamically in RSC and on the client', async () => {
@@ -113,6 +111,8 @@ export default async function testCases({
     expect(streamedChunks.length).toBeGreaterThan(1); // Streamed more than 1 chunk
 
     const body = streamedChunks.join('');
+    expect(body).toContain('var __flight=[];');
+    expect(body).toContain('__flight.push(`S1:"react.suspense"');
     expect(body).toContain('<div c="5">');
     expect(body).toContain('>footer!<');
   });
@@ -128,11 +128,11 @@ export default async function testCases({
       streamedChunks.push(chunk.toString());
     }
 
-    // Worker test is returning 1 chunk, while node test are returning 2 chunk
-    // The second chunk is undefined
-    // expect(streamedChunks.length).toEqual(1); // Did not stream because it's a bot
+    expect(streamedChunks.length).toEqual(1); // Did not stream because it's a bot
 
     const body = streamedChunks.join('');
+    expect(body).toContain('var __flight=[];');
+    expect(body).toContain('__flight.push(`S1:"react.suspense"');
     expect(body).toContain('<div c="5">');
     expect(body).toContain('>footer!<');
   });
@@ -392,20 +392,14 @@ export default async function testCases({
       expect(await page.textContent('*')).toContain('fname=sometext');
     });
 
-    // it('can concatenate requests', async () => {
-    //   await page.goto(getServerUrl() + '/html-form');
-    //   expect(await page.textContent('#counter')).toEqual('0');
-    //   await page.click('#increase');
-
-    //   // TODO: Fix test flakiness
-    //   await new Promise((res) => setTimeout(res, 1000));
-    //   expect(await page.textContent('#counter')).toEqual('1');
-    //   await page.click('#increase');
-
-    //   // TODO: Fix test flakiness
-    //   await new Promise((res) => setTimeout(res, 1000));
-    //   expect(await page.textContent('#counter')).toEqual('2');
-    // });
+    it('can concatenate requests', async () => {
+      await page.goto(getServerUrl() + '/html-form');
+      expect(await page.textContent('#counter')).toEqual('0');
+      await page.click('#increase');
+      expect(await page.textContent('#counter')).toEqual('1');
+      await page.click('#increase');
+      expect(await page.textContent('#counter')).toEqual('2');
+    });
   });
 
   describe('Custom Routing', () => {

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -112,7 +112,7 @@ export default async function testCases({
 
     const body = streamedChunks.join('');
     expect(body).toContain('var __flight=[];');
-    expect(body).toContain('__flight.push(`S1:"react.suspense"');
+    expect(body).toContain(`__flight.push("S1:\\"react.suspense\\"`);
     expect(body).toContain('<div c="5">');
     expect(body).toContain('>footer!<');
   });
@@ -132,7 +132,7 @@ export default async function testCases({
 
     const body = streamedChunks.join('');
     expect(body).toContain('var __flight=[];');
-    expect(body).toContain('__flight.push(`S1:"react.suspense"');
+    expect(body).toContain(`__flight.push("S1:\\"react.suspense\\"`);
     expect(body).toContain('<div c="5">');
     expect(body).toContain('>footer!<');
   });
@@ -197,6 +197,13 @@ export default async function testCases({
 
     expect(response.headers.get('Content-Type')).toEqual('text/plain');
     expect(body).toEqual('User-agent: *\nDisallow: /admin\n');
+  });
+
+  it('properly escapes props in the SSR flight script chunks', async () => {
+    await page.goto(getServerUrl() + '/escaping');
+    expect(await page.textContent('body')).toContain(
+      "</script><script>alert('hi')</script>"
+    );
   });
 
   describe('HMR', () => {


### PR DESCRIPTION
Reverts Shopify/hydrogen#1272

This PR adds logic to escape script tags which would put the embedded flight script chunks in SSR payloads in a bad or vulnerable state.

Note: This simply prevents the script tag from being terminated too early. Developers who accept untrusted data via inputs should still sanitize the data before sending it to the client.

Inspired by https://github.com/facebook/react/pull/24385