### PR TITLE
Automatically fix GQL imports in exisiting Hydrogen Projects

### DIFF
--- a/packages/eslint-plugin/.github/CONTRIBUTING.md
+++ b/packages/eslint-plugin/.github/CONTRIBUTING.md
@@ -13,11 +13,11 @@ All changes should have tests and documentation.
 
 ## Test changes in the Demo Store template
 
-Before submitting a PR please test your changes in one of the hydrogen templates in the top-level `/examples` folder in this repo.
+Before submitting a PR please test your changes in one of the hydrogen templates in the top-level `/templates` folder in this repo.
 
 To do this you must first run `yarn link` from within the `packages/eslint-plugin` folder.
 
-Then make sure the ESLint configuration (`.eslintrc.js`) inside the template is extending from this plugin. For example, to test in the `demo-store`, the `/examples/demo-store/.eslintrc.js` should look something like this:
+Then make sure the ESLint configuration (`.eslintrc.js`) inside the template is extending from this plugin. For example, to test in the `demo-store`, the `/templates/demo-store/.eslintrc.js` should look something like this:
 
 ```js
 // example: /examples/demo-store/.eslintrc.js`
@@ -27,7 +27,7 @@ module.exports = {
 };
 ```
 
-Then run `yarn link eslint-plugin-hydrogen` and `yarn lint:js` from within the Demo Store template (example: `/examples/demo-store`).
+Then run `yarn link eslint-plugin-hydrogen` and `yarn lint:js` from within the Demo Store template (example: `/templates/demo-store`).
 
 ## Resources
 

--- a/packages/eslint-plugin/src/configs/hydrogen.ts
+++ b/packages/eslint-plugin/src/configs/hydrogen.ts
@@ -5,5 +5,6 @@ export default {
     'hydrogen/prefer-image-component': 'error',
     'hydrogen/server-component-banned-hooks': 'error',
     'hydrogen/server-no-json-parse': 'error',
+    'hydrogen/prefer-gql': 'error',
   },
 };

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -2,10 +2,12 @@ import {clientComponentBannedHooks} from './client-component-banned-hooks';
 import {serverComponentBannedHooks} from './server-component-banned-hooks';
 import {preferImageComponent} from './prefer-image-component';
 import {serverNoJsonParse} from './server-no-json-parse';
+import {preferGQL} from './prefer-gql';
 
 export const rules: {[key: string]: any} = {
   'client-component-banned-hooks': clientComponentBannedHooks,
   'server-component-banned-hooks': serverComponentBannedHooks,
   'prefer-image-component': preferImageComponent,
   'server-no-json-parse': serverNoJsonParse,
+  'prefer-gql': preferGQL,
 };

--- a/packages/eslint-plugin/src/rules/prefer-gql/README.md
+++ b/packages/eslint-plugin/src/rules/prefer-gql/README.md
@@ -1,14 +1,14 @@
 # Prefer using the `gql` utility from Hydrogen
 
-Projects that consume a GraphQL API typically use a utility that parses GraphQL queries into ASTNodes for the projects' GraphQL client library or provides syntax highlighting.
+Projects that consume a GraphQL API typically use a utility to parses GraphQL queries into an AST for the projects' GraphQL client library to use. It will also often provide syntax highlighting, auto-completion and other integrations with the developers editor.
 
-In Hydrogen, you don't need to parse GraphQL queries. Instead, you can use Hydrogen's light-weight [`gql` utility](https://shopify.dev/api/hydrogen/utilities/gql) that adds syntax highlighting to your GraphQL queries.
+In Hydrogen, you don't need to parse GraphQL queries into an AST and can cut down on the projects' final bundle size by using Hydrogen's light-weight [`gql` utility](https://shopify.dev/api/hydrogen/utilities/gql) instead.
 
 Using the `gql` utility makes your production bundle smaller by dropping certain AST-related dependencies. In development, however, the `gql` utility uses ASTNodes to provide better errors in your queries.
 
 ## Rule details
 
-This rule is used to detect the use of a GraphQL utility other than the one provided by Hydrogen. If another GraphQL utility is being used, then the `gql` utility from `@shopify/hydrogen` is suggested.
+This rule is used to detect the use of a GraphQL utility other than the one provided by Hydrogen. If another GraphQL utility is used, then the `gql` utility from `@shopify/hydrogen` is suggested. This will also replace the utility automatically when `eslint` is run with the `--fix` flag if you choose.
 
 ### Incorrect code
 

--- a/packages/eslint-plugin/src/rules/prefer-gql/README.md
+++ b/packages/eslint-plugin/src/rules/prefer-gql/README.md
@@ -1,4 +1,4 @@
-# Prefer using the `gql` utility from hydrogen
+# Prefer using the `gql` utility from Hydrogen
 
 Projects that consume a GraphQL API will often use utility to help write GraphQL queries to parse the queries into an AST for the project's GraphQL client library and/or provide syntax highlighting. In hydrogen, we do not require to parse the GraphQL queries and provide a lightweight `gql` utility that is optimized for use within Hydrogen projects.
 

--- a/packages/eslint-plugin/src/rules/prefer-gql/README.md
+++ b/packages/eslint-plugin/src/rules/prefer-gql/README.md
@@ -1,10 +1,14 @@
 # Prefer using the `gql` utility from Hydrogen
 
-Projects that consume a GraphQL API will often use utility to help write GraphQL queries to parse the queries into an AST for the project's GraphQL client library and/or provide syntax highlighting. In hydrogen, we do not require to parse the GraphQL queries and provide a lightweight `gql` utility that is optimized for use within Hydrogen projects.
+Projects that consume a GraphQL API typically use a utility that parses GraphQL queries into ASTNodes for the projects' GraphQL client library or provides syntax highlighting.
+
+In Hydrogen, you don't need to parse GraphQL queries. Instead, you can use Hydrogen's light-weight [`gql` utility](https://shopify.dev/api/hydrogen/utilities/gql) that adds syntax highlighting to your GraphQL queries.
+
+Using the `gql` utility makes your production bundle smaller by dropping certain AST-related dependencies. In development, however, the `gql` utility uses ASTNodes to provide better errors in your queries.
 
 ## Rule details
 
-This rule is used to detect usages of `gql` utility other than the one provided by Hydrogen and suggests the utility from `@shopify/hydrogen`instead.
+This rule is used to detect the use of a GraphQL utility other than the one provided by Hydrogen. If another GraphQL utility is being used, then the `gql` utility from `@shopify/hydrogen` is suggested.
 
 ### Incorrect code
 

--- a/packages/eslint-plugin/src/rules/prefer-gql/README.md
+++ b/packages/eslint-plugin/src/rules/prefer-gql/README.md
@@ -1,0 +1,37 @@
+# Prefer using the `gql` utility from hydrogen
+
+Projects that consume a GraphQL API will often use utility to help write GraphQL queries to parse the queries into an AST for the project's GraphQL client library and/or provide syntax highlighting. In hydrogen, we do not require to parse the GraphQL queries and provide a lightweight `gql` utility that is optimized for use within Hydrogen projects.
+
+## Rule details
+
+This rule is used to detect usages of `gql` utility other than the one provided by Hydrogen and suggests the utility from `@shopify/hydrogen`instead.
+
+### Incorrect code
+
+```tsx
+import {gql} from 'graphql-tag';
+
+function MyComponent() {
+  const query = gql`
+    //...
+  `
+  return (
+    //...
+  );
+}
+```
+
+### Correct code
+
+```tsx
+import {gql} from '@shopify/hydrogen';
+
+function MyComponent() {
+  const query = gql`
+    //...
+  `
+  return (
+    //...
+  );
+}
+```

--- a/packages/eslint-plugin/src/rules/prefer-gql/index.ts
+++ b/packages/eslint-plugin/src/rules/prefer-gql/index.ts
@@ -1,0 +1,1 @@
+export {preferGQL} from './prefer-gql';

--- a/packages/eslint-plugin/src/rules/prefer-gql/prefer-gql.ts
+++ b/packages/eslint-plugin/src/rules/prefer-gql/prefer-gql.ts
@@ -1,0 +1,83 @@
+import {TSESTree} from '@typescript-eslint/types';
+
+import {createRule} from '../../utilities';
+
+export const preferGQL = createRule({
+  name: `hydrogen/${__dirname}`,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer using the `gql` utility from hydrogen',
+      category: 'Best Practices',
+      recommended: 'warn',
+    },
+    messages: {
+      preferGQL: `Use the \`gql\` utility from '@shopify/hydrogen'.`,
+      replaceWithGQL: `Replace with the \`gql\` utility from @shopify/hydrogen.`,
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    let hydrogenImportNode: TSESTree.ImportDeclaration | undefined;
+    let lastImportNode: TSESTree.ImportDeclaration;
+
+    return {
+      ImportDeclaration(node) {
+        const imported = node.specifiers.map(
+          (specifier) => specifier.local.name
+        );
+
+        hydrogenImportNode =
+          node.source.value === '@shopify/hydrogen' ? node : hydrogenImportNode;
+        lastImportNode = node;
+
+        if (
+          imported.includes('gql') &&
+          node.source.value !== '@shopify/hydrogen'
+          // node !== hydrogenImportNode
+        ) {
+          return context.report({
+            node,
+            messageId: 'preferGQL',
+            fix(fixer) {
+              const tagFix = fixer.replaceTextRange(
+                [node.range[0] + 1, node.range[0] + 4],
+                'gql'
+              );
+              let importFix = lastImportNode
+                ? fixer.insertTextAfter(
+                    lastImportNode,
+                    `import {gql} from '@shopify/hydrogen';`
+                  )
+                : fixer.insertTextBefore(
+                    context.getAncestors()[0],
+                    `import {gql} from '@shopify/hydrogen';`
+                  );
+
+              if (hydrogenImportNode) {
+                if (
+                  hydrogenImportNode.specifiers.some(
+                    (specifier) => specifier.local.name === `gql`
+                  )
+                ) {
+                  return [tagFix];
+                }
+
+                const lastSpecifier =
+                  hydrogenImportNode.specifiers[
+                    hydrogenImportNode.specifiers.length - 1
+                  ];
+
+                importFix = fixer.insertTextAfter(lastSpecifier, `, gql`);
+              }
+
+              return [fixer.remove(node), importFix];
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/prefer-gql/prefer-gql.ts
+++ b/packages/eslint-plugin/src/rules/prefer-gql/prefer-gql.ts
@@ -33,11 +33,7 @@ export const preferGQL = createRule({
           node.source.value === '@shopify/hydrogen' ? node : hydrogenImportNode;
         lastImportNode = node;
 
-        if (
-          imported.includes('gql') &&
-          node.source.value !== '@shopify/hydrogen'
-          // node !== hydrogenImportNode
-        ) {
+        if (imported.includes('gql') && node !== hydrogenImportNode) {
           return context.report({
             node,
             messageId: 'preferGQL',

--- a/packages/eslint-plugin/src/rules/prefer-gql/tests/prefer-gql.test.ts
+++ b/packages/eslint-plugin/src/rules/prefer-gql/tests/prefer-gql.test.ts
@@ -1,0 +1,73 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {AST_NODE_TYPES} from '@typescript-eslint/types';
+import {preferGQL} from '../prefer-gql';
+import dedent from 'dedent';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+function error(options: {suggestion?: string} = {}) {
+  const suggestions = options.suggestion
+    ? {
+        suggestions: [
+          {
+            output: options.suggestion,
+            messageId: 'replaceWithGQL' as const,
+          },
+        ],
+      }
+    : {};
+  return {
+    type: AST_NODE_TYPES.ImportDeclaration,
+    messageId: 'preferGQL' as const,
+    ...suggestions,
+  };
+}
+
+ruleTester.run('hydrogen/prefer-gql', preferGQL, {
+  valid: [
+    {
+      code: dedent`
+        import {gql} from '@shopify/hydrogen';
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+          import {gql} from 'graphql-tag';
+        `,
+      errors: [error()],
+    },
+    {
+      code: dedent`
+      import {gql} from 'graphql-tag';
+      `,
+      errors: [
+        error({
+          suggestion: dedent`
+            import {gql} from '@shopify/hydrogen';
+          `,
+        }),
+      ],
+    },
+    {
+      code: dedent`
+        import {Image} from '@shopify/hydrogen';
+        import {gql} from 'graphql-tag';
+      `,
+      errors: [
+        error({
+          suggestion: `import {Image, gql} from '@shopify/hydrogen';
+`,
+        }),
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/prefer-gql/tests/prefer-gql.test.ts
+++ b/packages/eslint-plugin/src/rules/prefer-gql/tests/prefer-gql.test.ts
@@ -12,21 +12,10 @@ const ruleTester = new TSESLint.RuleTester({
   },
 });
 
-function error(options: {suggestion?: string} = {}) {
-  const suggestions = options.suggestion
-    ? {
-        suggestions: [
-          {
-            output: options.suggestion,
-            messageId: 'replaceWithGQL' as const,
-          },
-        ],
-      }
-    : {};
+function error(options: {fix?: string} = {}) {
   return {
     type: AST_NODE_TYPES.ImportDeclaration,
     messageId: 'preferGQL' as const,
-    ...suggestions,
   };
 }
 
@@ -44,30 +33,27 @@ ruleTester.run('hydrogen/prefer-gql', preferGQL, {
           import {gql} from 'graphql-tag';
         `,
       errors: [error()],
+      output: dedent`
+        import {gql} from '@shopify/hydrogen';
+      `,
     },
     {
       code: dedent`
-      import {gql} from 'graphql-tag';
-      `,
-      errors: [
-        error({
-          suggestion: dedent`
-            import {gql} from '@shopify/hydrogen';
+          import {gql} from 'graphql-tag';
           `,
-        }),
-      ],
+      errors: [error()],
+      output: dedent`
+        import {gql} from '@shopify/hydrogen';
+      `,
     },
     {
       code: dedent`
-        import {Image} from '@shopify/hydrogen';
-        import {gql} from 'graphql-tag';
-      `,
-      errors: [
-        error({
-          suggestion: `import {Image, gql} from '@shopify/hydrogen';
+            import {Image} from '@shopify/hydrogen';
+            import {gql} from 'graphql-tag';
+          `,
+      errors: [error()],
+      output: `import {Image, gql} from '@shopify/hydrogen';
 `,
-        }),
-      ],
     },
   ],
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a new ESlint rule to help large projects migrate to us our new `gql` utility introduced in https://github.com/Shopify/hydrogen/pull/1332.

### Why add this?

Removing the `graphql-tag` library from being needlessly bundled will bring a performance bump across all Hydrogen projects (41KB according to @frandiox) . We want to the developer experience of migrating as great as possible. Using this rule, any project that updates to the latest `eslint-plugin-hydrogen` simply needs to run the `eslint` command in their project, and they should see something like this:

<img width="876" alt="Screenshot 2022-05-24 at 12 51 00" src="https://user-images.githubusercontent.com/462077/170018206-26e0e324-be9f-4a47-808e-bcab461e4953.png">

If they run it again with `--fix` they should see something like this in their git tree.

<img width="1512" alt="Screenshot 2022-05-24 at 12 52 39" src="https://user-images.githubusercontent.com/462077/170018538-c118db6f-7748-4fca-a05a-dedc9fdcebe5.png">

Where you can see that all instances of using the wrong `gql` utility have been fixed. Users can always disable this rule if this is not their desired outcome. 

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
