### PR TITLE
Move logger options to Hydrogen config

### DIFF
--- a/.changeset/rotten-nails-complain.md
+++ b/.changeset/rotten-nails-complain.md
@@ -1,0 +1,44 @@
+---
+'@shopify/hydrogen': minor
+---
+
+The `setLogger` and `setLoggerOptions` utilities have been removed. The same information can now be passed under the `logger` property in Hydrogen config:
+
+```diff
+// App.server.jsx
+
+-import {setLogger, setLoggerOptions} from '@shopify/hydrogen';
+
+-setLogger({
+-  trace() {},
+-  error() {},
+-  // ...
+-});
+
+-setLoggerOptions({
+-  showQueryTiming: true,
+-  showCacheControlHeader: true,
+-  // ...
+-});
+
+function App() {
+  // ...
+}
+
+export default renderHydrogen(App);
+```
+
+```diff
+// hydrogen.config.js
+
+export default defineConfig({
+  // ...
++ logger: {
++   trace() {},
++   error() {},
++   showQueryTiming: true,
++   showCacheControlHeader: true,
++   // ...
++ },
+});
+```

--- a/docs/framework/cache.md
+++ b/docs/framework/cache.md
@@ -161,7 +161,7 @@ To enable logging for the cache API status, set `logger.showCacheApiStatus` to `
 [Cache] MISS   query Localization
 ```
 
-To enable logging for cache control headers, set `logger.showCacheControlHeader` to `true` in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components). A cache control header report displays for each page request. The report includes the associated queries
+To enable logging for cache control headers, set `logger.showCacheControlHeader` to `true` in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger). A cache control header report displays for each page request. The report includes the associated queries
 that built the request and the cache control headers:
 
 ```sh

--- a/docs/framework/cache.md
+++ b/docs/framework/cache.md
@@ -152,25 +152,7 @@ export default defineConfig({
 
 {% endcodeblock %}
 
-To enable logging for the cache API status, call `setLoggerOptions` and set `showCacheApiStatus` to `true`:
-
-{% codeblock file, filename: '/src/App.server.jsx' %}
-
-```js
-import renderHydrogen from '@shopify/hydrogen/entry-server';
-import {setLoggerOptions} from '@shopify/hydrogen';
-
-setLoggerOptions({showCacheApiStatus: true});
-
-function App() {
-  /* ... */
-}
-// ...
-```
-
-{% endcodeblock %}
-
-The status of the cache updates on each query:
+To enable logging for the cache API status, set `logger.showCacheApiStatus` to `true` in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger). The status of the cache updates on each query:
 
 ```sh
 [Cache] MISS   query shopInfo
@@ -179,25 +161,7 @@ The status of the cache updates on each query:
 [Cache] MISS   query Localization
 ```
 
-To enable logging for cache control headers, call `setLoggerOptions` and set `showCacheControlHeader` to `true`:
-
-{% codeblock file, filename: '/src/App.server.jsx' %}
-
-```js
-import renderHydrogen from '@shopify/hydrogen/entry-server';
-import {setLoggerOptions} from '@shopify/hydrogen';
-
-setLoggerOptions({showCacheControlHeader: true});
-
-function App() {
-  /* ... */
-}
-// ...
-```
-
-{% endcodeblock %}
-
-A cache control header report displays for each page request. The report includes the associated queries
+To enable logging for cache control headers, set `logger.showCacheControlHeader` to `true` in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/react-server-components). A cache control header report displays for each page request. The report includes the associated queries
 that built the request and the cache control headers:
 
 ```sh

--- a/docs/framework/cache.md
+++ b/docs/framework/cache.md
@@ -152,7 +152,7 @@ export default defineConfig({
 
 {% endcodeblock %}
 
-To enable logging for the cache API status, set `logger.showCacheApiStatus` to `true` in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger). The status of the cache updates on each query:
+To enable logging for the cache API status, set `logger.showCacheApiStatus` to `true` in your [Hydrogen configuration file](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger). The status of the cache updates on each query:
 
 ```sh
 [Cache] MISS   query shopInfo
@@ -161,7 +161,7 @@ To enable logging for the cache API status, set `logger.showCacheApiStatus` to `
 [Cache] MISS   query Localization
 ```
 
-To enable logging for cache control headers, set `logger.showCacheControlHeader` to `true` in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger). A cache control header report displays for each page request. The report includes the associated queries
+To enable logging for cache control headers, set `logger.showCacheControlHeader` to `true` in your [Hydrogen configuration file](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger). A cache control header report displays for each page request. The report includes the associated queries
 that built the request and the cache control headers:
 
 ```sh

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -212,18 +212,18 @@ export default defineConfig({
 
 ## Logger
 
-The [`log` utility](https://shopify.dev/api/hydrogen/utilities/log)'s default behavior is mapping to the global `console` object. However, this behavior can be customized in the configuration object.
+The default behavior of the [`log` utility](https://shopify.dev/api/hydrogen/utilities/log) maps to the global `console` object. However, you can also customize this behavior in the configuration object.
 
-Pass [any method](https://shopify.dev/api/hydrogen/utilities/log#methods) of the `log` utility in the `logger` object to override it. The first argument of each log method will contain a `request` object if the log was called in the same context as a request. Aside from that, the following boolean options are also available:
+You can pass [any method](https://shopify.dev/api/hydrogen/utilities/log#methods) of the `log` utility in the `logger` object to override the default behavior. The first argument of each log method contains a `request` object if the log was called in the same context as a request. The following Boolean options are also available:
 
 {% codeblock file, filename: 'hydrogen.config.ts' %}
 
 ```tsx
 export default defineConfig({
   logger: {
-    /* Overrides the default `log.trace` behavior */
+    /* Overrides the default `log.trace` behavior. */
     trace: (request, ...args) => console.log(request.url, ...args),
-    /* Overrides the default `log.error` behavior */
+    /* Overrides the default `log.error` behavior. */
     error: (request, error) => myErrorTrackingService.send(error, {request}),
     /* ... */
 

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -44,6 +44,7 @@ The following groupings of configuration properties can exist in Hydrogen:
 - [`session`](#session)
 - [`serverAnalyticsConnectors`](#serveranalyticsconnectors)
 - [`enableStreaming`](#enablestreaming)
+- [`logger`](#logger)
 
 ### `routes`
 
@@ -208,6 +209,37 @@ export default defineConfig({
 
 > Tip:
 > There are [performance benefits](https://shopify.dev/custom-storefronts/hydrogen/best-practices/performance) to streaming. You shouldn't completely disable streaming for all of your storefront's routes.
+
+## Logger
+
+The [`log` utility](https://shopify.dev/api/hydrogen/utilities/log)'s default behavior is mapping to the global `console` object. However, this behavior can be customized in the configuration object.
+
+Pass [any method](https://shopify.dev/api/hydrogen/utilities/log#methods) of the `log` utility in the `logger` object to override it. The first argument of each log method will contain a `request` object if the log was called in the same context as a request. Aside from that, the following boolean options are also available:
+
+{% codeblock file, filename: 'hydrogen.config.ts' %}
+
+```tsx
+export default defineConfig({
+  logger: {
+    /* Overrides the default `log.trace` behavior */
+    trace: (request, ...args) => console.log(request.url, ...args),
+    /* Overrides the default `log.error` behavior */
+    error: (request, error) => myErrorTrackingService.send(error, {request}),
+    /* ... */
+
+    /* Logs the cache status of each stored entry: `PUT`, `HIT`, `MISS` or `STALE`. */
+    showCacheApiStatus: true,
+    /* Logs the cache control headers of the main document and its sub queries. */
+    showCacheControlHeader: true,
+    /* Logs the timeline of when queries are being requested, resolved, and rendered. */
+    showQueryTiming: true,
+    /* Logs warnings in your app if you're over-fetching data from the Storefront API. */
+    showUnusedQueryProperties: true,
+  }
+});
+```
+
+{% endcodeblock %}
 
 ## Changing the configuration file location
 

--- a/docs/framework/preloaded-queries.md
+++ b/docs/framework/preloaded-queries.md
@@ -101,21 +101,9 @@ const data = fetchSync('https://my.api.com/data.json', {
 
 ## Test a preloaded query
 
-To test a preloaded query, enable the `showQueryTiming` property in `App.server.js`. The [`showQueryTiming`](https://shopify.dev/api/hydrogen/utilities/log#logger-options) property logs the timeline of when queries are being requested, resolved, and rendered.
+To test a preloaded query, enable the `logger.showQueryTiming` property in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger).
 
-{% codeblock file, filename: "App.server.js" %}
-
-```js
-import {setLoggerOptions} from '@shopify/hydrogen';
-...
-setLoggerOptions({
-  showQueryTiming: true
-})
-```
-
-{% endcodeblock %}
-
-If a query is preloaded, but isn't being used, then a warning displays in the server log:
+The [`showQueryTiming`](https://shopify.dev/api/hydrogen/utilities/log#logger-options) property logs the timeline of when queries are being requested, resolved, and rendered. If a query is preloaded, but isn't being used, then a warning displays in the server log:
 
 ![Shows a screenshot of preloaded query warning](/assets/custom-storefronts/hydrogen/preload-query-warning.png)
 

--- a/docs/framework/preloaded-queries.md
+++ b/docs/framework/preloaded-queries.md
@@ -101,7 +101,7 @@ const data = fetchSync('https://my.api.com/data.json', {
 
 ## Test a preloaded query
 
-To test a preloaded query, enable the `logger.showQueryTiming` property in [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger).
+To test a preloaded query, enable the `logger.showQueryTiming` property in your [Hydrogen configuration file](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger).
 
 The [`showQueryTiming`](https://shopify.dev/api/hydrogen/utilities/log#logger-options) property logs the timeline of when queries are being requested, resolved, and rendered. If a query is preloaded, but isn't being used, then a warning displays in the server log:
 

--- a/docs/utilities/log.md
+++ b/docs/utilities/log.md
@@ -22,13 +22,9 @@ export default function Product({country = {isoCode: 'US'}, log}) {
 }
 ```
 
-## Arguments
+## Methods
 
-None
-
-## Return type
-
-Return an object with methods for logging information at different priorities:
+The `log` utility exposes the following methods for logging information at different priorities:
 
 | Log method    | Description                                                                       |
 | ------------- | --------------------------------------------------------------------------------- |
@@ -38,52 +34,7 @@ Return an object with methods for logging information at different priorities:
 | `log.error()` | The logging used for errors or invalid application state.                         |
 | `log.fatal()` | The logging used just prior to the process exiting.                               |
 
-## Logger options
+## Swap logger implementation and options
 
-Logger has the following Boolean options:
+Hydrogen includes a default logger implementation that can be swapped for a logger of your choice. It is also possible to show debug information for cache and queries by providing extra options. See [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger) for more information.
 
-| Option                      | Description                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------- |
-| `showCacheApiStatus`        | Logs the cache status of each stored entry: `PUT`, `HIT`, `MISS` or `STALE`.    |
-| `showCacheControlHeader`    | Logs the cache control headers of the main document and its sub queries.        |
-| `showQueryTiming`           | Logs the timeline of when queries are being requested, resolved, and rendered.  |
-| `showUnusedQueryProperties` | Logs warnings in your app if you're over-fetching data from the Storefront API. |
-
-### Example
-
-```js
-import {setLoggerOptions} from '@shopify/hydrogen';
-
-setLoggerOptions({
-  showCacheApiStatus: true,
-  showCacheControlHeader: true,
-  showQueryTiming: true,
-  showUnusedQueryProperties: true,
-});
-```
-
-## Swap logger implementation
-
-Hydrogen includes a default logger implementation that can be swapped for a logger of your choice. You can call `setLogger` with your own implementation. The first argument of each log method will contain a `request` object if the log was called in the same context as a request:
-
-```js
-import {setLogger} from '@shopify/hydrogen';
-
-setLogger({
-  trace(request, ...args) {
-    // Call your own logger.
-  },
-  debug(request, ...args) {
-    // Call your own logger.
-  },
-  warn(request, ...args) {
-    // Call your own logger.
-  },
-  error(request, ...args) {
-    // Call your own logger.
-  },
-  fatal(request, ...args) {
-    // Call your own logger.
-  },
-});
-```

--- a/docs/utilities/log.md
+++ b/docs/utilities/log.md
@@ -36,5 +36,5 @@ The `log` utility exposes the following methods for logging information at diffe
 
 ## Swap logger implementation and options
 
-Hydrogen includes a default logger implementation that can be swapped for a logger of your choice. It is also possible to show debug information for cache and queries by providing extra options. See [Hydrogen config](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger) for more information.
+Hydrogen includes a default logger implementation that can be swapped for a logger of your choice. You can also show debugging information for cache and queries by providing extra options. For more information, refer to [Hydrogen configuration](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger).
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -42,7 +42,7 @@ import {
 } from './streaming.server';
 import {RSC_PATHNAME, EVENT_PATHNAME, EVENT_PATHNAME_REGEX} from './constants';
 import {stripScriptsFromTemplate} from './utilities/template';
-import {RenderType} from './utilities/log/log';
+import {setLogger, RenderType} from './utilities/log/log';
 import {Analytics} from './foundation/Analytics/Analytics.server';
 import {ServerAnalyticsRoute} from './foundation/Analytics/ServerAnalyticsRoute.server';
 import {getSyncSessionApi} from './foundation/session/session';
@@ -112,6 +112,10 @@ export const renderHydrogen = (App: any) => {
 
     request.ctx.hydrogenConfig = hydrogenConfig;
     request.ctx.buyerIpHeader = buyerIpHeader;
+
+    if (hydrogenConfig.logger) {
+      setLogger(hydrogenConfig.logger);
+    }
 
     const response = new ServerComponentResponse();
     const log = getLoggerWithContext(request);

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -113,12 +113,10 @@ export const renderHydrogen = (App: any) => {
     request.ctx.hydrogenConfig = hydrogenConfig;
     request.ctx.buyerIpHeader = buyerIpHeader;
 
-    if (hydrogenConfig.logger) {
-      setLogger(hydrogenConfig.logger);
-    }
+    setLogger(hydrogenConfig.logger);
+    const log = getLoggerWithContext(request);
 
     const response = new ServerComponentResponse();
-    const log = getLoggerWithContext(request);
     const sessionApi = hydrogenConfig.session
       ? hydrogenConfig.session(log)
       : undefined;

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -17,7 +17,7 @@ export * from './foundation/useServerProps';
 export {FileRoutes} from './foundation/FileRoutes/FileRoutes.server';
 export {Route} from './foundation/Route/Route.server';
 export {Router} from './foundation/Router/Router.server';
-export {log, setLogger, setLoggerOptions, Logger} from './utilities/log';
+export {log, type Logger} from './utilities/log';
 export {LocalizationProvider} from './components/LocalizationProvider/LocalizationProvider.server';
 export {ShopifyProvider} from './foundation/ShopifyProvider/ShopifyProvider.server';
 export {

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -1,5 +1,5 @@
 import type {ServerResponse} from 'http';
-import type {Logger} from './utilities/log/log';
+import type {Logger, LoggerConfig} from './utilities/log/log';
 import type {ServerComponentRequest} from './framework/Hydration/ServerComponentRequest.server';
 import type {ServerComponentResponse} from './framework/Hydration/ServerComponentResponse.server';
 import type {
@@ -84,6 +84,7 @@ export type InlineHydrogenConfig = {
   routes?: InlineHydrogenRoutes;
   shopify?: ShopifyConfig | ShopifyConfigFetcher;
   serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>;
+  logger?: LoggerConfig;
   session?: (log: Logger) => SessionStorageAdapter;
   enableStreaming?: (request: ServerComponentRequest) => boolean;
 };

--- a/packages/hydrogen/src/utilities/log/__tests__/log-cache-api-status.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-cache-api-status.test.ts
@@ -1,10 +1,4 @@
-import {
-  Logger,
-  setLogger,
-  logCacheApiStatus,
-  resetLogger,
-  setLoggerOptions,
-} from '../index';
+import {Logger, setLogger, logCacheApiStatus, resetLogger} from '../index';
 
 let mockLogger: jest.Mocked<Logger>;
 
@@ -19,10 +13,7 @@ describe('cache header log', () => {
       options: jest.fn(() => ({})),
     };
 
-    setLogger(mockLogger);
-    setLoggerOptions({
-      showCacheApiStatus: true,
-    });
+    setLogger({...mockLogger, showCacheApiStatus: true});
   });
 
   afterEach(() => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log-cache-api-status.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-cache-api-status.test.ts
@@ -1,4 +1,4 @@
-import {Logger, setLogger, logCacheApiStatus, resetLogger} from '../index';
+import {Logger, setLogger, logCacheApiStatus} from '../index';
 
 let mockLogger: jest.Mocked<Logger>;
 
@@ -17,7 +17,7 @@ describe('cache header log', () => {
   });
 
   afterEach(() => {
-    resetLogger();
+    setLogger(undefined);
   });
 
   it('should log cache api status', () => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log-cache-header.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-cache-header.test.ts
@@ -3,7 +3,6 @@ import {
   setLogger,
   logCacheControlHeaders,
   collectQueryCacheControlHeaders,
-  resetLogger,
 } from '../index';
 import {ServerComponentRequest} from '../../../framework/Hydration/ServerComponentRequest.server';
 import {ServerComponentResponse} from '../../../framework/Hydration/ServerComponentResponse.server';
@@ -29,7 +28,7 @@ describe('cache header log', () => {
   });
 
   afterEach(() => {
-    resetLogger();
+    setLogger(undefined);
   });
 
   it('should log cache control header for main request', () => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log-cache-header.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-cache-header.test.ts
@@ -4,7 +4,6 @@ import {
   logCacheControlHeaders,
   collectQueryCacheControlHeaders,
   resetLogger,
-  setLoggerOptions,
 } from '../index';
 import {ServerComponentRequest} from '../../../framework/Hydration/ServerComponentRequest.server';
 import {ServerComponentResponse} from '../../../framework/Hydration/ServerComponentResponse.server';
@@ -26,10 +25,7 @@ describe('cache header log', () => {
       options: jest.fn(() => ({})),
     };
 
-    setLogger(mockLogger);
-    setLoggerOptions({
-      showCacheControlHeader: true,
-    });
+    setLogger({...mockLogger, showCacheControlHeader: true});
   });
 
   afterEach(() => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log-query-timeline.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-query-timeline.test.ts
@@ -1,5 +1,5 @@
 import {ServerComponentRequest} from '../../../framework/Hydration/ServerComponentRequest.server';
-import {Logger, setLogger, resetLogger} from '../log';
+import {Logger, setLogger} from '../log';
 import {collectQueryTimings, logQueryTimings} from '../log-query-timeline';
 
 let mockLogger: jest.Mocked<Logger>;
@@ -40,7 +40,7 @@ describe('cache header log', () => {
   });
 
   afterEach(() => {
-    resetLogger();
+    setLogger(undefined);
   });
 
   it('should log query timing', () => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log-query-timeline.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-query-timeline.test.ts
@@ -1,5 +1,5 @@
 import {ServerComponentRequest} from '../../../framework/Hydration/ServerComponentRequest.server';
-import {Logger, setLogger, resetLogger, setLoggerOptions} from '../index';
+import {Logger, setLogger, resetLogger} from '../log';
 import {collectQueryTimings, logQueryTimings} from '../log-query-timeline';
 
 let mockLogger: jest.Mocked<Logger>;
@@ -36,10 +36,7 @@ describe('cache header log', () => {
       options: jest.fn(() => ({})),
     };
 
-    setLogger(mockLogger);
-    setLoggerOptions({
-      showQueryTiming: true,
-    });
+    setLogger({...mockLogger, showQueryTiming: true});
   });
 
   afterEach(() => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log.test.ts
@@ -4,7 +4,6 @@ import {
   Logger,
   logServerResponse,
   getLoggerWithContext,
-  resetLogger,
 } from '../log';
 import {ServerComponentRequest} from '../../../framework/Hydration/ServerComponentRequest.server';
 
@@ -28,7 +27,7 @@ describe('log', () => {
   });
 
   afterEach(() => {
-    resetLogger();
+    setLogger(undefined);
   });
 
   it('should return the wrapped mockLogger instance when log is called', () => {

--- a/packages/hydrogen/src/utilities/log/__tests__/log.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log.test.ts
@@ -7,7 +7,6 @@ import {
   resetLogger,
 } from '../log';
 import {ServerComponentRequest} from '../../../framework/Hydration/ServerComponentRequest.server';
-import {setLoggerOptions} from '..';
 
 let mockLogger: jest.Mocked<Logger>;
 
@@ -47,11 +46,10 @@ describe('log', () => {
       warn: jest.fn(),
       error: jest.fn(),
       fatal: jest.fn(),
-      options: jest.fn(() => ({
-        showCacheControlHeader: true,
-      })),
+      options: jest.fn(() => ({})),
     };
-    setLogger(mockLogger2);
+
+    setLogger({...mockLogger2, showCacheControlHeader: true});
 
     log.debug('test');
     expect(mockLogger2.debug).toHaveBeenCalled();
@@ -62,17 +60,15 @@ describe('log', () => {
     expect(mockLogger2.debug.mock.calls[0][1]).toEqual('test');
   });
 
-  it('should set showCacheControlHeader option when setLoggerOptions is called', () => {
-    setLoggerOptions({
-      showCacheControlHeader: true,
-    });
+  it('should set showCacheControlHeader option correctly', () => {
+    setLogger({showCacheControlHeader: true});
     expect(log.options()).toEqual({
       showCacheControlHeader: true,
     });
   });
 
-  it('should set showCacheApiStatus option when setLoggerOptions is called', () => {
-    setLoggerOptions({
+  it('should set showCacheApiStatus option correctly', () => {
+    setLogger({
       showCacheApiStatus: true,
     });
     expect(log.options()).toEqual({
@@ -80,14 +76,14 @@ describe('log', () => {
     });
   });
 
-  it('should return the correct options when setLoggerOptions is set multiple times', () => {
-    setLoggerOptions({
+  it('should set multiple options correctly', () => {
+    setLogger({
       showCacheControlHeader: true,
     });
     expect(log.options()).toEqual({
       showCacheControlHeader: true,
     });
-    setLoggerOptions({
+    setLogger({
       showCacheApiStatus: true,
       showCacheControlHeader: true,
     });

--- a/packages/hydrogen/src/utilities/log/index.ts
+++ b/packages/hydrogen/src/utilities/log/index.ts
@@ -4,7 +4,6 @@ export {
   getLoggerWithContext,
   Logger,
   logServerResponse,
-  resetLogger,
 } from './log';
 export {
   collectQueryCacheControlHeaders,

--- a/packages/hydrogen/src/utilities/log/index.ts
+++ b/packages/hydrogen/src/utilities/log/index.ts
@@ -1,7 +1,6 @@
 export {
   log,
   setLogger,
-  setLoggerOptions,
   getLoggerWithContext,
   Logger,
   logServerResponse,

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -65,7 +65,12 @@ export function getLoggerWithContext(context: any): Logger {
 
 export const log: Logger = getLoggerWithContext({});
 
-export function setLogger(config: LoggerConfig) {
+export function setLogger(config?: LoggerConfig) {
+  if (!config) {
+    currentLogger = defaultLogger;
+    return;
+  }
+
   const options = {} as LoggerOptions;
   currentLogger = {...defaultLogger, ...config, options: () => options};
 
@@ -75,11 +80,6 @@ export function setLogger(config: LoggerConfig) {
       options[key] = config[key];
     }
   }
-}
-
-// For tests
-export function resetLogger() {
-  currentLogger = defaultLogger;
 }
 
 const SERVER_RESPONSE_MAP: Record<string, string> = {

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -29,22 +29,21 @@ export type LoggerConfig = Partial<Exclude<Logger, 'options'>> & LoggerOptions;
 
 export type RenderType = 'str' | 'rsc' | 'ssr' | 'api';
 
-type LoggerContext = Record<string, any>;
-const defaultLogger = {
-  trace(context: LoggerContext, ...args: Array<any>) {
+const defaultLogger: Logger = {
+  trace(context, ...args) {
     // Re-enable following line to show trace debugging information
     // console.log(context.id, ...args);
   },
-  debug(context: LoggerContext, ...args: Array<any>) {
+  debug(context, ...args) {
     console.log(...args);
   },
-  warn(context: LoggerContext, ...args: Array<any>) {
+  warn(context, ...args) {
     console.warn(yellow('WARN: '), ...args);
   },
-  error(context: LoggerContext, ...args: Array<any>) {
+  error(context, ...args) {
     console.error(red('ERROR: '), ...args);
   },
-  fatal(context: LoggerContext, ...args: Array<any>) {
+  fatal(context, ...args) {
     console.error(red('FATAL: '), ...args);
   },
   options: () => ({} as LoggerOptions),

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -25,10 +25,12 @@ export type LoggerOptions = {
   showUnusedQueryProperties?: boolean;
 };
 
+export type LoggerConfig = Partial<Exclude<Logger, 'options'>> & LoggerOptions;
+
 export type RenderType = 'str' | 'rsc' | 'ssr' | 'api';
 
 type LoggerContext = Record<string, any>;
-export const defaultLogger = {
+const defaultLogger = {
   trace(context: LoggerContext, ...args: Array<any>) {
     // Re-enable following line to show trace debugging information
     // console.log(context.id, ...args);
@@ -63,14 +65,19 @@ export function getLoggerWithContext(context: any): Logger {
 
 export const log: Logger = getLoggerWithContext({});
 
-export function setLogger(newLogger: Logger) {
-  currentLogger = newLogger;
+export function setLogger(config: LoggerConfig) {
+  const options = {} as LoggerOptions;
+  currentLogger = {...defaultLogger, ...config, options: () => options};
+
+  for (const key of Object.keys(config) as (keyof LoggerOptions)[]) {
+    if (!(key in defaultLogger)) {
+      delete currentLogger[key as keyof Logger];
+      options[key] = config[key];
+    }
+  }
 }
 
-export function setLoggerOptions(options: LoggerOptions) {
-  setLogger({...currentLogger, options: () => options});
-}
-
+// For tests
 export function resetLogger() {
   currentLogger = defaultLogger;
 }

--- a/packages/playground/async-config/hydrogen.config.js
+++ b/packages/playground/async-config/hydrogen.config.js
@@ -16,4 +16,8 @@ export default defineConfig({
       storefrontApiVersion: '2022-07',
     };
   },
+  logger: {
+    trace() {},
+    debug() {},
+  },
 });

--- a/packages/playground/async-config/src/App.server.jsx
+++ b/packages/playground/async-config/src/App.server.jsx
@@ -1,27 +1,6 @@
 import renderHydrogen from '@shopify/hydrogen/entry-server';
-import {
-  Router,
-  FileRoutes,
-  ShopifyProvider,
-  setLogger,
-  useUrl,
-} from '@shopify/hydrogen';
+import {Router, FileRoutes, ShopifyProvider, useUrl} from '@shopify/hydrogen';
 import {Suspense} from 'react';
-
-setLogger({
-  trace() {},
-  debug() {},
-  warn(context, ...args) {
-    console.warn(...args);
-  },
-  error(context, ...args) {
-    console.error(...args);
-  },
-  fatal(context, ...args) {
-    console.error(...args);
-  },
-  options: () => ({}),
-});
 
 let localeRedirects;
 

--- a/packages/playground/server-components/hydrogen.config.js
+++ b/packages/playground/server-components/hydrogen.config.js
@@ -14,4 +14,8 @@ export default defineConfig({
   enableStreaming: (req) => {
     return req.headers.get('user-agent') !== 'custom bot';
   },
+  logger: {
+    trace() {},
+    debug() {},
+  },
 });

--- a/packages/playground/server-components/src/App.server.jsx
+++ b/packages/playground/server-components/src/App.server.jsx
@@ -1,31 +1,10 @@
 import renderHydrogen from '@shopify/hydrogen/entry-server';
-import {
-  Route,
-  Router,
-  FileRoutes,
-  ShopifyProvider,
-  setLogger,
-} from '@shopify/hydrogen';
+import {Route, Router, FileRoutes, ShopifyProvider} from '@shopify/hydrogen';
 import {Suspense} from 'react';
 import Custom1 from './customRoutes/custom1.server';
 import Custom2 from './customRoutes/custom2.server';
 import LazyRoute from './customRoutes/lazyRoute.server';
 import ServerParams from './customRoutes/params.server';
-
-setLogger({
-  trace() {},
-  debug() {},
-  warn(context, ...args) {
-    console.warn(...args);
-  },
-  error(context, ...args) {
-    console.error(...args);
-  },
-  fatal(context, ...args) {
-    console.error(...args);
-  },
-  options: () => ({}),
-});
 
 export default renderHydrogen(() => {
   return (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1260 

This moves the logger options to the Hydrogen config as mentioned in https://github.com/Shopify/hydrogen/issues/948#issuecomment-1075231306 and removes `setLogger` and `setLoggerOptions` from the public API. I've also changed the logger implementation a bit since I think we don't need some stuff there anymore (e.g. `globalThis.__logger`, which was a workaround that is not necessary anymore).

Differences with the previous behavior:
- You don't need to pass **all** the logger hooks when swapping the implementation anymore. It now falls back to `defaultLogger` when a hook is missing.

I wasn't sure what to do with the docs... I've moved part of `log.md` to `hydrogen-config.md` but I can revert it if you have better ideas.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
