### PR TITLE
Flip client import regex to filter out server components

### DIFF
--- a/packages/hydrogen/src/framework/plugins/vite-plugin-client-imports.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-client-imports.ts
@@ -6,11 +6,14 @@ export default function clientImports(): Plugin {
 
     enforce: 'pre',
 
-    // When importer ends in `client.jsx`, and source is `@shopify/hydrogen`, replace with `@shopify/hydrogen/client`.
-    // This prevents other server-only imports from "leaking" into the client bundle.
+    /**
+     * When importer does not end in `server.jsx`, and source is `@shopify/hydrogen`,
+     * replace with `@shopify/hydrogen/client`. This prevents other server-only imports
+     * from "leaking" into the client bundle.
+     */
     async resolveId(source, importer, {ssr}) {
       if (ssr) return;
-      if (!/\.client\.(j|t)sx?/.test(importer ?? '')) return;
+      if (/\.server\.(j|t)sx?/.test(importer ?? '')) return;
       if ('@shopify/hydrogen' !== source) return;
 
       const resolution = await this.resolve(


### PR DESCRIPTION
### Description

Instead of being exclusive to client components, this PR updates the logic to convert `@shopify/hydrogen` imports to `@shopify/hydrogen/client` when referenced in all modules that don't end in `.server.jsx`.

This ensures that developers who import Hydrogen components in shared components e.g. `ProductCard.jsx` which is eventually imported in a client component will be importing the correct endpoint in a client bundle.