### PR TITLE
Add rule override for `rule-of-hooks` in server components

### DIFF
--- a/.changeset/strange-bobcats-tell.md
+++ b/.changeset/strange-bobcats-tell.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-hydrogen': patch
+---
+
+Updates default hydrogen eslint config to ignore `rule-of-hooks` rule inside server components.

--- a/packages/eslint-plugin/src/configs/core.ts
+++ b/packages/eslint-plugin/src/configs/core.ts
@@ -50,5 +50,9 @@ export default {
         jest: true,
       },
     },
+    {
+      files: ['*.server.*'],
+      rules: {'react-hooks/rules-of-hooks': 'off'},
+    },
   ],
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Closes https://github.com/Shopify/hydrogen/issues/1358

### Description

Adds an override to the `'react-hooks/rules-of-hooks'` eslint rule for `.server.*` files to disable it.

### Testing

1. `yarn link` inside of `packages/eslint-plugin`
1. `yarn link eslint-plugin-hydrogen ` inside of `templates/template-hydrogen-default`
1. Add a violation such as wrapping a hook inside of a server component in an if statement
1. `yarn lint` inside of `templates/template-hydrogen-default`


### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
