### PR TITLE
Ignore skipped tests to avoid CI noise

### DIFF
--- a/packages/hydrogen/src/components/CartLineImage/tests/CartLineImage.test.tsx
+++ b/packages/hydrogen/src/components/CartLineImage/tests/CartLineImage.test.tsx
@@ -66,6 +66,7 @@ describe(`<CartLineImage />`, () => {
     expect(wrapper).not.toContainReactComponent(Image);
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it.skip(`typescript types`, () => {
     // this test is actually just using //@ts-expect-error as the assertion, and don't need to execute in order to have TS validation on them
     // I don't love this idea, but at the moment I also don't have other great ideas for how to easily test our component TS types

--- a/packages/hydrogen/src/components/Image/tests/Image.test.tsx
+++ b/packages/hydrogen/src/components/Image/tests/Image.test.tsx
@@ -283,6 +283,7 @@ describe('<Image />', () => {
     });
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it.skip(`typescript types`, () => {
     // this test is actually just using //@ts-expect-error as the assertion, and don't need to execute in order to have TS validation on them
     // I don't love this idea, but at the moment I also don't have other great ideas for how to easily test our component TS types


### PR DESCRIPTION
This prevents the check annotations from showing up in every single PR!