### PR TITLE
Fix (some) sourcemap warnings

### DIFF
--- a/.changeset/twenty-mangos-matter.md
+++ b/.changeset/twenty-mangos-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix some sourcemap warnings in server console

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydration-auto-import.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydration-auto-import.ts
@@ -34,7 +34,7 @@ export default () => {
 
         return {
           code: code.toString(),
-          map: code.generateMap(),
+          map: {mappings: ''},
         };
       }
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydration-auto-import.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydration-auto-import.ts
@@ -34,10 +34,7 @@ export default () => {
 
         return {
           code: code.toString(),
-          map: code.generateMap({
-            file: HYDROGEN_ENTRY_FILE,
-            source: HYDROGEN_ENTRY_FILE,
-          }),
+          map: code.generateMap(),
         };
       }
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-ssr-interop.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-ssr-interop.ts
@@ -6,9 +6,12 @@ export default () => {
     enforce: 'pre',
     transform(code, id, options = {}) {
       if (options.ssr && id.includes('foundation/ssr-interop')) {
-        return code
-          .replace(/(\s*META_ENV_SSR\s*=\s*)false/, '$1import.meta.env.SSR')
-          .replace(/\/\/@SSR\s*/g, '');
+        return {
+          code: code
+            .replace(/(\s*META_ENV_SSR\s*=\s*)false/, '$1import.meta.env.SSR')
+            .replace(/\/\/@SSR\s*/g, ''),
+          map: {mappings: ''},
+        };
       }
     },
   } as Plugin;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes two warnings being printed in the server console by modifying our sourcemap declarations:

When running `yarn dev`:

>Sourcemap for "/Users/joshlarson/src/github.com/Shopify/hydrogen/templates/template-hydrogen-default/hydrogen-entry-client.jsx" points to missing source files

When building for production:

>Sourcemap is likely to be incorrect: a plugin (vite-plugin-ssr-interop) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help

Note: There are still additional Vite RSC sourcemaps warnings, but those exist in the upstream plugin in @frandiox's repo. We should get those fixed as well before GA, but leaving it to Fran to get to the next time he makes an update 👍 