### PR TITLE
Add a built-in health check route

### DIFF
--- a/.changeset/loud-timers-pay.md
+++ b/.changeset/loud-timers-pay.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Add a built in healthcheck route available at `/__health`. It responds with a 200 and no body.
+Add a built-in healthcheck route available at `/__health`. It responds with a 200 and no body. Also suppresses server logs for built-in routes like healthcheck and analytics.

--- a/.changeset/loud-timers-pay.md
+++ b/.changeset/loud-timers-pay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add a built in healthcheck route available at `/__health`. It responds with a 200 and no body.

--- a/docs/framework/routes.md
+++ b/docs/framework/routes.md
@@ -102,6 +102,14 @@ By default, when a user hovers or focuses on the link for more than 100ms, a pre
 
 You can extend dynamic routes to catch all paths by adding an ellipsis (...) inside the brackets. For example, `/routes/example/[...handle].server.jsx` will match `/example/a` and `/example/a/b`.
 
+### Built-in routes
+
+Hydrogen provides the following built-in routes:
+
+- `/__health` - A health check route that responds with a 200 status and no body. You can use this route within your infrastructure to verify that your app is healthy and able to respond to requests.
+- `/__rsc` - An internal route used to re-render server components. It's called by the Hydrogen frontend when the route changes, or when server props change. You should never need to manually request this route.
+- `/__event` - An internal route used to save client observability events. You should never need to manually request this route.
+
 ### Example
 
 The following example shows how to obtain catch all routes data using `location.pathname`:
@@ -240,8 +248,8 @@ export default function Page() {
 
 Server components placed in the `src/routes` directory receive the following special props that you can use to create custom experiences:
 
-| Prop       | Type                      |
-| ---------- | ------------------------- |
+| Prop       | Type               |
+| ---------- | ------------------ |
 | `request`  | `HydrogenRequest`  |
 | `response` | `HydrogenResponse` |
 
@@ -396,14 +404,6 @@ function MyPage({custom, props, here}) {
 ```
 
 {% endcodeblock %}
-
-### Built-in routes
-
-Hydrogen provides a few built-in routes
-
-1. `/__health` - A health check route that responds witha 200 status and no body. You can use this route within your infrastructure to verify your app is healthy and able to respond to requests.
-2. `/__rsc` - An internal route used to re-render server components. It's called by the hydrogen front-end when the route changes, or server props change. You should never need to manually request this route.
-3. `/__event` - An internal route used to save client observability events. You should never need to manually request this route.
 
 ## Related components and hooks
 

--- a/docs/framework/routes.md
+++ b/docs/framework/routes.md
@@ -397,6 +397,14 @@ function MyPage({custom, props, here}) {
 
 {% endcodeblock %}
 
+### Built-in routes
+
+Hydrogen provides a few built-in routes
+
+1. `/__health` - A health check route that responds witha 200 status and no body. You can use this route within your infrastructure to verify your app is healthy and able to respond to requests.
+2. `/__rsc` - An internal route used to re-render server components. It's called by the hydrogen front-end when the route changes, or server props change. You should never need to manually request this route.
+3. `/__event` - An internal route used to save client observability events. You should never need to manually request this route.
+
 ## Related components and hooks
 
 - [`Link`](https://shopify.dev/api/hydrogen/components/framework/link)

--- a/packages/hydrogen/src/foundation/Analytics/ServerAnalyticsRoute.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/ServerAnalyticsRoute.tsx
@@ -1,12 +1,13 @@
-import type {ServerAnalyticsConnector} from '../../types';
+import type {ResolvedHydrogenConfig} from '../../types';
 import {log} from '../../utilities/log';
 
-export function ServerAnalyticsRoute(
+export async function ServerAnalyticsRoute(
   request: Request,
-  serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>
+  {hydrogenConfig}: {hydrogenConfig: ResolvedHydrogenConfig}
 ) {
   const requestHeader = request.headers;
   const requestUrl = request.url;
+  const serverAnalyticsConnectors = hydrogenConfig.serverAnalyticsConnectors;
 
   if (requestHeader.get('Content-Length') === '0') {
     serverAnalyticsConnectors?.forEach((connector) => {

--- a/packages/hydrogen/src/foundation/Analytics/tests/ServerAnalyticsRoute.test.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/tests/ServerAnalyticsRoute.test.tsx
@@ -1,4 +1,5 @@
-import {ServerAnalyticsRoute} from '../ServerAnalyticsRoute.server';
+import {ResolvedHydrogenConfig} from '../../../types';
+import {ServerAnalyticsRoute} from '../ServerAnalyticsRoute';
 
 const createRequest = () => {
   return new Request('__event', {
@@ -9,37 +10,47 @@ const createRequest = () => {
 };
 
 describe('Analytics - ServerAnalyticsRoute', () => {
-  it('should return a 200 response', () => {
-    const response = ServerAnalyticsRoute(createRequest());
+  it('should return a 200 response', async () => {
+    const response = await ServerAnalyticsRoute(createRequest(), {
+      hydrogenConfig: {} as ResolvedHydrogenConfig,
+    });
     expect(response.status).toEqual(200);
   });
 
-  it('should delegate request to a server analytics connector', () => {
+  it('should delegate request to a server analytics connector', async () => {
     const mockServerAnalyticsConnector = jest.fn();
     const request = createRequest();
-    const response = ServerAnalyticsRoute(request, [
-      {
-        request: mockServerAnalyticsConnector,
-      },
-    ]);
+    const response = await ServerAnalyticsRoute(request, {
+      hydrogenConfig: {
+        serverAnalyticsConnectors: [
+          {
+            request: mockServerAnalyticsConnector,
+          },
+        ],
+      } as unknown as ResolvedHydrogenConfig,
+    });
 
     expect(response.status).toEqual(200);
     expect(mockServerAnalyticsConnector).toHaveBeenCalled();
     expect(mockServerAnalyticsConnector.mock.calls[0][0]).toEqual(request.url);
   });
 
-  it('should delegate request to multiple server analytics connectors', () => {
+  it('should delegate request to multiple server analytics connectors', async () => {
     const mockServerAnalyticsConnector1 = jest.fn();
     const mockServerAnalyticsConnector2 = jest.fn();
     const request = createRequest();
-    const response = ServerAnalyticsRoute(request, [
-      {
-        request: mockServerAnalyticsConnector1,
-      },
-      {
-        request: mockServerAnalyticsConnector2,
-      },
-    ]);
+    const response = await ServerAnalyticsRoute(request, {
+      hydrogenConfig: {
+        serverAnalyticsConnectors: [
+          {
+            request: mockServerAnalyticsConnector1,
+          },
+          {
+            request: mockServerAnalyticsConnector2,
+          },
+        ],
+      } as unknown as ResolvedHydrogenConfig,
+    });
 
     expect(response.status).toEqual(200);
     expect(mockServerAnalyticsConnector1).toHaveBeenCalled();
@@ -48,66 +59,70 @@ describe('Analytics - ServerAnalyticsRoute', () => {
     expect(mockServerAnalyticsConnector2.mock.calls[0][0]).toEqual(request.url);
   });
 
-  it('should delegate json request', async () => {
-    return new Promise<void>((resolve) => {
-      const testRequest = new Request('__event', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          test: '123',
-        }),
-      });
-      const mockServerAnalyticsConnector = (
-        requestUrl: string,
-        requestHeader: Headers,
-        data?: any,
-        type?: string
-      ): void => {
-        expect(requestUrl).toEqual(testRequest.url);
-        expect(requestHeader).toEqual(testRequest.headers);
-        expect(data).toEqual({
-          test: '123',
-        });
-        expect(type).toEqual('json');
-        resolve();
-      };
-      const response = ServerAnalyticsRoute(testRequest, [
-        {
-          request: mockServerAnalyticsConnector,
-        },
-      ]);
-
-      expect(response.status).toEqual(200);
+  it('should delegate json request', async (done) => {
+    const testRequest = new Request('__event', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        test: '123',
+      }),
     });
+    const mockServerAnalyticsConnector = (
+      requestUrl: string,
+      requestHeader: Headers,
+      data?: any,
+      type?: string
+    ): void => {
+      expect(requestUrl).toEqual(testRequest.url);
+      expect(requestHeader).toEqual(testRequest.headers);
+      expect(data).toEqual({
+        test: '123',
+      });
+      expect(type).toEqual('json');
+      done();
+    };
+    const response = await ServerAnalyticsRoute(testRequest, {
+      hydrogenConfig: {
+        serverAnalyticsConnectors: [
+          {
+            request: mockServerAnalyticsConnector,
+          },
+        ],
+      } as unknown as ResolvedHydrogenConfig,
+    });
+
+    expect(response.status).toEqual(200);
   });
 
-  it('should delegate text request', async () => {
-    return new Promise<void>((resolve) => {
-      const testRequest = new Request('__event', {
-        method: 'POST',
-        body: 'test123',
-      });
-      const mockServerAnalyticsConnector = (
-        requestUrl: string,
-        requestHeader: Headers,
-        data?: any,
-        type?: string
-      ): void => {
-        expect(requestUrl).toEqual(testRequest.url);
-        expect(requestHeader).toEqual(testRequest.headers);
-        expect(data).toEqual('test123');
-        expect(type).toEqual('text');
-        resolve();
-      };
-      const response = ServerAnalyticsRoute(testRequest, [
-        {
-          request: mockServerAnalyticsConnector,
-        },
-      ]);
-
-      expect(response.status).toEqual(200);
+  it('should delegate text request', async (done) => {
+    const testRequest = new Request('__event', {
+      method: 'POST',
+      body: 'test123',
     });
+    const mockServerAnalyticsConnector = (
+      requestUrl: string,
+      requestHeader: Headers,
+      data?: any,
+      type?: string
+    ): void => {
+      expect(requestUrl).toEqual(testRequest.url);
+      expect(requestHeader).toEqual(testRequest.headers);
+      expect(data).toEqual('test123');
+      expect(type).toEqual('text');
+      done();
+    };
+    const response = await ServerAnalyticsRoute(testRequest, {
+      hydrogenConfig: {
+        serverAnalyticsConnectors: [
+          {
+            request: mockServerAnalyticsConnector,
+          },
+        ],
+      } as unknown as ResolvedHydrogenConfig,
+    });
+
+    expect(response.status).toEqual(200);
   });
 });

--- a/packages/hydrogen/src/foundation/BuiltInRoutes/BuiltInRoutes.ts
+++ b/packages/hydrogen/src/foundation/BuiltInRoutes/BuiltInRoutes.ts
@@ -1,0 +1,34 @@
+import {EVENT_PATHNAME, EVENT_PATHNAME_REGEX} from '../../constants';
+import {ResourceGetter} from '../../utilities/apiRoutes';
+import {ServerAnalyticsRoute} from '../Analytics/ServerAnalyticsRoute';
+import {HealthCheck} from './healthCheck';
+
+type BuiltInRoute = {
+  pathname?: string;
+  regex?: RegExp;
+  resource: ResourceGetter;
+};
+
+const builtInRoutes: Array<BuiltInRoute> = [
+  {
+    pathname: EVENT_PATHNAME,
+    regex: EVENT_PATHNAME_REGEX,
+    resource: ServerAnalyticsRoute,
+  },
+  {
+    pathname: '/__health',
+    resource: HealthCheck,
+  },
+];
+
+export function getBuiltInRoute(url: URL): ResourceGetter | null {
+  for (const route of builtInRoutes) {
+    if (
+      url.pathname === route.pathname ||
+      (route.regex && route.regex.test(url.pathname))
+    ) {
+      return route.resource;
+    }
+  }
+  return null;
+}

--- a/packages/hydrogen/src/foundation/BuiltInRoutes/healthCheck.ts
+++ b/packages/hydrogen/src/foundation/BuiltInRoutes/healthCheck.ts
@@ -1,0 +1,3 @@
+export async function HealthCheck() {
+  return new Response(null, {status: 200});
+}

--- a/templates/demo-store/src/components/ProductCard.jsx
+++ b/templates/demo-store/src/components/ProductCard.jsx
@@ -1,5 +1,5 @@
 import {Suspense} from 'react';
-import {Image, Link} from '@shopify/hydrogen';
+import {Image, Link, flattenConnection} from '@shopify/hydrogen';
 
 import MoneyCompareAtPrice from './MoneyCompareAtPrice.client';
 import MoneyPrice from './MoneyPrice.client';
@@ -8,7 +8,7 @@ import MoneyPrice from './MoneyPrice.client';
  * A shared component that displays a single product to allow buyers to quickly identify a particular item of interest
  */
 export default function ProductCard({product}) {
-  const selectedVariant = product.variants.nodes[0];
+  const selectedVariant = flattenConnection(product.variants)[0];
 
   if (selectedVariant == null) {
     return null;


### PR DESCRIPTION
### Description

Add a built in health check route available at `/__health`. It responds with a 200 and no body. I also refactored the code to more easily add in built-in routes. The `__event` route has been refactored to use the same logic.

Resolves https://github.com/Shopify/hydrogen/issues/1315


### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
