### PR TITLE
Use IntersectionObserver instead of hover for link prefetch

### DIFF
--- a/.changeset/nervous-berries-turn.md
+++ b/.changeset/nervous-berries-turn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Use IntersectionObserver to prefetch Links to support mobile

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -200,6 +200,10 @@ type ObserveCallback = (isVisible: boolean) => void;
 
 const observers: Map<Identifier, Observer> = new Map();
 
+/**
+ * Inspired by Next.js's hook of the same name:
+ * @see https://github.com/vercel/next.js/blob/0613f76f3862f49df46949d103e85514b566ede8/packages/next/client/use-intersection.tsx
+ */
 function useIntersection<T extends Element>(
   options: ObserverOptions
 ): [(element: T | null) => void, boolean] {

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -98,28 +98,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       [forwardedRef, setIntersectionRef]
     );
 
-    const signalPrefetchIntent = () => {
-      /**
-       * startTransition to yield to more important updates
-       */
-      startTransition(() => {
-        if (prefetch) {
-          setMaybePrefetch(true);
-        }
-      });
-    };
-
-    const cancelPrefetchIntent = () => {
-      /**
-       * startTransition to yield to more important updates
-       */
-      startTransition(() => {
-        if (prefetch) {
-          setMaybePrefetch(false);
-        }
-      });
-    };
-
     useEffect(() => {
       startTransition(() => {
         if (isVisible && prefetch) {
@@ -144,21 +122,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       }
     }, [maybePrefetch]);
 
-    const onMouseEnter = composeEventHandlers(
-      props.onMouseEnter,
-      signalPrefetchIntent
-    );
-    const onMouseLeave = composeEventHandlers(
-      props.onMouseLeave,
-      cancelPrefetchIntent
-    );
-    const onFocus = composeEventHandlers(props.onFocus, signalPrefetchIntent);
-    const onBlur = composeEventHandlers(props.onBlur, cancelPrefetchIntent);
-    const onTouchStart = composeEventHandlers(
-      props.onTouchStart,
-      signalPrefetchIntent
-    );
-
     return (
       <>
         <a
@@ -171,11 +134,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
           ])}
           ref={setRef}
           onClick={internalClick}
-          onMouseEnter={onMouseEnter}
-          onMouseLeave={onMouseLeave}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          onTouchStart={onTouchStart}
           href={props.to}
         >
           {props.children}
@@ -206,23 +164,6 @@ function Prefetch({pathname}: {pathname: string}) {
     encodeURIComponent(JSON.stringify(proposedServerState));
 
   return <link rel="prefetch" as="fetch" href={href} />;
-}
-
-/**
- * Credit: Remix's <Link> component.
- */
-export function composeEventHandlers<
-  EventType extends React.SyntheticEvent | Event
->(
-  theirHandler: ((event: EventType) => any) | undefined,
-  ourHandler: (event: EventType) => any
-): (event: EventType) => any {
-  return (event) => {
-    theirHandler?.(event);
-    if (!event.defaultPrevented) {
-      ourHandler(event);
-    }
-  };
 }
 
 function isModifiedEvent(event: React.MouseEvent) {

--- a/packages/hydrogen/src/components/Link/tests/Link.test.tsx
+++ b/packages/hydrogen/src/components/Link/tests/Link.test.tsx
@@ -16,6 +16,7 @@ describe('<Link />', () => {
     );
   });
 
+  // TODO: Fix this
   it('forwards the ref', (done) => {
     mountWithProviders(
       <Link


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1319 

This PR switches our link prefetching strategy to a 200px `IntersectionObserver` instead of user interaction. This ensures prefetching works on mobile as well as desktop.

This removes the old user interaction events because it doesn't make sense to ship both, and this new method is effective.

### Additional context

Other ideas considered:

- Expanding the Link prop to accept different values than true, e.g. `prefetch: 'hover' | 'observer'`. I didn't go this route because it adds complexity, and we don't even want devs to even have to think about this stuff

Downside:

- More bandwidth used, because user is probably not going to visit all the links prefetched in the viewport

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
