### PR TITLE
Fix MagicString usage (was generating an identity sourcemap) and avoid source replacement where appending can be used.

### DIFF
--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -47,22 +47,21 @@ export default () => {
     },
     transform(code, id) {
       if (normalizePath(id).includes('/hydrogen/dist/esnext/platforms/')) {
-        code = code
-          .replace('__SERVER_ENTRY__', HYDROGEN_DEFAULT_SERVER_ENTRY)
-          .replace(
-            '__INDEX_TEMPLATE__',
-            normalizePath(
-              path.resolve(
-                config.root,
-                config.build.outDir,
-                '..',
-                'client',
-                'index.html'
-              )
-            )
-          );
-
         const ms = new MagicString(code);
+
+        ms.replace('__SERVER_ENTRY__', HYDROGEN_DEFAULT_SERVER_ENTRY);
+
+        const indexTemplatePath = normalizePath(
+          path.resolve(
+            config.root,
+            config.build.outDir,
+            '..',
+            'client',
+            'index.html'
+          )
+        );
+        ms.replace('__INDEX_TEMPLATE__', indexTemplatePath);
+
         return {
           code: ms.toString(),
           map: ms.generateMap({file: id, source: id}),
@@ -83,10 +82,7 @@ export default () => {
         // default export instead of exporting an
         // object containing a 'default' property.
         if (value.type === 'chunk' && !isESM) {
-          value.code = value.code.replace(
-            /((^|;)[\s]*)exports\[['"]default['"]\]\s*=/m,
-            '$1module.exports ='
-          );
+          value.code += `\nmodule.exports = exports.default || exports;`;
         }
       }
     },


### PR DESCRIPTION
### Description

This should be a non-functional change - it just fixes an incorrect MagicString usage, and avoids a string replacement on generated JS code where appending the same operation to the end of the bundle produces the same result.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] N/A Update docs in this repository according to your change
- [ ] N/A Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
