### PR TITLE
Re-export all client exports from the server entrypoint

### DIFF
--- a/.changeset/popular-wombats-greet.md
+++ b/.changeset/popular-wombats-greet.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Ensure all Hydrogen components are exported properly

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -1,37 +1,25 @@
+/**
+ * Export all client components from here to ensure they're available in both import
+ * paths. This is because we transform `@shopify/hydrogen` to `@shopify/hydrogen/client`
+ * inside client components during the client build only, but when the same components
+ * run during SSR, they reference this path.
+ */
+export * from './client';
+
+/**
+ * The following are exported from this file because they are intended to be available
+ * *only* on the server.
+ */
 export * from './foundation/';
-export * from './components/';
-export * from './hooks/';
-
-export {
-  flattenConnection,
-  fetchBuilder,
-  graphqlRequestBody,
-  decodeShopifyId,
-  isClient,
-  getTime,
-} from './utilities';
-export {gql} from './utilities/graphql-tag';
-
+export * from './hooks/useShopQuery/hooks';
+export * from './foundation/useQuery/hooks';
+export * from './foundation/useServerProps';
 export {FileRoutes} from './foundation/FileRoutes/FileRoutes.server';
 export {Route} from './foundation/Route/Route.server';
 export {Router} from './foundation/Router/Router.server';
 export {log, setLogger, setLoggerOptions, Logger} from './utilities/log';
-export {useRouteParams} from './foundation/useRouteParams/useRouteParams';
-
-// This is exported here because it contains a Server Component
 export {LocalizationProvider} from './components/LocalizationProvider/LocalizationProvider.server';
 export {ShopifyProvider} from './foundation/ShopifyProvider/ShopifyProvider.server';
-
-// Exported here because users shouldn't be making `useShopQuery` calls from the client
-export * from './hooks/useShopQuery/hooks';
-export * from './foundation/useQuery/hooks';
-export * from './foundation/useServerProps';
-export {Head} from './foundation/Head';
-
-// Export server-only CartQuery here instead of `CartProvider.client` to prevent
-// it from being bundled with other client components
-export {CartQuery} from './components/CartProvider/cart-queries';
-
 export {
   generateCacheControlHeader,
   NoStore,
@@ -43,14 +31,20 @@ export {
   CacheMonths,
   CacheCustom,
 } from './framework/CachingStrategy';
-
-export {fetchSync} from './foundation/fetchSync/server/fetchSync';
 export {useServerAnalytics} from './foundation/Analytics';
 export * as PerformanceMetricsServerAnalyticsConnector from './foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetrics.server';
-export {PerformanceMetrics} from './foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetrics.client';
-export {PerformanceMetricsDebug} from './foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetricsDebug.client';
-
 export {useSession} from './foundation/useSession/useSession';
 export {CookieSessionStorage} from './foundation/CookieSessionStorage/CookieSessionStorage';
 export {MemorySessionStorage} from './foundation/MemorySessionStorage/MemorySessionStorage';
 export {Cookie} from './foundation/Cookie/Cookie';
+
+/**
+ * Export server-only CartQuery here instead of `CartProvider.client` to prevent
+ * it from being bundled with other client components
+ */
+export {CartQuery} from './components/CartProvider/cart-queries';
+
+/**
+ * Override the client version of `fetchSync` with the server version.
+ */
+export {fetchSync} from './foundation/fetchSync/server/fetchSync';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1350 by re-exporting all client exports from `/client.ts` from `/index.ts` as well.

### Additional context

When we dropped the requirement for using `/client` as a suffix when importing Hydrogen modules from client components #1311, we realized we'd been exporting some modules from `client.ts` only, when they really should have been exported from both paths.

By re-exporting them from `index.ts`, we can avoid these mismatches in the future.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
