### PR TITLE
Move client options to Hydrogen config

### DIFF
--- a/.changeset/spicy-pans-turn.md
+++ b/.changeset/spicy-pans-turn.md
@@ -1,0 +1,30 @@
+---
+'@shopify/hydrogen': minor
+---
+
+The client configuration, including the `strictMode` option, has been moved from custom client entry handlers to the Hydrogen configuration file. If you had a custom client entry file just to pass client options, you can remove it and do the same in `hydrogen.config.js`:
+
+```diff
+// Custom client entry handler
+
+-renderHydrogen(ClientWrapper, {strictMode: false});
++renderHydrogen(ClientWrapper);
+```
+
+```diff
+// hydrogen.config.jsx
+
+export default defineConfig({
++  strictMode: false,
+});
+```
+
+To remove a custom client entry handler in case it's not needed anymore, delete the custom file and change `index.html`:
+
+```diff
+<body>
+  <div id="root"></div>
+- <script type="module" src="/src/custom-client-entry"></script>
++ <script type="module" src="/@shopify/hydrogen/entry-client"></script>
+</body>
+```

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -45,6 +45,7 @@ The following groupings of configuration properties can exist in Hydrogen:
 - [`serverAnalyticsConnectors`](#serveranalyticsconnectors)
 - [`enableStreaming`](#enablestreaming)
 - [`logger`](#logger)
+- [`strictMode`](#strictmode)
 
 ### `routes`
 
@@ -240,6 +241,25 @@ export default defineConfig({
 ```
 
 {% endcodeblock %}
+
+### `strictMode`
+
+[Strict mode](https://reactjs.org/docs/strict-mode.html) is enabled by default for all Hydrogen apps in development. It includes [strict effects](https://github.com/reactwg/react-18/discussions/19), which mounts and unmounts components multiple times to catch potential issues with user or third-party code.
+
+If strict effects cause problems for your app, then you can turn off strict mode.
+
+{% codeblock file, filename: 'hydrogen.config.ts' %}
+
+```tsx
+export default defineConfig({
+  strictMode: false, 
+});
+```
+
+{% endcodeblock %}
+
+> Caution:
+> If you turn off strict mode, then we recommended that you still include the `StrictMode` component at as high of a level as possible in your React tree to catch errors.
 
 ## Changing the configuration file location
 

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -80,23 +80,6 @@ export default renderHydrogen(ClientWrapper);
 
 {% endcodeblock %}
 
-#### Strict mode
-
-[Strict mode](https://reactjs.org/docs/strict-mode.html) is enabled by default for all Hydrogen apps in development. It includes [strict effects](https://github.com/reactwg/react-18/discussions/19), which mounts and unmounts components multiple times to catch potential issues with user or third-party code.
-
-If strict effects cause problems for your app, then you can turn off strict mode. Create a `src/entry-client.jsx` file in your project and set `strictMode` to `false`:
-
-{% codeblock file, filename: 'src/entry-client.jsx' %}
-
-```jsx
-renderHydrogen(ClientWrapper, {strictMode: false});
-```
-
-{% endcodeblock %}
-
-> Caution:
-> If you turn off strict mode, then we recommended that you still include the `StrictMode` component at as high of a level as possible in your React tree to catch errors.
-
 ### Change the server entry point
 
 If you need to change the server entry point, then make the following updates in the `package.json` file:

--- a/packages/hydrogen/src/components/DevTools.client.tsx
+++ b/packages/hydrogen/src/components/DevTools.client.tsx
@@ -102,6 +102,7 @@ export default function DevTools() {
   if (import.meta.env.DEV && hasMounted) {
     return (
       <div
+        id="hydrogen-dev-tools"
         style={{
           position: 'fixed',
           right: open ? 0 : '2em',

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -6,7 +6,7 @@ import React, {
   type ElementType,
 } from 'react';
 import {hydrateRoot} from 'react-dom/client';
-import type {ClientHandler} from './types';
+import type {ClientConfig, ClientHandler} from './types';
 import {ErrorBoundary} from 'react-error-boundary';
 import {useServerResponse} from './framework/Hydration/rsc';
 import {ServerPropsProvider} from './foundation/ServerPropsProvider';
@@ -15,7 +15,7 @@ import type {LocationServerProps} from './foundation/ServerPropsProvider/ServerP
 
 const DevTools = React.lazy(() => import('./components/DevTools.client'));
 
-const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
+const renderHydrogen: ClientHandler = async (ClientWrapper) => {
   const root = document.getElementById('root');
 
   if (!root) {
@@ -33,8 +33,22 @@ const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
     });
   }
 
-  // default to StrictMode on, unless explicitly turned off
-  const RootComponent = config?.strictMode !== false ? StrictMode : Fragment;
+  let config: ClientConfig;
+  try {
+    config = JSON.parse(root.dataset.clientConfig ?? '{}');
+  } catch (error: any) {
+    config = {};
+    if (__DEV__) {
+      console.warn(
+        'Could not parse client configuration in browser',
+        error.message
+      );
+    }
+  }
+
+  const RootComponent =
+    // Default to StrictMode on, unless explicitly turned off
+    config.strictMode !== false ? StrictMode : Fragment;
 
   let hasCaughtError = false;
 
@@ -48,7 +62,7 @@ const renderHydrogen: ClientHandler = async (ClientWrapper, config) => {
           </Suspense>
         </ErrorBoundary>
       </RootComponent>
-      {typeof DevTools !== 'undefined' && config?.showDevTools ? (
+      {typeof DevTools !== 'undefined' && config.showDevTools ? (
         <DevTools />
       ) : null}
     </>,

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -273,7 +273,10 @@ async function runSSR({
     stripScriptsFromTemplate(template);
 
   const AppSSR = (
-    <Html template={response.canStream() ? noScriptTemplate : template}>
+    <Html
+      template={response.canStream() ? noScriptTemplate : template}
+      hydrogenConfig={request.ctx.hydrogenConfig!}
+    >
       <ServerRequestProvider request={request} isRSC={false}>
         <ServerPropsProvider
           initialServerProps={state as any}

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -80,7 +80,7 @@ export type ServerAnalyticsConnector = {
   ) => void;
 };
 
-export type InlineHydrogenConfig = {
+export type InlineHydrogenConfig = ClientConfig & {
   routes?: InlineHydrogenRoutes;
   shopify?: ShopifyConfig | ShopifyConfigFetcher;
   serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>;
@@ -93,7 +93,7 @@ export type ResolvedHydrogenConfig = Omit<InlineHydrogenConfig, 'routes'> & {
   routes: ResolvedHydrogenRoutes;
 };
 
-export type ClientHandlerConfig = {
+export type ClientConfig = {
   /** React's StrictMode is on by default for your client side app; if you want to turn it off (not recommended), you can pass `false` */
   strictMode?: boolean;
   showDevTools?: boolean;
@@ -101,7 +101,7 @@ export type ClientHandlerConfig = {
 
 export type ClientHandler = (
   App: React.ElementType,
-  config: ClientHandlerConfig
+  config: ClientConfig
 ) => Promise<void>;
 
 export interface GraphQLConnection<T> {

--- a/packages/playground/async-config/hydrogen.config.js
+++ b/packages/playground/async-config/hydrogen.config.js
@@ -20,4 +20,5 @@ export default defineConfig({
     trace() {},
     debug() {},
   },
+  showDevTools: true,
 });

--- a/packages/playground/async-config/tests/e2e-test-cases.ts
+++ b/packages/playground/async-config/tests/e2e-test-cases.ts
@@ -44,6 +44,15 @@ export default async function testCases({
     await page.goto(getServerUrl() + '/es/products');
     expect(await page.url()).toContain('/es/productos');
   });
+
+  if (!isBuild) {
+    it('sends client configuration to the browser and picks it', async () => {
+      await page.goto(getServerUrl());
+      expect(await page.textContent('h1')).toContain('Home');
+
+      expect(await page.locator('#hydrogen-dev-tools').isHidden()).toBeFalsy();
+    });
+  }
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1261

Instead of using a global in `window` object, this inlines the config as an attribute of the root element. If no options are passed, the attribute is omitted.
Any downside to this?

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
