### PR TITLE
Fix Netlify deployments, and deploy to prod each time

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -83,7 +83,10 @@ jobs:
       - name: Build for Netlify Functions
         working-directory: ./templates/template-hydrogen-default
         run: |
-          yarn shopify hydrogen build --target worker --entry @netlify/hydrogen-platform/handler
+          vite build --outDir dist/client --manifest
+          WORKER=true vite build --ssr @netlify/hydrogen-platform/handler
+          # TODO: Add support for ssrOutDir to the Shopify Hydrogen CLI
+          # yarn shopify hydrogen build --target worker --entry @netlify/hydrogen-platform/handler --ssrOutDir .netlify/edge-functions/handler
 
       - name: Install Netlify CLI
         run: |
@@ -93,7 +96,7 @@ jobs:
         id: netlify-deploy
         working-directory: ./templates/template-hydrogen-default
         run: |
-          netlify deploy --build --json | jq -r '.deploy_url' > deploy.txt
+          netlify deploy --build --prod --json | jq -r '.deploy_url' > deploy.txt
           echo "::set-output name=deploy-url::$(cat deploy.txt)"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Build for Netlify Functions
         working-directory: ./templates/template-hydrogen-default
         run: |
-          vite build --outDir dist/client --manifest
-          WORKER=true vite build --ssr @netlify/hydrogen-platform/handler
+          yarn vite build --outDir dist/client --manifest
+          WORKER=true yarn vite build --ssr @netlify/hydrogen-platform/handler
           # TODO: Add support for ssrOutDir to the Shopify Hydrogen CLI
           # yarn shopify hydrogen build --target worker --entry @netlify/hydrogen-platform/handler --ssrOutDir .netlify/edge-functions/handler
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When we shipped #1338, we started using `shopify hydrogen build`. It turns out that the Netlify deploy step actually has its own plugin, which sets a custom `outDir` https://github.com/netlify/vite-plugin-netlify-edge/blob/main/src/index.ts

This conflicts with the `outDir` we set in https://github.com/Shopify/shopify-cli-next/blob/main/packages/cli-hydrogen/src/cli/services/build.ts#L27, which resulted in Netlify uploading essentially a blank `index.html` skeleton missing an edge function handler.

This PR reverts to using raw Vite build commands for Netlify deploys. This is OK, because this is how Netlify has it documented today.

I'll open an issue for us to support something like `ssrOutDir` in `shopify hydrogen build` so they can migrate to that tool in the future.

### Additional context

I also added the `--prod` flag so future Netlify deploys are published to the https://hydrogen-template-default.netlify.app/ domain.