### PR TITLE
Adds event handlers to Buttons and allows ref passing

### DIFF
--- a/.changeset/pink-seas-attack.md
+++ b/.changeset/pink-seas-attack.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add `onClick` and `buttonRef` props to `AddToCartButton`, `BuyNowButton` and `CartLineQuantityAdjustButton`

--- a/docs/components/cart/addtocartbutton.md
+++ b/docs/components/cart/addtocartbutton.md
@@ -47,16 +47,16 @@ export function MyComponent() {
 | quantity?                    | <code>number</code>                         | The item quantity.                                                                                                                                            |
 | children                     | <code>ReactNode</code>                      | Any ReactNode elements.                                                                                                                                       |
 | accessibleAddingToCartLabel? | <code>string</code>                         | The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. |
-| onClick?                     | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | Click event handler. Default behaviour triggers unless prevented. |
-| buttonRef?                   | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>                | A ref to the underlying button. |
+| onClick?                     | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
+| buttonRef?                   | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>                | A reference to the underlying button. |
 
 ## Component type
 
 The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
 
-## Example code. Override `onClick` default behaviour
 
 ```tsx
+// Override `onClick` default behavior
 import {
   CartProvider,
   CartUIProvider,
@@ -91,9 +91,9 @@ export function MyComponent() {
 }
 ```
 
-## Example code. Run async action before default `onClick` behaviour
 
 ```tsx
+// Run an async action before the default `onClick` behaviour
 import {
   CartProvider,
   CartUIProvider,

--- a/docs/components/cart/addtocartbutton.md
+++ b/docs/components/cart/addtocartbutton.md
@@ -47,7 +47,99 @@ export function MyComponent() {
 | quantity?                    | <code>number</code>                         | The item quantity.                                                                                                                                            |
 | children                     | <code>ReactNode</code>                      | Any ReactNode elements.                                                                                                                                       |
 | accessibleAddingToCartLabel? | <code>string</code>                         | The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. |
+| onClick?                     | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | Click event handler. Default behaviour triggers unless prevented. |
+| buttonRef?                   | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>                | A ref to the underlying button. |
 
 ## Component type
 
 The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
+
+## Example code. Override `onClick` default behaviour
+
+```tsx
+import {
+  CartProvider,
+  CartUIProvider,
+  CartContainer,
+  AddToCartButton,
+} from '@shopify/hydrogen';
+
+export function MyComponent() {
+  // ...
+
+  const handleCustomOnClick = (event) => {
+    event.preventDefault(); // prevents button from triggering default behaviour
+    // custom click handler code
+  }
+
+  return (
+    <CartProvider>
+      <CartUIProvider>
+        <AddToCartButton
+          variantId="1234"
+          quantity={1}
+          attributes={[{key: 'Engraving', value: 'Hello world'}]}
+          accessibleAddingToCartLabel="Adding item to your cart"
+          onClick={handleCustomOnClick}
+        >
+          Add to Cart
+        </AddToCartButton>
+        <CartContainer>{/* Your cart container JSX */}</CartContainer>
+      </CartUIProvider>
+    </CartProvider>
+  );
+}
+```
+
+## Example code. Run async action before default `onClick` behaviour
+
+```tsx
+import {
+  CartProvider,
+  CartUIProvider,
+  CartContainer,
+  AddToCartButton,
+} from '@shopify/hydrogen';
+
+export function MyComponent() {
+  // ...
+  const performed = useRef();
+  const buttonRef = useRef();
+
+  const handleCustomOnClick = async (event) => {
+    if (performed.current) {
+      performed.current = false;
+      return;
+    }
+
+    event.preventDefault(); // stop default behaviour
+    console.log(`Performing custom action...`);
+    await new Promise((r) => setTimeout(r, 500));
+    console.log(`Custom action complete!`);
+
+    performed.current = true; // prevents retriggering
+    buttonRef.current.click(); // trigger button default behaviour
+  }
+
+  return (
+    <CartProvider>
+      <CartUIProvider>
+        <AddToCartButton
+          variantId="1234"
+          quantity={1}
+          attributes={[{key: 'Engraving', value: 'Hello world'}]}
+          accessibleAddingToCartLabel="Adding item to your cart"
+          onClick={handleCustomOnClick}
+          buttonRef={buttonRef}
+        >
+          Add to Cart
+        </AddToCartButton>
+        <CartContainer>{/* Your cart container JSX */}</CartContainer>
+      </CartUIProvider>
+    </CartProvider>
+  );
+}
+```
+
+
+

--- a/docs/components/cart/addtocartbutton.md
+++ b/docs/components/cart/addtocartbutton.md
@@ -38,23 +38,6 @@ export function MyComponent() {
 }
 ```
 
-## Props
-
-| Name                         | Type                                        | Description                                                                                                                                                   |
-| ---------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| attributes?                  | <code>Object<<wbr>key, value<wbr>>[]</code> | An array of cart line attributes that belong to the item being added to the cart.                                                                             |
-| variantId?                   | <code>string &#124; null</code>             | The ID of the variant.                                                                                                                                        |
-| quantity?                    | <code>number</code>                         | The item quantity.                                                                                                                                            |
-| children                     | <code>ReactNode</code>                      | Any ReactNode elements.                                                                                                                                       |
-| accessibleAddingToCartLabel? | <code>string</code>                         | The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. |
-| onClick?                     | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
-| buttonRef?                   | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>                | A reference to the underlying button. |
-
-## Component type
-
-The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
-
-
 ```tsx
 // Override `onClick` default behavior
 import {
@@ -141,5 +124,18 @@ export function MyComponent() {
 }
 ```
 
+## Props
 
+| Name                         | Type                                        | Description                                                                                                                                                   |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| attributes?                  | <code>Object<<wbr>key, value<wbr>>[]</code> | An array of cart line attributes that belong to the item being added to the cart.                                                                             |
+| variantId?                   | <code>string &#124; null</code>             | The ID of the variant.                                                                                                                                        |
+| quantity?                    | <code>number</code>                         | The item quantity.                                                                                                                                            |
+| children                     | <code>ReactNode</code>                      | Any ReactNode elements.                                                                                                                                       |
+| accessibleAddingToCartLabel? | <code>string</code>                         | The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. |
+| onClick?                     | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
+| buttonRef?                   | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>                | A reference to the underlying button. |
 
+## Component type
+
+The `AddToCartButton` component is a client component, which means that it renders on the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).

--- a/docs/components/cart/buynowbutton.md
+++ b/docs/components/cart/buynowbutton.md
@@ -20,28 +20,12 @@ export function MyComponent() {
 }
 ```
 
-## Props
-
-| Name        | Type                                            | Description                                                                       |
-| ----------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| quantity?   | <code>number</code>                             | The item quantity. Defaults to 1.                                                 |
-| variantId   | <code>string</code>                             | The ID of the variant.                                                            |
-| attributes? | <code>Object<<wbr>string, string<wbr>>[]</code> | An array of cart line attributes that belong to the item being added to the cart. |
-| children    | <code>ReactNode<<wbr>Imported<wbr>></code>      | Any `ReactNode` elements.                                                         |
-| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
-| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A reference to the underlying button. |
-
-## Component type
-
-The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
-
-
 ```tsx
 // Override `onClick` default behavior
 import {BuyNowButton} from '@shopify/hydrogen';
 
 export function MyComponent() {
-  
+
   const handleCustomOnClick = (event) => {
     event.preventDefault(); // prevents button from triggering default behaviour
     // custom click handler code
@@ -63,7 +47,7 @@ import {BuyNowButton} from '@shopify/hydrogen';
 export function MyComponent() {
   const performed = useRef();
   const buttonRef = useRef();
-  
+
   const handleCustomOnClick = async (event) => {
     if (performed.current) {
       performed.current = false;
@@ -80,7 +64,7 @@ export function MyComponent() {
   }
 
   return (
-    <BuyNowButton 
+    <BuyNowButton
       quantity={1}
       variantId={'123'}
       onClick={handleCustomOnClick}
@@ -90,3 +74,18 @@ export function MyComponent() {
   );
 }
 ```
+
+## Props
+
+| Name        | Type                                            | Description                                                                       |
+| ----------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| quantity?   | <code>number</code>                             | The item quantity. Defaults to 1.                                                 |
+| variantId   | <code>string</code>                             | The ID of the variant.                                                            |
+| attributes? | <code>Object<<wbr>string, string<wbr>>[]</code> | An array of cart line attributes that belong to the item being added to the cart. |
+| children    | <code>ReactNode<<wbr>Imported<wbr>></code>      | Any `ReactNode` elements.                                                         |
+| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
+| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A reference to the underlying button. |
+
+## Component type
+
+The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).

--- a/docs/components/cart/buynowbutton.md
+++ b/docs/components/cart/buynowbutton.md
@@ -28,16 +28,16 @@ export function MyComponent() {
 | variantId   | <code>string</code>                             | The ID of the variant.                                                            |
 | attributes? | <code>Object<<wbr>string, string<wbr>>[]</code> | An array of cart line attributes that belong to the item being added to the cart. |
 | children    | <code>ReactNode<<wbr>Imported<wbr>></code>      | Any `ReactNode` elements.                                                         |
-| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | Click event handler. Default behaviour triggers unless prevented. |
-| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A ref to the underlying button. |
+| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
+| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A reference to the underlying button. |
 
 ## Component type
 
 The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
 
-## Example code. Override `onClick` default behaviour
 
 ```tsx
+// Override `onClick` default behavior
 import {BuyNowButton} from '@shopify/hydrogen';
 
 export function MyComponent() {
@@ -55,9 +55,9 @@ export function MyComponent() {
 }
 ```
 
-## Example code. Run async action before default `onClick` behaviour
 
 ```tsx
+// Run an async action before the default `onClick` behaviour
 import {BuyNowButton} from '@shopify/hydrogen';
 
 export function MyComponent() {

--- a/docs/components/cart/buynowbutton.md
+++ b/docs/components/cart/buynowbutton.md
@@ -28,7 +28,65 @@ export function MyComponent() {
 | variantId   | <code>string</code>                             | The ID of the variant.                                                            |
 | attributes? | <code>Object<<wbr>string, string<wbr>>[]</code> | An array of cart line attributes that belong to the item being added to the cart. |
 | children    | <code>ReactNode<<wbr>Imported<wbr>></code>      | Any `ReactNode` elements.                                                         |
+| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | Click event handler. Default behaviour triggers unless prevented. |
+| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A ref to the underlying button. |
 
 ## Component type
 
 The `BuyNowButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
+
+## Example code. Override `onClick` default behaviour
+
+```tsx
+import {BuyNowButton} from '@shopify/hydrogen';
+
+export function MyComponent() {
+  
+  const handleCustomOnClick = (event) => {
+    event.preventDefault(); // prevents button from triggering default behaviour
+    // custom click handler code
+  }
+
+  return (
+    <BuyNowButton quantity={1} variantId={'123'} onClick={handleCustomOnClick}>
+      Buy it now
+    </BuyNowButton>
+  );
+}
+```
+
+## Example code. Run async action before default `onClick` behaviour
+
+```tsx
+import {BuyNowButton} from '@shopify/hydrogen';
+
+export function MyComponent() {
+  const performed = useRef();
+  const buttonRef = useRef();
+  
+  const handleCustomOnClick = async (event) => {
+    if (performed.current) {
+      performed.current = false;
+      return;
+    }
+
+    event.preventDefault(); // stop default behaviour
+    console.log(`Performing custom action...`);
+    await new Promise((r) => setTimeout(r, 500));
+    console.log(`Custom action complete!`);
+
+    performed.current = true; // prevents retriggering
+    buttonRef.current.click(); // trigger button default behaviour
+  }
+
+  return (
+    <BuyNowButton 
+      quantity={1}
+      variantId={'123'}
+      onClick={handleCustomOnClick}
+      buttonRef={buttonRef}>
+      Buy it now
+    </BuyNowButton>
+  );
+}
+```

--- a/docs/components/cart/cartlinequantityadjustbutton.md
+++ b/docs/components/cart/cartlinequantityadjustbutton.md
@@ -37,24 +37,6 @@ export function App() {
 }
 ```
 
-## Props
-
-| Name     | Type                                                      | Description                                                                                             |
-| -------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| adjust   | <code>"increase" &#124; "decrease" &#124; "remove"</code> | The adjustment for a cart line's quantity. Valid values: `increase` (default), `decrease`, or `remove`. |
-| children | <code>ReactNode</code>                                    | Any `ReactNode` elements.                                                                               |
-| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
-| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A reference to the underlying button. |
-
-## Component type
-
-The `CartLineQuantityAdjustButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
-
-## Related components
-
-- [`CartLineProvider`](https://shopify.dev/api/hydrogen/components/cart/cartlineprovider)
-
-
 ```tsx
 // Override `onClick` default behaviour
 import {
@@ -83,7 +65,6 @@ export function App() {
 }
 ```
 
-
 ```tsx
 // Run an async action before the default `onClick` behaviour
 import {
@@ -96,7 +77,7 @@ export function App() {
   const {lines} = useCart();
   const performed = useRef();
   const buttonRef = useRef();
-  
+
   const handleCustomOnClick = async (event) => {
     if (performed.current) {
       performed.current = false;
@@ -115,7 +96,7 @@ export function App() {
   return lines.map((line) => {
     return (
       <CartLineProvider key={line.id} line={line}>
-        <CartLineQuantityAdjustButton 
+        <CartLineQuantityAdjustButton
           adjust="increase"
           onClick={handleCustomOnClick}
           buttonRef={buttonRef}>
@@ -126,3 +107,20 @@ export function App() {
   });
 }
 ```
+
+## Props
+
+| Name     | Type                                                      | Description                                                                                             |
+| -------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| adjust   | <code>"increase" &#124; "decrease" &#124; "remove"</code> | The adjustment for a cart line's quantity. Valid values: `increase` (default), `decrease`, or `remove`. |
+| children | <code>ReactNode</code>                                    | Any `ReactNode` elements.                                                                               |
+| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
+| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A reference to the underlying button. |
+
+## Component type
+
+The `CartLineQuantityAdjustButton` component is a shared component, which means that it renders on both the server and the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components).
+
+## Related components
+
+- [`CartLineProvider`](https://shopify.dev/api/hydrogen/components/cart/cartlineprovider)

--- a/docs/components/cart/cartlinequantityadjustbutton.md
+++ b/docs/components/cart/cartlinequantityadjustbutton.md
@@ -43,6 +43,8 @@ export function App() {
 | -------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | adjust   | <code>"increase" &#124; "decrease" &#124; "remove"</code> | The adjustment for a cart line's quantity. Valid values: `increase` (default), `decrease`, or `remove`. |
 | children | <code>ReactNode</code>                                    | Any `ReactNode` elements.                                                                               |
+| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | Click event handler. Default behaviour triggers unless prevented. |
+| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A ref to the underlying button. |
 
 ## Component type
 
@@ -51,3 +53,76 @@ The `CartLineQuantityAdjustButton` component is a shared component, which means 
 ## Related components
 
 - [`CartLineProvider`](https://shopify.dev/api/hydrogen/components/cart/cartlineprovider)
+
+## Example code. Override `onClick` default behaviour
+
+```tsx
+import {
+  CartLineProvider,
+  useCart,
+  CartLineQuantityAdjustButton,
+} from '@shopify/hydrogen';
+
+export function App() {
+  const {lines} = useCart();
+
+  const handleCustomOnClick = (event) => {
+    event.preventDefault(); // prevents button from triggering default behaviour
+    // custom click handler code
+  }
+
+  return lines.map((line) => {
+    return (
+      <CartLineProvider key={line.id} line={line}>
+        <CartLineQuantityAdjustButton adjust="increase" onClick={handleCustomOnClick}>
+          Increase quantity
+        </CartLineQuantityAdjustButton>
+      </CartLineProvider>
+    );
+  });
+}
+```
+
+## Example code. Run async action before default `onClick` behaviour
+
+```tsx
+import {
+  CartLineProvider,
+  useCart,
+  CartLineQuantityAdjustButton,
+} from '@shopify/hydrogen';
+
+export function App() {
+  const {lines} = useCart();
+  const performed = useRef();
+  const buttonRef = useRef();
+  
+  const handleCustomOnClick = async (event) => {
+    if (performed.current) {
+      performed.current = false;
+      return;
+    }
+
+    event.preventDefault(); // stop default behaviour
+    console.log(`Performing custom action...`);
+    await new Promise((r) => setTimeout(r, 500));
+    console.log(`Custom action complete!`);
+
+    performed.current = true; // prevents retriggering
+    buttonRef.current.click(); // trigger button default behaviour
+  }
+
+  return lines.map((line) => {
+    return (
+      <CartLineProvider key={line.id} line={line}>
+        <CartLineQuantityAdjustButton 
+          adjust="increase"
+          onClick={handleCustomOnClick}
+          buttonRef={buttonRef}>
+          Increase quantity
+        </CartLineQuantityAdjustButton>
+      </CartLineProvider>
+    );
+  });
+}
+```

--- a/docs/components/cart/cartlinequantityadjustbutton.md
+++ b/docs/components/cart/cartlinequantityadjustbutton.md
@@ -43,8 +43,8 @@ export function App() {
 | -------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | adjust   | <code>"increase" &#124; "decrease" &#124; "remove"</code> | The adjustment for a cart line's quantity. Valid values: `increase` (default), `decrease`, or `remove`. |
 | children | <code>ReactNode</code>                                    | Any `ReactNode` elements.                                                                               |
-| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | Click event handler. Default behaviour triggers unless prevented. |
-| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A ref to the underlying button. |
+| onClick?    | <code>(event?: React.MouseEvent<<wbr>HTMLButtonElement, MouseEvent<wbr>>) => void &#124; boolean;</code> | A click event handler. Default behaviour triggers the click event, unless prevented. |
+| buttonRef?  | <code>Ref<<wbr>HTMLButtonElement<wbr>> </code>  | A reference to the underlying button. |
 
 ## Component type
 
@@ -54,9 +54,9 @@ The `CartLineQuantityAdjustButton` component is a shared component, which means 
 
 - [`CartLineProvider`](https://shopify.dev/api/hydrogen/components/cart/cartlineprovider)
 
-## Example code. Override `onClick` default behaviour
 
 ```tsx
+// Override `onClick` default behaviour
 import {
   CartLineProvider,
   useCart,
@@ -83,9 +83,9 @@ export function App() {
 }
 ```
 
-## Example code. Run async action before default `onClick` behaviour
 
 ```tsx
+// Run an async action before the default `onClick` behaviour
 import {
   CartLineProvider,
   useCart,

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -1,6 +1,7 @@
-import React, {ReactNode, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {useCart} from '../CartProvider';
 import {useProductOptions} from '../ProductOptionsProvider';
+import {BaseButton, BaseButtonProps} from '../BaseButton';
 
 interface AddToCartButtonProps {
   /** An array of cart line attributes that belong to the item being added to the cart. */
@@ -12,27 +13,21 @@ interface AddToCartButtonProps {
   variantId?: string | null;
   /** The item quantity. */
   quantity?: number;
-  /** Any ReactNode elements. */
-  children: ReactNode;
   /** The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. */
   accessibleAddingToCartLabel?: string;
 }
-
-type PropsWeControl = 'onClick';
 
 /**
  * The `AddToCartButton` component renders a button that adds an item to the cart when pressed.
  * It must be a descendent of the `CartProvider` component.
  */
-export function AddToCartButton(
-  props: Omit<JSX.IntrinsicElements['button'], PropsWeControl> &
-    AddToCartButtonProps
-) {
+export function AddToCartButton(props: AddToCartButtonProps & BaseButtonProps) {
   const [addingItem, setAddingItem] = useState<boolean>(false);
   const {
     variantId: explicitVariantId,
     quantity = 1,
     attributes,
+    onClick,
     children,
     accessibleAddingToCartLabel,
     ...passthroughProps
@@ -53,24 +48,27 @@ export function AddToCartButton(
     }
   }, [status, addingItem]);
 
+  const handleAddItem = useCallback(() => {
+    setAddingItem(true);
+    linesAdd([
+      {
+        quantity,
+        merchandiseId: variantId,
+        attributes,
+      },
+    ]);
+  }, [linesAdd, quantity, variantId, attributes]);
+
   return (
     <>
-      <button
+      <BaseButton
         {...passthroughProps}
         disabled={disabled}
-        onClick={() => {
-          setAddingItem(true);
-          linesAdd([
-            {
-              quantity,
-              merchandiseId: variantId,
-              attributes,
-            },
-          ]);
-        }}
+        onClick={onClick}
+        defaultOnClick={handleAddItem}
       >
         {children}
-      </button>
+      </BaseButton>
       {accessibleAddingToCartLabel ? (
         <p
           style={{

--- a/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/tests/AddToCart.test.tsx
@@ -6,6 +6,7 @@ import {mountWithCartProvider} from '../../CartProvider/tests/utilities';
 import {ProductOptionsProvider} from '../../ProductOptionsProvider';
 import {AddToCartButton} from '../AddToCartButton.client';
 import {getProduct, getVariant} from '../../../utilities/tests/product';
+import {BaseButton} from '../../BaseButton';
 
 describe('AddToCartButton', () => {
   beforeEach(() => {
@@ -208,6 +209,42 @@ describe('AddToCartButton', () => {
 
       expect(component).toContainReactComponent('p', {
         children: 'Adding product to your cart',
+      });
+    });
+  });
+
+  describe('BaseButton', () => {
+    it('passes the onClick handler', () => {
+      const product = getProduct();
+      const mockOnClick = jest.fn();
+
+      const component = mountWithProviders(
+        <CartProvider>
+          <ProductOptionsProvider data={product}>
+            <AddToCartButton onClick={mockOnClick}>Add to cart</AddToCartButton>
+          </ProductOptionsProvider>
+        </CartProvider>
+      );
+
+      expect(component).toContainReactComponent(BaseButton, {
+        onClick: mockOnClick,
+      });
+    });
+
+    it('passes the buttonRef', () => {
+      const product = getProduct();
+      const mockRef = React.createRef<HTMLButtonElement>();
+
+      const component = mountWithProviders(
+        <CartProvider>
+          <ProductOptionsProvider data={product}>
+            <AddToCartButton buttonRef={mockRef}>Add to cart</AddToCartButton>
+          </ProductOptionsProvider>
+        </CartProvider>
+      );
+
+      expect(component).toContainReactComponent(BaseButton, {
+        buttonRef: mockRef,
       });
     });
   });

--- a/packages/hydrogen/src/components/BaseButton/BaseButton.client.tsx
+++ b/packages/hydrogen/src/components/BaseButton/BaseButton.client.tsx
@@ -1,19 +1,26 @@
-import React, {MouseEvent, ReactNode, Ref} from 'react';
+import React, {ReactNode, Ref} from 'react';
 import {useCallback} from 'react';
 
 interface Props {
   /** Any ReactNode elements. */
   children: ReactNode;
-  /** A click event handler. Default behaviour triggers unless prevented */
-  onClick?: (event?: MouseEvent) => void | boolean;
+  /** Click event handler. Default behaviour triggers unless prevented */
+  onClick?: (
+    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | boolean;
   /** A default onClick behaviour */
-  defaultOnClick?: Function;
+  defaultOnClick?: (
+    event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | boolean;
   /** A ref to the underlying button */
   buttonRef?: Ref<HTMLButtonElement>;
-  /** Any ReactNode elements. */
 }
 
-export type BaseButtonProps = JSX.IntrinsicElements['button'] & Props;
+export type BaseButtonProps = Omit<
+  JSX.IntrinsicElements['button'],
+  'onClick' | 'children'
+> &
+  Props;
 
 export function BaseButton({
   onClick,
@@ -23,13 +30,18 @@ export function BaseButton({
   ...passthroughProps
 }: BaseButtonProps) {
   const handleOnClick = useCallback(
-    (event: MouseEvent) => {
+    (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       if (onClick) {
         const clickShouldContinue = onClick(event);
-        if (clickShouldContinue === false || event?.defaultPrevented) return;
+        if (
+          (typeof clickShouldContinue === 'boolean' &&
+            clickShouldContinue === false) ||
+          event?.defaultPrevented
+        )
+          return;
       }
 
-      defaultOnClick?.();
+      defaultOnClick?.(event);
     },
     [defaultOnClick, onClick]
   );

--- a/packages/hydrogen/src/components/BaseButton/BaseButton.client.tsx
+++ b/packages/hydrogen/src/components/BaseButton/BaseButton.client.tsx
@@ -1,0 +1,42 @@
+import React, {MouseEvent, ReactNode, Ref} from 'react';
+import {useCallback} from 'react';
+
+interface Props {
+  /** Any ReactNode elements. */
+  children: ReactNode;
+  /** A click event handler. Default behaviour triggers unless prevented */
+  onClick?: (event?: MouseEvent) => void | boolean;
+  /** A default onClick behaviour */
+  defaultOnClick?: Function;
+  /** A ref to the underlying button */
+  buttonRef?: Ref<HTMLButtonElement>;
+  /** Any ReactNode elements. */
+}
+
+export type BaseButtonProps = JSX.IntrinsicElements['button'] & Props;
+
+export function BaseButton({
+  onClick,
+  defaultOnClick,
+  children,
+  buttonRef,
+  ...passthroughProps
+}: BaseButtonProps) {
+  const handleOnClick = useCallback(
+    (event: MouseEvent) => {
+      if (onClick) {
+        const clickShouldContinue = onClick(event);
+        if (clickShouldContinue === false || event?.defaultPrevented) return;
+      }
+
+      defaultOnClick?.();
+    },
+    [defaultOnClick, onClick]
+  );
+
+  return (
+    <button {...passthroughProps} ref={buttonRef} onClick={handleOnClick}>
+      {children}
+    </button>
+  );
+}

--- a/packages/hydrogen/src/components/BaseButton/index.ts
+++ b/packages/hydrogen/src/components/BaseButton/index.ts
@@ -1,0 +1,1 @@
+export {BaseButton, BaseButtonProps} from './BaseButton.client';

--- a/packages/hydrogen/src/components/BaseButton/tests/BaseButton.test.tsx
+++ b/packages/hydrogen/src/components/BaseButton/tests/BaseButton.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
+import {BaseButton} from '../BaseButton.client';
+
+describe('BaseButton', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a button', () => {
+    const component = mountWithProviders(<BaseButton>Base Button</BaseButton>);
+
+    expect(component).toContainReactComponent('button', {
+      children: 'Base Button',
+    });
+  });
+
+  it('allows passthrough props', () => {
+    const component = mountWithProviders(
+      <BaseButton className="bg-blue-600">Base Button</BaseButton>
+    );
+
+    expect(component.find('button')).toHaveReactProps({
+      className: 'bg-blue-600',
+    });
+  });
+
+  describe('given an on click event handler', () => {
+    it('calls the on click event handler', () => {
+      const mockOnClick = jest.fn();
+      const component = mountWithProviders(
+        <BaseButton onClick={mockOnClick}>Base Button</BaseButton>
+      );
+
+      component.find('button')?.trigger('onClick');
+
+      expect(mockOnClick).toBeCalled();
+    });
+
+    it('calls the given default on click behaviour', () => {
+      const mockDefaultOnClick = jest.fn();
+      const component = mountWithProviders(
+        <BaseButton onClick={() => {}} defaultOnClick={mockDefaultOnClick}>
+          Base Button
+        </BaseButton>
+      );
+
+      component.find('button')?.trigger('onClick');
+
+      expect(mockDefaultOnClick).toBeCalled();
+    });
+
+    describe('and event preventDefault is called', () => {
+      it('calls the on click event handler without calling the default on click behaviour', () => {
+        const mockOnClick = jest.fn((event) => {
+          event.preventDefault();
+        });
+        const mockDefaultOnClick = jest.fn();
+        const component = mountWithProviders(
+          <BaseButton onClick={mockOnClick} defaultOnClick={mockDefaultOnClick}>
+            Base Button
+          </BaseButton>
+        );
+
+        component
+          .find('button')
+          ?.trigger('onClick', new MouseEvent('click', {cancelable: true}));
+
+        expect(mockOnClick).toBeCalled();
+        expect(mockDefaultOnClick).not.toBeCalled();
+      });
+    });
+
+    describe('and the on click handler returns false', () => {
+      it('calls the on click event handler without calling the default on click behaviour', () => {
+        const mockOnClick = jest.fn(() => false);
+        const mockDefaultOnClick = jest.fn();
+        const component = mountWithProviders(
+          <BaseButton onClick={mockOnClick} defaultOnClick={mockDefaultOnClick}>
+            Base Button
+          </BaseButton>
+        );
+
+        component.find('button')?.trigger('onClick');
+
+        expect(mockOnClick).toBeCalled();
+        expect(mockDefaultOnClick).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/packages/hydrogen/src/components/BaseButton/tests/BaseButton.test.tsx
+++ b/packages/hydrogen/src/components/BaseButton/tests/BaseButton.test.tsx
@@ -28,26 +28,30 @@ describe('BaseButton', () => {
   describe('given an on click event handler', () => {
     it('calls the on click event handler', () => {
       const mockOnClick = jest.fn();
+      const mouseEvent = new MouseEvent('click', {cancelable: true});
+
       const component = mountWithProviders(
         <BaseButton onClick={mockOnClick}>Base Button</BaseButton>
       );
 
-      component.find('button')?.trigger('onClick');
+      component.find('button')?.trigger('onClick', mouseEvent);
 
-      expect(mockOnClick).toBeCalled();
+      expect(mockOnClick).toBeCalledWith(mouseEvent);
     });
 
     it('calls the given default on click behaviour', () => {
       const mockDefaultOnClick = jest.fn();
+      const mouseEvent = new MouseEvent('click', {cancelable: true});
+
       const component = mountWithProviders(
         <BaseButton onClick={() => {}} defaultOnClick={mockDefaultOnClick}>
           Base Button
         </BaseButton>
       );
 
-      component.find('button')?.trigger('onClick');
+      component.find('button')?.trigger('onClick', mouseEvent);
 
-      expect(mockDefaultOnClick).toBeCalled();
+      expect(mockDefaultOnClick).toBeCalledWith(mouseEvent);
     });
 
     describe('and event preventDefault is called', () => {
@@ -56,17 +60,17 @@ describe('BaseButton', () => {
           event.preventDefault();
         });
         const mockDefaultOnClick = jest.fn();
+        const mouseEvent = new MouseEvent('click', {cancelable: true});
+
         const component = mountWithProviders(
           <BaseButton onClick={mockOnClick} defaultOnClick={mockDefaultOnClick}>
             Base Button
           </BaseButton>
         );
 
-        component
-          .find('button')
-          ?.trigger('onClick', new MouseEvent('click', {cancelable: true}));
+        component.find('button')?.trigger('onClick', mouseEvent);
 
-        expect(mockOnClick).toBeCalled();
+        expect(mockOnClick).toHaveBeenCalledWith(mouseEvent);
         expect(mockDefaultOnClick).not.toBeCalled();
       });
     });
@@ -75,15 +79,17 @@ describe('BaseButton', () => {
       it('calls the on click event handler without calling the default on click behaviour', () => {
         const mockOnClick = jest.fn(() => false);
         const mockDefaultOnClick = jest.fn();
+        const mouseEvent = new MouseEvent('click', {cancelable: true});
+
         const component = mountWithProviders(
           <BaseButton onClick={mockOnClick} defaultOnClick={mockDefaultOnClick}>
             Base Button
           </BaseButton>
         );
 
-        component.find('button')?.trigger('onClick');
+        component.find('button')?.trigger('onClick', mouseEvent);
 
-        expect(mockOnClick).toBeCalled();
+        expect(mockOnClick).toBeCalledWith(mouseEvent);
         expect(mockDefaultOnClick).not.toBeCalled();
       });
     });

--- a/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
+++ b/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useCallback, MouseEvent} from 'react';
+import React, {useEffect, useState, useCallback} from 'react';
 import {useInstantCheckout} from '../CartProvider';
 import {BaseButton, BaseButtonProps} from '../BaseButton';
 
@@ -34,25 +34,18 @@ export function BuyNowButton(props: BuyNowButtonProps & BaseButtonProps) {
     }
   }, [checkoutUrl]);
 
-  const handleBuyNow = useCallback(
-    (event?: MouseEvent) => {
-      if (onClick) {
-        const clickShouldContinue = onClick(event);
-        if (clickShouldContinue === false || event?.defaultPrevented) return;
-      }
-      setLoading(true);
-      createInstantCheckout({
-        lines: [
-          {
-            quantity: quantity ?? 1,
-            merchandiseId: variantId,
-            attributes,
-          },
-        ],
-      });
-    },
-    [onClick, createInstantCheckout, quantity, variantId, attributes]
-  );
+  const handleBuyNow = useCallback(() => {
+    setLoading(true);
+    createInstantCheckout({
+      lines: [
+        {
+          quantity: quantity ?? 1,
+          merchandiseId: variantId,
+          attributes,
+        },
+      ],
+    });
+  }, [createInstantCheckout, quantity, variantId, attributes]);
 
   return (
     <BaseButton

--- a/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
+++ b/packages/hydrogen/src/components/BuyNowButton/BuyNowButton.client.tsx
@@ -1,6 +1,6 @@
-import React, {useEffect, useState, useCallback} from 'react';
-import type {ReactNode} from 'react';
+import React, {useEffect, useState, useCallback, MouseEvent} from 'react';
 import {useInstantCheckout} from '../CartProvider';
+import {BaseButton, BaseButtonProps} from '../BaseButton';
 
 interface BuyNowButtonProps {
   /** The item quantity. Defaults to 1. */
@@ -12,22 +12,21 @@ interface BuyNowButtonProps {
     key: string;
     value: string;
   }[];
-  /** Any `ReactNode` elements. */
-  children: ReactNode;
 }
 
-type PropsWeControl = 'onClick';
-
 /** The `BuyNowButton` component renders a button that adds an item to the cart and redirects the customer to checkout. */
-export function BuyNowButton(
-  props: Omit<JSX.IntrinsicElements['button'], PropsWeControl> &
-    BuyNowButtonProps
-) {
+export function BuyNowButton(props: BuyNowButtonProps & BaseButtonProps) {
   const {createInstantCheckout, checkoutUrl} = useInstantCheckout();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const {quantity, variantId, attributes, children, ...passthroughProps} =
-    props;
+  const {
+    quantity,
+    variantId,
+    onClick,
+    attributes,
+    children,
+    ...passthroughProps
+  } = props;
 
   useEffect(() => {
     if (checkoutUrl) {
@@ -35,26 +34,34 @@ export function BuyNowButton(
     }
   }, [checkoutUrl]);
 
-  const handleBuyNow = useCallback(() => {
-    setLoading(true);
-    createInstantCheckout({
-      lines: [
-        {
-          quantity: quantity ?? 1,
-          merchandiseId: variantId,
-          attributes,
-        },
-      ],
-    });
-  }, [setLoading, createInstantCheckout, quantity, variantId, attributes]);
+  const handleBuyNow = useCallback(
+    (event?: MouseEvent) => {
+      if (onClick) {
+        const clickShouldContinue = onClick(event);
+        if (clickShouldContinue === false || event?.defaultPrevented) return;
+      }
+      setLoading(true);
+      createInstantCheckout({
+        lines: [
+          {
+            quantity: quantity ?? 1,
+            merchandiseId: variantId,
+            attributes,
+          },
+        ],
+      });
+    },
+    [onClick, createInstantCheckout, quantity, variantId, attributes]
+  );
 
   return (
-    <button
+    <BaseButton
       disabled={loading ?? passthroughProps.disabled}
       {...passthroughProps}
-      onClick={handleBuyNow}
+      onClick={onClick}
+      defaultOnClick={handleBuyNow}
     >
       {children}
-    </button>
+    </BaseButton>
   );
 }

--- a/packages/hydrogen/src/components/BuyNowButton/tests/BuyNowButton.test.tsx
+++ b/packages/hydrogen/src/components/BuyNowButton/tests/BuyNowButton.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
+import {BaseButton} from '../../BaseButton';
 
 const mockCreateInstantCheckout = jest.fn();
 const mockUseInstantCheckout = jest.fn();
@@ -28,17 +29,17 @@ describe('BuyNowButton', () => {
 
   it('renders a button', () => {
     const component = mountWithProviders(
-      <BuyNowButton variantId="1">Add to Cart</BuyNowButton>
+      <BuyNowButton variantId="1">Buy now</BuyNowButton>
     );
     expect(component).toContainReactComponent('button', {
-      children: 'Add to Cart',
+      children: 'Buy now',
     });
   });
 
   it('can optionally disable the button', () => {
     const component = mountWithProviders(
       <BuyNowButton disabled={true} variantId="1">
-        Add to Cart
+        Buy now
       </BuyNowButton>
     );
 
@@ -50,7 +51,7 @@ describe('BuyNowButton', () => {
   it('allows pass-through props', () => {
     const component = mountWithProviders(
       <BuyNowButton className="fancy-button" variantId="1">
-        Add to Cart
+        Buy now
       </BuyNowButton>
     );
 
@@ -70,7 +71,7 @@ describe('BuyNowButton', () => {
           quantity={4}
           variantId="SKU123"
         >
-          Add to Cart
+          Buy now
         </BuyNowButton>
       );
 
@@ -95,7 +96,7 @@ describe('BuyNowButton', () => {
 
     it('disables the button', () => {
       const component = mountWithProviders(
-        <BuyNowButton variantId="1">Add to Cart</BuyNowButton>
+        <BuyNowButton variantId="1">Buy now</BuyNowButton>
       );
 
       expect(component).toContainReactComponent('button', {
@@ -133,12 +134,40 @@ describe('BuyNowButton', () => {
     });
 
     it('redirects to checkout', () => {
-      mountWithProviders(
-        <BuyNowButton variantId="1">Add to Cart</BuyNowButton>
-      );
+      mountWithProviders(<BuyNowButton variantId="1">Buy now</BuyNowButton>);
 
       expect(mockSetHref).toHaveBeenCalledTimes(1);
       expect(mockSetHref).toHaveBeenCalledWith('/checkout?id=123');
+    });
+  });
+
+  describe('BaseButton', () => {
+    it('passes the onClick handler', () => {
+      const mockOnClick = jest.fn();
+
+      const component = mountWithProviders(
+        <BuyNowButton variantId="1" onClick={mockOnClick}>
+          Buy now
+        </BuyNowButton>
+      );
+
+      expect(component).toContainReactComponent(BaseButton, {
+        onClick: mockOnClick,
+      });
+    });
+
+    it('passes the buttonRef', () => {
+      const mockRef = React.createRef<HTMLButtonElement>();
+
+      const component = mountWithProviders(
+        <BuyNowButton variantId="1" buttonRef={mockRef}>
+          Buy now
+        </BuyNowButton>
+      );
+
+      expect(component).toContainReactComponent(BaseButton, {
+        buttonRef: mockRef,
+      });
     });
   });
 });

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/tests/CartLineQuantityAdjustButton.test.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/tests/CartLineQuantityAdjustButton.test.tsx
@@ -6,6 +6,7 @@ import {CART_LINE} from '../../CartLineProvider/tests/fixtures';
 import {useCart} from '../../CartProvider';
 import {CART_WITH_LINES_FLATTENED} from '../../CartProvider/tests/fixtures';
 import {mountWithCartProvider} from '../../CartProvider/tests/utilities';
+import {BaseButton} from '../../BaseButton';
 
 describe('CartLineQuantityAdjustButton', () => {
   it('increases quantity', () => {
@@ -115,6 +116,45 @@ describe('CartLineQuantityAdjustButton', () => {
     wrapper.find('button')!.trigger('onClick');
 
     expect(linesRemoveMock).toHaveBeenCalledWith([CART_LINE.id]);
+  });
+
+  describe('BaseButton', () => {
+    it('passes the onClick handler', () => {
+      const mockOnClick = jest.fn();
+      const wrapper = mountWithCartProvider(
+        <Cart>
+          <CartLineQuantityAdjustButton onClick={mockOnClick} adjust="increase">
+            Increase
+          </CartLineQuantityAdjustButton>
+        </Cart>,
+        {
+          cart: {lines: [CART_LINE]},
+        }
+      );
+
+      expect(wrapper).toContainReactComponent(BaseButton, {
+        onClick: mockOnClick,
+      });
+    });
+
+    it('passes the buttonRef', () => {
+      const mockRef = React.createRef<HTMLButtonElement>();
+
+      const wrapper = mountWithCartProvider(
+        <Cart>
+          <CartLineQuantityAdjustButton buttonRef={mockRef} adjust="increase">
+            Increase
+          </CartLineQuantityAdjustButton>
+        </Cart>,
+        {
+          cart: {lines: [CART_LINE]},
+        }
+      );
+
+      expect(wrapper).toContainReactComponent(BaseButton, {
+        buttonRef: mockRef,
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Description
Issue: https://github.com/Shopify/hydrogen/issues/717

### Additional context
We decided to keep `onClick` handlers as primitive as possible for now.
Also adding the possibility of using `buttonRef` for the use case in the issue.

@jplhomer made an example of how to use refs + onClick handlers to create a custom button and have code wrapping the default behaviour of the button: https://codesandbox.io/s/button-wrapping-ref-enedsj

I created `BaseButton` that can be reused for new buttons looking for this functionality.

### Tophatting
Created a branch for this: `dr/button-click-handlers-tophat`
Go to `demo-store-neue` and go to any product and click add to cart.
You should see in the dev console printing + the referenced button
