### PR TITLE
Allow scroll restoration to be disabled

### DIFF
--- a/.changeset/cool-spies-study.md
+++ b/.changeset/cool-spies-study.md
@@ -10,11 +10,16 @@ However, if you are building a user interface that should fetch a new server com
 
 ```jsx
 import {Link} from '@shopify/hydrogen';
-export default function Index() {
+export default function Index({request}) {
+  const url = new URL(request.normalizedUrl);
+
   return (
-    <Link to="/?new=param" restoreScroll={false}>
-      Update page
-    </Link>
+    <>
+      <p>Current param is: {url.searchParams.get('param')}</p>
+      <Link to="/?param=foo" restoreScroll={false}>
+        Update param to foo
+      </Link>
+    </>
   );
 }
 ```

--- a/.changeset/cool-spies-study.md
+++ b/.changeset/cool-spies-study.md
@@ -1,0 +1,20 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add `restoreScroll` prop to `Link` and `navigate` to allow the scroll restoration behavior to be disabled.
+
+By default, when a `<Link>` component is clicked, Hydrogen emulates default browser behavior and attempts to restore the scroll position previously used in the visitor's session. For new pages, this defaults to scrolling to the top of the page.
+
+However, if you are building a user interface that should fetch a new server components request and update the URL but not modify scroll position, then you can disable scroll restoration using the `restoreScroll` prop:
+
+```jsx
+import {Link} from '@shopify/hydrogen';
+export default function Index() {
+  return (
+    <Link to="/?new=param" restoreScroll={false}>
+      Update page
+    </Link>
+  );
+}
+```

--- a/.changeset/cool-spies-study.md
+++ b/.changeset/cool-spies-study.md
@@ -2,11 +2,11 @@
 '@shopify/hydrogen': minor
 ---
 
-Add `restoreScroll` prop to `Link` and `navigate` to allow the scroll restoration behavior to be disabled.
+Add `scroll` prop to `Link` and `navigate` to allow the scroll restoration behavior to be disabled.
 
 By default, when a `<Link>` component is clicked, Hydrogen emulates default browser behavior and attempts to restore the scroll position previously used in the visitor's session. For new pages, this defaults to scrolling to the top of the page.
 
-However, if you are building a user interface that should fetch a new server components request and update the URL but not modify scroll position, then you can disable scroll restoration using the `restoreScroll` prop:
+However, if you are building a user interface that should fetch a new server components request and update the URL but not modify scroll position, then you can disable scroll restoration using the `scroll` prop:
 
 ```jsx
 import {Link} from '@shopify/hydrogen';
@@ -16,7 +16,7 @@ export default function Index({request}) {
   return (
     <>
       <p>Current param is: {url.searchParams.get('param')}</p>
-      <Link to="/?param=foo" restoreScroll={false}>
+      <Link to="/?param=foo" scroll={false}>
         Update param to foo
       </Link>
     </>

--- a/docs/components/framework/link.md
+++ b/docs/components/framework/link.md
@@ -19,6 +19,24 @@ export default function Index() {
 
 {% endcodeblock %}
 
+## Scroll restoration
+
+By default, when a `<Link>` component is clicked, Hydrogen emulates default browser behavior and attempts to restore the scroll position previously used in the visitor's session. For new pages, this defaults to scrolling to the top of the page.
+
+However, if you are building a user interface that should fetch a new server components request and update the URL but not modify scroll position, then you can disable scroll restoration using the `restoreScroll` prop:
+
+
+{% codeblock file, filename: 'index.server.jsx' %}
+
+```jsx
+import {Link} from '@shopify/hydrogen';
+export default function Index() {
+  return <Link to="/?new=param" restoreScroll={false}>Update page</Link>;
+}
+```
+
+{% endcodeblock %}
+
 ## Props
 
 | Name            | Type                 | Description                                                                                                                                                                                                                                   |
@@ -28,6 +46,7 @@ export default function Index() {
 | clientState?    | <code>any</code>     | The custom client state with the navigation.                                                                                                                                                                                                  |
 | reloadDocument? | <code>boolean</code> | Whether to reload the whole document on navigation.                                                                                                                                                                                           |
 | prefetch?       | <code>boolean</code> | Whether to prefetch the link source when the user signals intent. Defaults to `true`. For more information, refer to [Prefetching a link source](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#prefetching-a-link-source). |
+| restoreScroll?  | <code>boolean</code> | Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to `true`.                                                                                                                                    |
 
 ## Component type
 

--- a/docs/components/framework/link.md
+++ b/docs/components/framework/link.md
@@ -21,10 +21,9 @@ export default function Index() {
 
 ## Scroll restoration
 
-By default, when a `<Link>` component is clicked, Hydrogen emulates default browser behavior and attempts to restore the scroll position previously used in the visitor's session. For new pages, this defaults to scrolling to the top of the page.
+By default, when you click a `<Link>` component, Hydrogen emulates default browser behavior and attempts to restore the scroll position that was previously used in the visitor's session. For new pages, the  `<Link>` component defaults to scrolling to the top of the page.
 
-However, if you are building a user interface that should fetch a new server components request and update the URL but not modify scroll position, then you can disable scroll restoration using the `restoreScroll` prop:
-
+However, if you want to build a user interface that re-renders server components and updates the URL, but doesn't modify the scroll position, then you can disable scroll restoration using the `scroll` prop:
 
 {% codeblock file, filename: 'index.server.jsx' %}
 
@@ -36,7 +35,7 @@ export default function Index({request}) {
   return (
     <>
       <p>Current param is: {url.searchParams.get('param')}</p>
-      <Link to="/?param=foo" restoreScroll={false}>
+      <Link to="/?param=foo" scroll={false}>
         Update param to foo
       </Link>
     </>
@@ -55,7 +54,7 @@ export default function Index({request}) {
 | clientState?    | <code>any</code>     | The custom client state with the navigation.                                                                                                                                                                                                  |
 | reloadDocument? | <code>boolean</code> | Whether to reload the whole document on navigation.                                                                                                                                                                                           |
 | prefetch?       | <code>boolean</code> | Whether to prefetch the link source when the user signals intent. Defaults to `true`. For more information, refer to [Prefetching a link source](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#prefetching-a-link-source). |
-| restoreScroll?  | <code>boolean</code> | Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to `true`.                                                                                                                                    |
+| scroll?         | <code>boolean</code> | Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to `true`.                                                                                                                                    |
 
 ## Component type
 

--- a/docs/components/framework/link.md
+++ b/docs/components/framework/link.md
@@ -30,8 +30,17 @@ However, if you are building a user interface that should fetch a new server com
 
 ```jsx
 import {Link} from '@shopify/hydrogen';
-export default function Index() {
-  return <Link to="/?new=param" restoreScroll={false}>Update page</Link>;
+export default function Index({request}) {
+  const url = new URL(request.normalizedUrl);
+
+  return (
+    <>
+      <p>Current param is: {url.searchParams.get('param')}</p>
+      <Link to="/?param=foo" restoreScroll={false}>
+        Update param to foo
+      </Link>
+    </>
+  );
 }
 ```
 

--- a/docs/hooks/framework/usenavigate.md
+++ b/docs/hooks/framework/usenavigate.md
@@ -27,24 +27,14 @@ export default function ClientComponent() {
 
 {% endcodeblock %}
 
-## Arguments
-
-The `useNavigate` hook takes the following arguments:
-
-| Argument        | Description                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------ |
-| replace?        | Whether to update the state object or URL of the current history entry. Defaults to false. |
-| reloadDocument? | Whether to reload the whole document on navigation.                                        |
-| clientState?    | The custom client state with the navigation.                                               |
-
 ## Return value
 
-The `useNavigate` hook returns the following values:
+The `useNavigate` hook returns a function which accepts the following values:
 
 | Name    | Description                                                                                                                                                                                                        |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | path    | The path you want to navigate to.                                                                                                                                                                                  |
-| options | The options for the configuration object: `replace`, `reloadDocument`, `clientState`. For more information the options, refer to the [Link component](https://shopify.dev/api/hydrogen/components/framework/link). |
+| options | The options for the configuration object: `replace`, `reloadDocument`, `clientState`, `restoreScroll`. For more information the options, refer to the [Link component](https://shopify.dev/api/hydrogen/components/framework/link). |
 
 ## Considerations
 

--- a/docs/hooks/framework/usenavigate.md
+++ b/docs/hooks/framework/usenavigate.md
@@ -31,10 +31,10 @@ export default function ClientComponent() {
 
 The `useNavigate` hook returns a function which accepts the following values:
 
-| Name    | Description                                                                                                                                                                                                        |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| path    | The path you want to navigate to.                                                                                                                                                                                  |
-| options | The options for the configuration object: `replace`, `reloadDocument`, `clientState`, `restoreScroll`. For more information the options, refer to the [Link component](https://shopify.dev/api/hydrogen/components/framework/link). |
+| Name    | Description                                                                                                                                                                                                                  |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| path    | The path you want to navigate to.                                                                                                                                                                                            |
+| options | The options for the configuration object: `replace`, `reloadDocument`, `clientState`, `scroll`. For more information the options, refer to the [Link component](https://shopify.dev/api/hydrogen/components/framework/link). |
 
 ## Considerations
 

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -44,7 +44,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       replace: _replace,
       to,
       onClick,
-      clientState = {},
+      clientState,
       prefetch = true,
       restoreScroll = true,
     } = props;

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -17,6 +17,8 @@ export interface LinkProps
   reloadDocument?: boolean;
   /** Whether to prefetch the link source when the user signals intent. Defaults to `true`. For more information, refer to [Prefetching a link source](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#prefetching-a-link-source). */
   prefetch?: boolean;
+  /** Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to true. */
+  restoreScroll?: boolean;
 }
 
 /**
@@ -42,8 +44,9 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       replace: _replace,
       to,
       onClick,
-      clientState,
+      clientState = {},
       prefetch = true,
+      restoreScroll = true,
     } = props;
 
     const internalClick = useCallback(
@@ -63,19 +66,21 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
           navigate(to, {
             replace,
+            restoreScroll,
             clientState,
           });
         }
       },
       [
+        onClick,
         reloadDocument,
         target,
         _replace,
-        to,
-        clientState,
-        onClick,
         location,
+        to,
         navigate,
+        clientState,
+        restoreScroll,
       ]
     );
 
@@ -141,6 +146,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
             'clientState',
             'reloadDocument',
             'prefetch',
+            'restoreScroll',
           ])}
           ref={ref}
           onClick={internalClick}

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -17,8 +17,8 @@ export interface LinkProps
   reloadDocument?: boolean;
   /** Whether to prefetch the link source when the user signals intent. Defaults to `true`. For more information, refer to [Prefetching a link source](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#prefetching-a-link-source). */
   prefetch?: boolean;
-  /** Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to true. */
-  restoreScroll?: boolean;
+  /** Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to `true`. */
+  scroll?: boolean;
 }
 
 /**
@@ -46,7 +46,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       onClick,
       clientState,
       prefetch = true,
-      restoreScroll = true,
+      scroll = true,
     } = props;
 
     const internalClick = useCallback(
@@ -66,7 +66,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
           navigate(to, {
             replace,
-            restoreScroll,
+            scroll,
             clientState,
           });
         }
@@ -80,7 +80,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         to,
         navigate,
         clientState,
-        restoreScroll,
+        scroll,
       ]
     );
 
@@ -146,7 +146,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
             'clientState',
             'reloadDocument',
             'prefetch',
-            'restoreScroll',
+            'scroll',
           ])}
           ref={ref}
           onClick={internalClick}

--- a/packages/hydrogen/src/components/Link/tests/Link.test.tsx
+++ b/packages/hydrogen/src/components/Link/tests/Link.test.tsx
@@ -1,4 +1,5 @@
 import {createBrowserHistory} from 'history';
+import {nextTick} from 'process';
 import React from 'react';
 import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {Link} from '../Link.client';
@@ -42,7 +43,10 @@ describe('<Link />', () => {
     const unlisten = history.listen(({location}) => {
       try {
         expect(location.pathname).toBe('/products/hydrogen');
-        done();
+        nextTick(() => {
+          expect(global.window.scrollTo).toBeCalledWith(0, 0);
+          done();
+        });
       } catch (e) {
         done(e);
       } finally {
@@ -52,6 +56,39 @@ describe('<Link />', () => {
 
     const component = mountWithProviders(
       <Link to="/products/hydrogen">Link</Link>,
+      {
+        history,
+      }
+    );
+
+    component.act(() => {
+      component?.domNode?.click();
+    });
+  });
+
+  it('does not scroll to top if restore is disabled', (done) => {
+    const history = createBrowserHistory();
+
+    global.window.scrollTo = jest.fn();
+
+    const unlisten = history.listen(({location}) => {
+      try {
+        expect(location.pathname).toBe('/products/hydrogen');
+        nextTick(() => {
+          expect(global.window.scrollTo).not.toBeCalledWith(0, 0);
+          done();
+        });
+      } catch (e) {
+        done(e);
+      } finally {
+        unlisten();
+      }
+    });
+
+    const component = mountWithProviders(
+      <Link to="/products/hydrogen" restoreScroll={false}>
+        Link
+      </Link>,
       {
         history,
       }

--- a/packages/hydrogen/src/components/Link/tests/Link.test.tsx
+++ b/packages/hydrogen/src/components/Link/tests/Link.test.tsx
@@ -86,7 +86,7 @@ describe('<Link />', () => {
     });
 
     const component = mountWithProviders(
-      <Link to="/products/hydrogen" restoreScroll={false}>
+      <Link to="/products/hydrogen" scroll={false}>
         Link
       </Link>,
       {

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -63,7 +63,7 @@ export const BrowserRouter: FC<{
        * "pop" navigations, like forward/backward buttons, always restore scroll position
        * regardless of what the original forward navigation intent was.
        */
-      const needsScrollRestoration = action === 'POP' || !!state.restoreScroll;
+      const needsScrollRestoration = action === 'POP' || !!state.scroll;
 
       setScrollNeedsRestoration(needsScrollRestoration);
     });

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -47,7 +47,7 @@ export const BrowserRouter: FC<{
   });
 
   useLayoutEffect(() => {
-    const unlisten = history.listen(({location: newLocation}) => {
+    const unlisten = history.listen(({location: newLocation, action}) => {
       positions[location.key] = window.scrollY;
 
       setLocationServerProps({
@@ -56,7 +56,16 @@ export const BrowserRouter: FC<{
       });
 
       setLocation(newLocation);
-      setScrollNeedsRestoration(!!(newLocation.state as any)?.restoreScroll);
+
+      const state = (newLocation.state ?? {}) as Record<string, any>;
+
+      /**
+       * "pop" navigations, like forward/backward buttons, always restore scroll position
+       * regardless of what the original forward navigation intent was.
+       */
+      const needsScrollRestoration = action === 'POP' || !!state.restoreScroll;
+
+      setScrollNeedsRestoration(needsScrollRestoration);
     });
 
     return () => unlisten();

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -33,7 +33,7 @@ export const BrowserRouter: FC<{
 
   const history = useMemo(() => pHistory || createBrowserHistory(), [pHistory]);
   const [location, setLocation] = useState(history.location);
-  const [locationChanged, setLocationChanged] = useState(false);
+  const [scrollNeedsRestoration, setScrollNeedsRestoration] = useState(false);
 
   const {pending, locationServerProps, setLocationServerProps} =
     useInternalServerProps();
@@ -42,8 +42,8 @@ export const BrowserRouter: FC<{
     location,
     pending,
     serverProps: locationServerProps,
-    locationChanged,
-    onFinishNavigating: () => setLocationChanged(false),
+    scrollNeedsRestoration,
+    onFinishNavigating: () => setScrollNeedsRestoration(false),
   });
 
   useLayoutEffect(() => {
@@ -56,14 +56,14 @@ export const BrowserRouter: FC<{
       });
 
       setLocation(newLocation);
-      setLocationChanged(true);
+      setScrollNeedsRestoration(!!(newLocation.state as any)?.restoreScroll);
     });
 
     return () => unlisten();
   }, [
     history,
     location,
-    setLocationChanged,
+    setScrollNeedsRestoration,
     setLocation,
     setLocationServerProps,
   ]);
@@ -112,13 +112,13 @@ function useScrollRestoration({
   location,
   pending,
   serverProps,
-  locationChanged,
+  scrollNeedsRestoration,
   onFinishNavigating,
 }: {
   location: Location;
   pending: boolean;
   serverProps: LocationServerProps;
-  locationChanged: boolean;
+  scrollNeedsRestoration: boolean;
   onFinishNavigating: () => void;
 }) {
   /**
@@ -141,7 +141,7 @@ function useScrollRestoration({
 
   useLayoutEffect(() => {
     // The app has just loaded
-    if (isFirstLoad || !locationChanged) {
+    if (isFirstLoad || !scrollNeedsRestoration) {
       isFirstLoad = false;
       return;
     }
@@ -190,7 +190,7 @@ function useScrollRestoration({
     pending,
     serverProps.pathname,
     serverProps.search,
-    locationChanged,
+    scrollNeedsRestoration,
     onFinishNavigating,
   ]);
 }

--- a/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
+++ b/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
@@ -9,6 +9,9 @@ type NavigationOptions = {
 
   /** The custom client state with the navigation. */
   clientState?: any;
+
+  /** Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to true. */
+  restoreScroll?: any;
 };
 
 /**
@@ -21,9 +24,16 @@ export function useNavigate() {
     path: string,
     options: NavigationOptions = {replace: false, reloadDocument: false}
   ) => {
+    const state = {
+      ...options?.clientState,
+      restoreScroll: options?.restoreScroll ?? true,
+    };
+
     // @todo wait for RSC and then change focus for a11y?
-    if (options?.replace)
-      router.history.replace(path, options?.clientState || {});
-    else router.history.push(path, options?.clientState || {});
+    if (options?.replace) {
+      router.history.replace(path, state);
+    } else {
+      router.history.push(path, state);
+    }
   };
 }

--- a/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
+++ b/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
@@ -11,7 +11,7 @@ type NavigationOptions = {
   clientState?: any;
 
   /** Whether to emulate natural browser behavior and restore scroll position on navigation. Defaults to true. */
-  restoreScroll?: any;
+  scroll?: any;
 };
 
 /**
@@ -26,7 +26,7 @@ export function useNavigate() {
   ) => {
     const state = {
       ...options?.clientState,
-      restoreScroll: options?.restoreScroll ?? true,
+      scroll: options?.scroll ?? true,
     };
 
     // @todo wait for RSC and then change focus for a11y?


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1370 
RE #1139 #1152 #810 etc

A common pattern Hydrogen developers face is to need to update the current page URL for e.g. a search or filter, but keep the current scroll position. Since we added scroll restoration to Hydrogen, this became very difficult and workarounds like using two sources in the server components (`serverProps` + `url.searchParams`).

This PR adds a new `restoreScroll` prop to `Link` and `useNavigate` to prevent this behavior when desired:

```jsx
import {Link} from '@shopify/hydrogen';
export default function Index({request}) {
  const url = new URL(request.normalizedUrl);

  return (
    <>
      <p>Current param is: {url.searchParams.get('param')}</p>
      <Link to="/?param=foo" restoreScroll={false}>
        Update param to foo
      </Link>
    </>
  );
}
```

### Additional context

I considered naming this `shallow` similar to Next.js, but I avoided that because it could cause confusion. Next.js specifically does _not_ fetch new data for the route when shallow is passed, which is the opposite of Hydrogen's behavior.

I'm definitely open to new names for the prop, though!

### Potential downsides

~Since we're attaching `restoreScroll` as a client state in the navigation history, this means that pop events (forward and backward buttons) result in no scroll restoration.~

~I'm not sure if this is the desired behavior: if I click the filter a bunch of times on a collections page and keep my scroll position, click on a product (scroll to top), and click Back, my scroll position will be the same position I left the product page on.~

~Are there concerns with this approach?~

**Update**: I've added logic to prioritize scroll restoration for `POP` events, regardless of what the initial intent was for the location entry. This ensures that disabling scroll restoration only affects forward navigations (`PUSH` or `REPLACE` events).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
