### PR TITLE
Buffer RSC flight responses

### DIFF
--- a/.changeset/friendly-ravens-wash.md
+++ b/.changeset/friendly-ravens-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Buffer RSC flight responses. There isn't any benefit to streaming them, because we start a transition on page navigation. Buffering also fixes caching problems on the flight response.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -23,7 +23,7 @@ import {
   ServerRequestProvider,
 } from './foundation/ServerRequestProvider';
 import type {ServerResponse, IncomingMessage} from 'http';
-import type {PassThrough as PassThroughType, Writable} from 'stream';
+import type {PassThrough as PassThroughType} from 'stream';
 import {
   getApiRouteFromURL,
   renderApiRoute,
@@ -608,41 +608,18 @@ async function hydrate(
     response: componentResponse,
   });
 
-  if (__WORKER__) {
-    const rscReadable = rscRenderToReadableStream(AppRSC);
+  const rscReadable = rscRenderToReadableStream(AppRSC);
 
-    if (isStreamable && (await isStreamingSupported())) {
-      postRequestTasks('rsc', 200, request, componentResponse);
-      return new Response(rscReadable);
-    }
+  // Note: CFW does not support reader.piteTo nor iterable syntax
+  const bufferedBody = await bufferReadableStream(rscReadable.getReader());
 
-    // Note: CFW does not support reader.piteTo nor iterable syntax
-    const bufferedBody = await bufferReadableStream(rscReadable.getReader());
+  postRequestTasks('rsc', 200, request, componentResponse);
 
-    postRequestTasks('rsc', 200, request, componentResponse);
-
-    return new Response(bufferedBody, {
-      headers: {
-        'cache-control': componentResponse.cacheControlHeader,
-      },
-    });
-  } else if (response) {
-    const rscWriter = await import(
-      // @ts-ignore
-      '@shopify/hydrogen/vendor/react-server-dom-vite/writer.node.server'
-    );
-
-    const streamer = rscWriter.renderToPipeableStream(AppRSC);
-    const stream = streamer.pipe(response) as Writable;
-
-    response.writeHead(200, 'ok', {
+  return new Response(bufferedBody, {
+    headers: {
       'cache-control': componentResponse.cacheControlHeader,
-    });
-
-    stream.on('finish', function () {
-      postRequestTasks('rsc', response.statusCode, request, componentResponse);
-    });
-  }
+    },
+  });
 }
 
 type SharedServerProps = {

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -162,7 +162,7 @@ export default async function testCases({
     expect(body).toContain('>footer!<');
   });
 
-  it('streams the RSC response', async () => {
+  it('buffers the RSC response', async () => {
     const response = await fetch(
       getServerUrl() +
         `${RSC_PATHNAME}?state=` +
@@ -178,7 +178,7 @@ export default async function testCases({
       streamedChunks.push(chunk.toString());
     }
 
-    expect(streamedChunks.length).toBeGreaterThan(1);
+    expect(streamedChunks.length).toBe(1);
 
     const body = streamedChunks.join('');
     expect(body).toContain('S1:"react.suspense"');


### PR DESCRIPTION
### Description

Buffer RSC flight responses. There isn't any benefit to streaming them, because we start a transition on page navigation. Buffering also fixes caching problems on the flight response.

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
