### PR TITLE
Center logo in Demo Store header

### DIFF
--- a/.changeset/chilled-garlics-promise.md
+++ b/.changeset/chilled-garlics-promise.md
@@ -1,0 +1,5 @@
+---
+'demo-store': minor
+---
+
+Centers logo in Header component

--- a/templates/demo-store/src/components/Header.client.jsx
+++ b/templates/demo-store/src/components/Header.client.jsx
@@ -31,25 +31,27 @@ export default function Header({collections, storeName}) {
         }`}
       >
         <div
-          className="h-full flex lg:flex-col place-content-between"
+          className="flex h-full lg:flex-col place-content-between"
           style={{
             paddingRight: isCartOpen ? scrollbarWidth : 0,
           }}
         >
-          <div className="text-center w-full flex justify-between items-center">
-            <CountrySelector />
-            <MobileNavigation
-              collections={collections}
-              isOpen={isMobileNavOpen}
-              setIsOpen={setIsMobileNavOpen}
-            />
+          <div className="flex items-center justify-between w-full text-center">
+            <div className="w-20 lg:w-40">
+              <CountrySelector />
+              <MobileNavigation
+                collections={collections}
+                isOpen={isMobileNavOpen}
+                setIsOpen={setIsMobileNavOpen}
+              />
+            </div>
             <Link
-              className="font-black uppercase text-3xl tracking-widest"
+              className="flex-grow text-3xl font-black tracking-widest uppercase"
               to="/"
             >
               {storeName}
             </Link>
-            <div className="flex">
+            <div className="flex justify-end w-20 lg:w-40">
               <Link to="/account" className="mr-2">
                 <AccountIcon />
               </Link>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

A very minor CSS change that has always bugged me. This adds wrapper `div` elements to the left and right menu bar items so we can properly center the logo. Today it's a little off to the right on desktop, left on mobile.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
