### PR TITLE
Remove server utilities from client build

### DIFF
--- a/.changeset/unlucky-apples-smile.md
+++ b/.changeset/unlucky-apples-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Remove some server utilities from client build.

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
 } from 'react';
 import type {Reducer} from 'react';
-import {flattenConnection} from '../../utilities';
+import {flattenConnection} from '../../utilities/flattenConnection';
 import {
   CartCreateMutation,
   CartCreateMutationVariables,
@@ -68,7 +68,7 @@ import {CartFragmentFragment} from './graphql/CartFragment';
 import {CartQueryQuery, CartQueryQueryVariables} from './graphql/CartQuery';
 
 import type {CartWithActions} from './types';
-import {ClientAnalytics} from '../../foundation/Analytics';
+import {ClientAnalytics} from '../../foundation/Analytics/ClientAnalytics';
 
 function cartReducer(state: State, action: CartAction): State {
   switch (action.type) {

--- a/packages/hydrogen/src/foundation/Analytics/Analytics.client.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/Analytics.client.tsx
@@ -1,5 +1,5 @@
 import {useEffect} from 'react';
-import {ClientAnalytics} from './index';
+import {ClientAnalytics} from './ClientAnalytics';
 
 export function Analytics({
   analyticsDataFromServer,

--- a/packages/hydrogen/src/foundation/Analytics/ClientAnalytics.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/ClientAnalytics.tsx
@@ -1,8 +1,8 @@
 import {getNamedspacedEventname} from './utils';
 import type {Subscriber, Subscribers, SubscriberFunction} from './types';
-import {isServer} from '../../utilities';
 import {eventNames} from './const';
 import {EVENT_PATHNAME} from '../../constants';
+import {META_ENV_SSR} from '../ssr-interop';
 
 type EventGuard = Record<string, NodeJS.Timeout>;
 
@@ -14,7 +14,7 @@ const USAGE_ERROR =
   'ClientAnalytics should only be used within the useEffect callback or event handlers';
 
 function isInvokedFromServer(): boolean {
-  if (isServer()) {
+  if (META_ENV_SSR) {
     console.warn(USAGE_ERROR);
     return true;
   }

--- a/packages/hydrogen/src/foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetrics.client.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetrics.client.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
-import {loadScript} from '../../../../utilities';
-import {ClientAnalytics} from '../../index';
+import {loadScript} from '../../../../utilities/load_script';
+import {ClientAnalytics} from '../../ClientAnalytics';
 import {useShop} from '../../../useShop';
 
 declare global {

--- a/packages/hydrogen/src/foundation/Analytics/index.ts
+++ b/packages/hydrogen/src/foundation/Analytics/index.ts
@@ -1,3 +1,1 @@
-export {useServerAnalytics} from './hook';
-
 export {ClientAnalytics} from './ClientAnalytics';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -45,7 +45,7 @@ export {
 } from './framework/CachingStrategy';
 
 export {fetchSync} from './foundation/fetchSync/server/fetchSync';
-export {useServerAnalytics} from './foundation/Analytics';
+export {useServerAnalytics} from './foundation/Analytics/hook';
 export * as PerformanceMetricsServerAnalyticsConnector from './foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetrics.server';
 export {PerformanceMetrics} from './foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetrics.client';
 export {PerformanceMetricsDebug} from './foundation/Analytics/connectors/PerformanceMetrics/PerformanceMetricsDebug.client';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed we were downloading `kolorist` in he browser... and some other minor code. I think this should fix that.
The reason seems to be mixing server-only and client-only exports from the same `index.ts` files.
I think we should use the full path internally when importing stuff to avoid this kind of problem.

You can test by running `ack kolorist` (or grep) in the `dist/client` in main branch vs this branch.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
