### PR TITLE
New eslint rule for valid usage of fetch sync

### DIFF
--- a/packages/eslint-plugin/src/rules/valid-fetchsync/index.ts
+++ b/packages/eslint-plugin/src/rules/valid-fetchsync/index.ts
@@ -1,0 +1,1 @@
+export {validFetchSync} from './valid-fetch-sync';

--- a/packages/eslint-plugin/src/rules/valid-fetchsync/tests/valid-fetch-sync.test.ts
+++ b/packages/eslint-plugin/src/rules/valid-fetchsync/tests/valid-fetch-sync.test.ts
@@ -1,0 +1,53 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {AST_NODE_TYPES} from '@typescript-eslint/types';
+import {validFetchSync} from '../valid-fetch-sync';
+import dedent from 'dedent';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+function error(messageId: 'serverInvalidFetchSync' | 'clientInvalidFetchSync') {
+  return {
+    type: AST_NODE_TYPES.ImportDeclaration,
+    messageId,
+  };
+}
+
+ruleTester.run('hydrogen/valid-fetch-sync', validFetchSync, {
+  valid: [
+    {
+      code: dedent`
+        import {fetchSync} from '@shopify/hydrogen';
+      `,
+      filename: 'ServerComponent.server.tsx',
+    },
+    {
+      code: dedent`
+        import {fetchSync} from '@shopify/hydrogen/client';
+      `,
+      filename: 'ClientComponent.client.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        import {fetchSync} from '@shopify/hydrogen/client';
+      `,
+      filename: 'ServerComponent.server.tsx',
+      errors: [error('serverInvalidFetchSync')],
+    },
+    {
+      code: dedent`
+        import {fetchSync} from '@shopify/hydrogen';
+      `,
+      filename: 'ClientComponent.client.tsx',
+      errors: [error('clientInvalidFetchSync')],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/valid-fetchsync/valid-fetch-sync.ts
+++ b/packages/eslint-plugin/src/rules/valid-fetchsync/valid-fetch-sync.ts
@@ -1,0 +1,70 @@
+import {AST_NODE_TYPES, TSESTree} from '@typescript-eslint/types';
+
+import {
+  createRule,
+  isServerComponentFile,
+  isClientComponentFile,
+} from '../../utilities';
+
+export const validFetchSync = createRule({
+  name: `hydrogen/${__dirname}`,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'TODO',
+      category: 'Possible Errors',
+      recommended: 'warn',
+    },
+    messages: {
+      serverInvalidFetchSync:
+        'Import fetchSync from `@shopify/hydrogen` in server components',
+      clientInvalidFetchSync:
+        'Import fetchSync from `@shopify/hydrogen/client` in client components',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const imported = node.specifiers.map(
+          (specifier) => specifier.local.name
+        );
+
+        if (!imported.includes('fetchSync')) {
+          return;
+        }
+
+        const filename = context.getFilename();
+
+        if (isServerComponentFile(filename) && isHydrogenClientImport(node)) {
+          context.report({
+            node,
+            messageId: 'serverInvalidFetchSync',
+          });
+        }
+
+        if (isClientComponentFile(filename) && isHydrogenServerImport(node)) {
+          context.report({
+            node,
+            messageId: 'clientInvalidFetchSync',
+          });
+        }
+      },
+    };
+  },
+});
+
+function isHydrogenServerImport(node: TSESTree.ImportDeclaration) {
+  return (
+    node.source.type === AST_NODE_TYPES.Literal &&
+    node.source.value === '@shopify/hydrogen'
+  );
+}
+
+function isHydrogenClientImport(node: TSESTree.ImportDeclaration) {
+  return (
+    node.source.type === AST_NODE_TYPES.Literal &&
+    node.source.value === '@shopify/hydrogen/client'
+  );
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is a quick proof of concept for enforcing that users import `fetchSync` from the right location. 

### Additional context

More information [in the docs](https://shopify.dev/api/hydrogen/hooks/global/fetchsync#fetchsync-in-client-components).

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
