### PR TITLE
[Hydrogen]: Specify props as optional

### DIFF
--- a/docs/components/primitive/money.md
+++ b/docs/components/primitive/money.md
@@ -86,8 +86,8 @@ export default function Product() {
 | withoutCurrency? | <code>boolean</code> | Whether to remove the currency symbol from the output. |
 | withoutTrailingZeros? | <code>boolean</code> | Whether to remove trailing zeros (fractional money) from the output. If there are no trailing zeros, then the fractional money amount remains. For example, `$640.00` turns into `$640`. `$640.42` turns into `$640.42`. |
 | data | <code>PartialDeep&#60;MoneyV2&#62;</code> | An object with fields that correspond to the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/latest/objects/moneyv2). |
-| measurement | <code>PartialDeep&#60;UnitPriceMeasurement&#62;</code> | A [UnitPriceMeasurement object](https://shopify.dev/api/storefront/latest/objects/unitpricemeasurement). |
-| measurementSeparator | <code>ReactNode</code> | Customizes the separator between the money output and the measurement output. Used with the `measurement` prop. Defaults to `'/'`. |
+| measurement? | <code>PartialDeep&#60;UnitPriceMeasurement&#62;</code> | A [UnitPriceMeasurement object](https://shopify.dev/api/storefront/latest/objects/unitpricemeasurement). |
+| measurementSeparator? | <code>ReactNode</code> | Customizes the separator between the money output and the measurement output. Used with the `measurement` prop. Defaults to `'/'`. |
 
 
 ## Component type


### PR DESCRIPTION
## This PR: 
- Specifies the `measurement` and `measurementSeparator` props as optional for the `Money` component