### PR TITLE
[Utilities] Fix HTML double-decoding

### DIFF
--- a/.changeset/hip-adults-teach.md
+++ b/.changeset/hip-adults-teach.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix HTML double-decoding in flight response

--- a/packages/hydrogen/src/utilities/html-encoding.ts
+++ b/packages/hydrogen/src/utilities/html-encoding.ts
@@ -9,9 +9,9 @@ export function htmlEncode(html: string) {
 
 export function htmlDecode(text: string) {
   return text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
 }

--- a/packages/hydrogen/src/utilities/tests/html-encoding.test.ts
+++ b/packages/hydrogen/src/utilities/tests/html-encoding.test.ts
@@ -1,6 +1,6 @@
 import {htmlDecode, htmlEncode} from '../html-encoding';
 
-describe('html encodgin', () => {
+describe('html encoding', () => {
   describe('htmlEncode', () => {
     it('encodes things properly', () => {
       expect(htmlEncode('<div>')).toBe('&lt;div&gt;');
@@ -21,6 +21,10 @@ M2:{&quot;id&quot;:&quot;ShopifyProvider-MTY2NjM5NzU1NQ&quot;,&quot;name&quot;:&
 M2:{&quot;id&quot;:&quot;ShopifyProvider-MTY2NjM5NzU1NQ&quot;,&quot;name&quot;:&quot;ShopifyProviderClient&quot;}`)
       ).toBe(`S1:"react.suspense"
 M2:{"id":"ShopifyProvider-MTY2NjM5NzU1NQ","name":"ShopifyProviderClient"}`);
+    });
+
+    it('does not double-decode ampersands', () => {
+      expect(htmlDecode(`drink: g&amp;gt;`)).toBe(`drink: g&gt;`);
     });
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hydrogen includes utility functions for encoding and decoding strings containing HTML entities. The `htmlDecode()` decodes each of 5 entity encoding within a given string, in-order. Due to `&amp;` being decoded to `&` before subsequent replacements, the function can accidentally double-decode strings - effectively treating `&amp;quot;` as `&quot;`.


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
