### PR TITLE
Fix fetch response handling in Node environments

### DIFF
--- a/.changeset/lazy-jokes-brush.md
+++ b/.changeset/lazy-jokes-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix server hanging in Node.js environment when not using Hydrogen Middleware.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -850,9 +850,7 @@ function writeHeadToServerResponse(
     response.statusMessage = statusText;
   }
 
-  Object.entries((headers as any).raw()).forEach(([key, value]) =>
-    response.setHeader(key, value as string)
-  );
+  setServerHeaders(headers, response);
 }
 
 function isRedirect(response: {status?: number; statusCode?: number}) {
@@ -897,9 +895,7 @@ function handleFetchResponseInNode(
     fetchResponsePromise.then((response) => {
       if (!response) return;
 
-      response.headers.forEach((value: string, key: string) => {
-        nodeResponse.setHeader(key, value);
-      });
+      setServerHeaders(response.headers, nodeResponse);
 
       nodeResponse.statusCode = response.status;
 
@@ -912,4 +908,14 @@ function handleFetchResponseInNode(
   }
 
   return fetchResponsePromise;
+}
+
+// From fetch Headers to Node Response
+function setServerHeaders(headers: Headers, nodeResponse: ServerResponse) {
+  // Headers.raw is only implemented in node-fetch, which is used by Hydrogen in dev and prod.
+  // It is the only way for now to access `set-cookie` header as an array.
+  // https://github.com/Shopify/hydrogen/issues/1228
+  Object.entries((headers as any).raw()).forEach(([key, value]) =>
+    nodeResponse.setHeader(key, value as string)
+  );
 }

--- a/packages/hydrogen/src/framework/middleware.ts
+++ b/packages/hydrogen/src/framework/middleware.ts
@@ -98,7 +98,7 @@ export function hydrogenMiddleware({
 
       entrypointError = null;
 
-      return handleRequest(request, {
+      await handleRequest(request, {
         dev,
         cache,
         indexTemplate,

--- a/packages/hydrogen/src/framework/middleware.ts
+++ b/packages/hydrogen/src/framework/middleware.ts
@@ -98,30 +98,12 @@ export function hydrogenMiddleware({
 
       entrypointError = null;
 
-      const eventResponse = await handleRequest(request, {
+      return handleRequest(request, {
         dev,
         cache,
         indexTemplate,
         streamableResponse: response,
       });
-
-      /**
-       * If a `Response` was returned, that means it was not streamed.
-       * Convert the response into a proper Node.js response.
-       */
-      if (eventResponse) {
-        eventResponse.headers.forEach((value: string, key: string) => {
-          response.setHeader(key, value);
-        });
-
-        response.statusCode = eventResponse.status;
-
-        if (eventResponse.body) {
-          response.write(eventResponse.body);
-        }
-
-        response.end();
-      }
     } catch (e: any) {
       if (dev && devServer) devServer.ssrFixStacktrace(e);
       response.statusCode = 500;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Node.js environments that don't use `hydrogenMiddleware` (e.g. serverless functions) could have the server hanging for `render` requests (bots) and for `hydrate` requests after #1318 is merged.

This moves the response handling logic for Node.js from the middleware to the core.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
