### PR TITLE
Update stackblitz workflow to manually update files

### DIFF
--- a/.github/workflows/publish_stackblitz.yml
+++ b/.github/workflows/publish_stackblitz.yml
@@ -1,6 +1,8 @@
 name: Publish to Stackblitz
 
 on:
+  # Note: the `released` event does not currently work because
+  # a bot is the creator of the release. Run this manually instead.
   release:
     types: [released]
   workflow_dispatch:
@@ -9,20 +11,19 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish latest release to Stackblitz
-    strategy:
-      matrix:
-        template: ['template-hydrogen-default', 'template-hydrogen-hello-world']
     steps:
       - uses: actions/checkout@v2
         with:
           ref: 'v1.x-2022-07'
       - run: |
-          mv templates/${{ matrix.template }}/_gitignore templates/${{ matrix.template }}/.gitignore
+          mv templates/template-hydrogen-default/_gitignore templates/template-hydrogen-default/.gitignore
+          mv templates/template-hydrogen-hello-world/_gitignore templates/template-hydrogen-hello-world/.gitignore
       - run: |
-          sed -i.bak 's/cross-env LOCAL_DEV=true //' templates/${{ matrix.template }}/package.json
+          sed -i.bak 's/cross-env LOCAL_DEV=true //' templates/template-hydrogen-default/package.json
+          sed -i.bak 's/cross-env LOCAL_DEV=true //' templates/template-hydrogen-hello-world/package.json
       - run: |
           git show-ref
           git config user.email "hydrogen@shopify.com"
           git config user.name "Hydrogen Bot"
-          git commit -am "Update ${{ matrix.template }} on Stackblitz branch"
+          git commit -am "Update templates on Stackblitz branch"
           git push origin HEAD:stackblitz --force


### PR DESCRIPTION
This needs to happen in a single commit as opposed to concurrent/parallel workflows because they both check out the main branch first and then force push.