### PR TITLE
Reduce amount of user app files downloaded

### DIFF
--- a/.changeset/honest-snakes-hug.md
+++ b/.changeset/honest-snakes-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Reduce the amount of user app files downloaded in the browser.

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
@@ -89,6 +89,7 @@ function _createForOfIteratorHelper(o, allowArrayLike) {
 }
 
 var rscViteFileRE = /\/react-server-dom-vite.js/;
+var noProxyRE = /[&?]no-proxy($|&)/;
 function ReactFlightVitePlugin() {
   var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
       _ref$isServerComponen = _ref.isServerComponentImporterAllowed,
@@ -157,7 +158,23 @@ function ReactFlightVitePlugin() {
     },
     load: function (id) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      return options.ssr && shouldCheckClientComponent(id) ? wrapIfClientComponent(id) : null;
+      if (!options.ssr || !shouldCheckClientComponent(id)) return;
+
+      if (server) {
+        var mod = server.moduleGraph.idToModuleMap.get(id.replace('/@fs', ''));
+
+        if (mod && mod.importers) {
+          if (Array.from(mod.importers).every(function (impMod) {
+            return noProxyRE.test(impMod.id);
+          })) {
+            // This module is only imported from client components
+            // so we don't need to create a module reference
+            return;
+          }
+        }
+      }
+
+      return wrapIfClientComponent(id);
     },
     transform: function (code, id) {
       var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -280,7 +297,7 @@ async function proxyClientComponent(filepath, src) {
 }
 
 function shouldCheckClientComponent(id) {
-  return /\.[jt]sx?($|\?)/.test(id) && !/[&?]no-proxy($|&)/.test(id);
+  return /\.[jt]sx?($|\?)/.test(id) && !noProxyRE.test(id);
 }
 
 function findClientComponentsForDev(server) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Related #954

This PR updates the RSC plugin to stop creating module references for client components that are only imported by other client components (not by server components). It basically moves the client boundary to the parent component. For example, `CartToggle.client.jsx` is now bundled inside `Header.client.jsx` instead of being in a different chunk because they are always used together.

For that, we check Vite's module graph to see the importer files. The problem is that we lose this information when a component is re-exported from an `index.ts` file. Therefore, this change is only really reducing chunks from the user app files, not from Hydrogen itself. However, it opens the door to make improvements in our Hydrogen components -- I'll try some refactoring in another PR.

The demo template goes from 47 client component chunks downloaded to 38.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
