### PR TITLE
Fix Image typescript issues

### DIFF
--- a/.changeset/fair-weeks-turn.md
+++ b/.changeset/fair-weeks-turn.md
@@ -1,0 +1,8 @@
+---
+'@shopify/hydrogen': patch
+---
+
+## `<Image/>` updates
+
+- Fixed some TypeScript type issues with Image.
+- `data.url` and `alt` are now required props in Typescript, but won't break the actual component if you don't pass them.

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -15,6 +15,7 @@ Hydrogen is a React framework and SDK that you can use to build fast and dynamic
 
 ```bash
 npx degit Shopify/hydrogen/examples/typescript hydrogen-app
+cd hydrogen-app
 yarn
 yarn dev
 ```

--- a/packages/hydrogen/src/components/CartLineImage/tests/CartLineImage.test.tsx
+++ b/packages/hydrogen/src/components/CartLineImage/tests/CartLineImage.test.tsx
@@ -12,55 +12,73 @@ const cartMerchandiseImage = {
   height: 300,
 };
 
-it('displays the image', () => {
-  const line = {
-    ...CART_LINE,
-    merchandise: {
-      ...CART_LINE.merchandise,
-      image: {...cartMerchandiseImage},
-    },
-  };
-
-  const wrapper = mount(
-    <CartLineProvider line={line}>
-      <CartLineImage />
-    </CartLineProvider>
-  );
-
-  expect(wrapper).toContainReactComponent(Image, {
-    data: line.merchandise.image,
-  });
-});
-
-it('allows passthrough props', () => {
-  const line = {
-    ...CART_LINE,
-    merchandise: {
-      ...CART_LINE.merchandise,
-      image: {
-        ...cartMerchandiseImage,
+describe(`<CartLineImage />`, () => {
+  it('displays the image', () => {
+    const line = {
+      ...CART_LINE,
+      merchandise: {
+        ...CART_LINE.merchandise,
+        image: {...cartMerchandiseImage},
       },
-    },
-  };
+    };
 
-  const wrapper = mount(
-    <CartLineProvider line={line}>
-      <CartLineImage className="w-full" />
-    </CartLineProvider>
-  );
+    const wrapper = mount(
+      <CartLineProvider line={line}>
+        <CartLineImage />
+      </CartLineProvider>
+    );
 
-  expect(wrapper).toContainReactComponent(Image, {
-    data: line.merchandise.image,
-    className: 'w-full',
+    expect(wrapper).toContainReactComponent(Image, {
+      data: line.merchandise.image,
+    });
   });
-});
 
-it('displays nothing if there is no image', () => {
-  const wrapper = mount(
-    <CartLineProvider line={CART_LINE}>
-      <CartLineImage />
-    </CartLineProvider>
-  );
+  it('allows passthrough props', () => {
+    const line = {
+      ...CART_LINE,
+      merchandise: {
+        ...CART_LINE.merchandise,
+        image: {
+          ...cartMerchandiseImage,
+        },
+      },
+    };
 
-  expect(wrapper).not.toContainReactComponent(Image);
+    const wrapper = mount(
+      <CartLineProvider line={line}>
+        <CartLineImage className="w-full" />
+      </CartLineProvider>
+    );
+
+    expect(wrapper).toContainReactComponent(Image, {
+      data: line.merchandise.image,
+      className: 'w-full',
+    });
+  });
+
+  it('displays nothing if there is no image', () => {
+    const wrapper = mount(
+      <CartLineProvider line={CART_LINE}>
+        <CartLineImage />
+      </CartLineProvider>
+    );
+
+    expect(wrapper).not.toContainReactComponent(Image);
+  });
+
+  it.skip(`typescript types`, () => {
+    // this test is actually just using //@ts-expect-error as the assertion, and don't need to execute in order to have TS validation on them
+    // I don't love this idea, but at the moment I also don't have other great ideas for how to easily test our component TS types
+
+    // no errors in these situations
+    <CartLineImage />;
+
+    // @ts-expect-error no need to pass data
+    <CartLineImage data={{}} />;
+    // @ts-expect-error no need to pass src
+    <CartLineImage src="" />;
+
+    // @ts-expect-error foo is invalid
+    <CartLineImage data={{url: ''}} foo="bar" />;
+  });
 });

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -14,7 +14,7 @@ export function Image<GenericLoaderOpts>(props: ImageProps<GenericLoaderOpts>) {
     throw new Error(`<Image/>: requires either a 'data' or 'src' prop.`);
   }
 
-  if (import.meta.env.DEV && props.data && props.src) {
+  if (__DEV__ && props.data && props.src) {
     console.warn(
       `<Image/>: using both 'data' and 'src' props is not supported; using the 'data' prop by default`
     );
@@ -77,7 +77,7 @@ function ShopifyImage({
     throw new Error(`<Image/>: the 'data' prop requires the 'url' property`);
   }
 
-  if (import.meta.env.DEV && !data.altText && !rest.alt) {
+  if (__DEV__ && !data.altText && !rest.alt) {
     console.warn(
       `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. ${`Image: ${
         data.id ?? data.url
@@ -90,7 +90,7 @@ function ShopifyImage({
     loaderOptions
   );
 
-  if ((import.meta.env.DEV && !finalWidth) || !finalHeight) {
+  if ((__DEV__ && !finalWidth) || !finalHeight) {
     console.warn(
       `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. ${`Image: ${
         data.id ?? data.url
@@ -194,7 +194,7 @@ function ExternalImage<GenericLoaderOpts>({
     );
   }
 
-  if (import.meta.env.DEV && !alt) {
+  if (__DEV__ && !alt) {
     console.warn(
       `<Image/>: when 'src' is provided, 'alt' should also be provided. ${`Image: ${src}`}`
     );

--- a/packages/hydrogen/src/components/Image/tests/Image.test.tsx
+++ b/packages/hydrogen/src/components/Image/tests/Image.test.tsx
@@ -173,6 +173,7 @@ describe('<Image />', () => {
           width={width}
           height={height}
           loading={loading}
+          alt=""
         />
       );
 
@@ -199,7 +200,9 @@ describe('<Image />', () => {
         const height = 100;
 
         expect(() => {
-          mount(<Image src={src} id={id} width={width} height={height} />);
+          mount(
+            <Image src={src} id={id} width={width} height={height} alt="" />
+          );
         }).toThrowError(
           `<Image/>: when 'src' is provided, 'width' and 'height' are required and need to be valid values (i.e. greater than zero). Provided values: 'src': ${src}, 'width': ${width}, 'height': ${height}`
         );
@@ -211,7 +214,9 @@ describe('<Image />', () => {
         const height = 0;
 
         expect(() => {
-          mount(<Image src={src} id={id} width={width} height={height} />);
+          mount(
+            <Image src={src} id={id} width={width} height={height} alt="" />
+          );
         }).toThrowError(
           `<Image/>: when 'src' is provided, 'width' and 'height' are required and need to be valid values (i.e. greater than zero). Provided values: 'src': ${src}, 'width': ${width}, 'height': ${height}`
         );
@@ -243,6 +248,7 @@ describe('<Image />', () => {
           height={height}
           loader={loaderMock}
           loaderOptions={loaderOptions}
+          alt=""
         />
       );
 
@@ -275,5 +281,32 @@ describe('<Image />', () => {
         alt: 'Fancy image',
       });
     });
+  });
+
+  it.skip(`typescript types`, () => {
+    // this test is actually just using //@ts-expect-error as the assertion, and don't need to execute in order to have TS validation on them
+    // I don't love this idea, but at the moment I also don't have other great ideas for how to easily test our component TS types
+
+    // no errors in these situations
+    <Image data={{url: ''}} />;
+    <Image src="" width="" height="" alt="" />;
+
+    // @ts-expect-error data.url
+    <Image data={{}} />;
+
+    // @ts-expect-error data and src
+    <Image data={{url: ''}} src="" width="" height="" />;
+
+    // @ts-expect-error foo is invalid
+    <Image data={{url: ''}} foo="bar" />;
+
+    // @ts-expect-error must have alt
+    <Image src="" width="" height="" />;
+
+    // @ts-expect-error must have width
+    <Image src="" alt="" height="" />;
+
+    // @ts-expect-error must have height
+    <Image src="" alt="" width="" />;
   });
 });

--- a/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
+++ b/packages/hydrogen/src/components/MediaFile/MediaFile.tsx
@@ -35,8 +35,9 @@ export function MediaFile({
 }: MediaFileProps) {
   switch (data.mediaContentType) {
     case 'IMAGE': {
-      const dataImage = (data as PartialDeep<MediaImageType>).image;
-      if (!dataImage) {
+      const dataImage = (data as PartialDeep<MediaImageType>)
+        .image as ShopifyImageProps['data'];
+      if (!dataImage || !dataImage.url) {
         console.warn(
           `No "image" property was found on the "data" prop for <MediaFile/>, for the "type='image'"`
         );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It was reported that the TS types for `<Image/>` were having issues. Strangely, these issues never manifested in our monorepo, but they did when installing from npm. I narrowed it down to the `Simplify<>` wrapper around `ImageProps`, but the _why_ I'm still not sure about. So for now, I'm just removing `Simplify<>` from that type. 

Also updated the Image component to only use `console.warn` behind a dev flag. This works for now, but when we migrate components over to hydrogen-ui we're going to have to change it so that we have a dev bundle and a prod bundle; otherwise it would also require other libraries to know about the `__DEV__` thing and use a [webpack/rollup/vite/etc] plugin to remove it, which isn't ideal. 

Finally, added some basic TS types tests. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
