### PR TITLE
Rename dev commands since we updated Turbo

### DIFF
--- a/packages/playground/async-config/package.json
+++ b/packages/playground/async-config/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.11.0",
   "scripts": {
-    "_dev": "vite",
+    "dev": "vite",
     "start:node": "node ../test-utils/start-node",
     "start:worker": "node ../test-utils/start-worker",
     "build": "yarn build:client && yarn build:server && yarn build:worker",

--- a/packages/playground/server-components/package.json
+++ b/packages/playground/server-components/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.11.0",
   "scripts": {
-    "_dev": "vite",
+    "dev": "vite",
     "start:node": "node ../test-utils/start-node",
     "start:worker": "node ../test-utils/start-worker",
     "build": "yarn build:client && yarn build:server && yarn build:worker",


### PR DESCRIPTION
They no longer need to be prefixed with `_dev` after updating Turbo to use proper filters.