### PR TITLE
[Hydrogen docs]: Remove references to render props

### DIFF
--- a/docs/components/cart/cartestimatedcost.md
+++ b/docs/components/cart/cartestimatedcost.md
@@ -6,7 +6,6 @@ description: The CartEstimatedCost component renders a Money component with the 
 
 The `CartEstimatedCost` component renders a `Money` component with the
 cost associated with the `amountType` prop. If no `amountType` prop is specified, then it defaults to `totalAmount`.
-If `children` is a function, then it will pass down the render props provided by the parent component.
 
 ## Example code
 

--- a/docs/components/primitive/externalvideo.md
+++ b/docs/components/primitive/externalvideo.md
@@ -5,7 +5,7 @@ description: The ExternalVideo component renders an embedded video for the Store
 ---
 
 The `ExternalVideo` component renders an embedded video for the Storefront
-API's [ExternalVideo object](https://shopify.dev/api/storefront/reference/products/externalvideo).
+API's [ExternalVideo object](https://shopify.dev/api/storefront/reference/products/externalvideo). You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/image.md
+++ b/docs/components/primitive/image.md
@@ -5,7 +5,7 @@ description: The Image component renders an image for the Storefront API's Image
 ---
 
 The `Image` component renders an image for the Storefront API's
-[Image object](https://shopify.dev/api/storefront/reference/common-objects/image).
+[Image object](https://shopify.dev/api/storefront/reference/common-objects/image). You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/mediafile.md
+++ b/docs/components/primitive/mediafile.md
@@ -7,7 +7,7 @@ description: The MediaFile component renders the media for the Storefront API's 
 The `MediaFile` component renders the media for the Storefront API's
 [Media object](https://shopify.dev/api/storefront/reference/products/media). It renders an `Image`, a
 `Video`, an `ExternalVideo`, or a `ModelViewer` depending on the `mediaContentType` of the
-`media` provided as a prop.
+`media` provided as a prop. You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/metafield.md
+++ b/docs/components/primitive/metafield.md
@@ -7,10 +7,6 @@ description: The Metafield component renders the value of a Storefront API's Met
 The `Metafield` component renders the value of a Storefront
 API's [Metafield object](https://shopify.dev/api/storefront/reference/common-objects/metafield).
 
-When a render function is provided, it passes the Metafield object with a value
-that was parsed according to the Metafield's `type` field. For more information,
-refer to the [Render props](#render-props) section.
-
 When no render function is provided, it renders a smart default of the
 Metafield's `value`. For more information, refer to the [Default output](#default-output) section.
 
@@ -57,10 +53,6 @@ When no `children` prop is provided, the `Metafield` component renders the follo
 | `page_reference`         | A `span` containing the page reference GID.                                                                                                                                                               |
 | `variant_reference`      | A `span` containing the variant reference GID.                                                                                                                                                            |
 | `url`                    | An `a` tag with the `href` corresponding to the URL and the label corresponding to the URL.                                                                                                               |
-
-## Render props
-
-The `Metafield` components provides the Metafield object with a `value` that was parsed according to the `Metafield`'s `type` field. For details on the parsed value, refer to the [`parseMetafieldValue`](https://shopify.dev/api/hydrogen/utilities/parsemetafieldvalue) utility.
 
 ## Component type
 

--- a/docs/components/primitive/metafield.md
+++ b/docs/components/primitive/metafield.md
@@ -5,10 +5,7 @@ description: The Metafield component renders the value of a Storefront API's Met
 ---
 
 The `Metafield` component renders the value of a Storefront
-API's [Metafield object](https://shopify.dev/api/storefront/reference/common-objects/metafield).
-
-When no render function is provided, it renders a smart default of the
-Metafield's `value`. For more information, refer to the [Default output](#default-output) section.
+API's [Metafield object](https://shopify.dev/api/storefront/reference/common-objects/metafield). You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/modelviewer.md
+++ b/docs/components/primitive/modelviewer.md
@@ -5,7 +5,7 @@ description: The ModelViewer component renders a 3D model (with the model-viewer
 ---
 
 The `ModelViewer` component renders a 3D model (with the `model-viewer` tag) for
-the Storefront API's [Model3d object](https://shopify.dev/api/storefront/reference/products/model3d).
+the Storefront API's [Model3d object](https://shopify.dev/api/storefront/reference/products/model3d). You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/money.md
+++ b/docs/components/primitive/money.md
@@ -6,7 +6,7 @@ description: The Money component renders a string of the Storefront API's MoneyV
 
 The `Money` component renders a string of the Storefront API's
 [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) according to the
-`defaultLocale` in the [the `hydrogen.config.js` file](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config).
+`defaultLocale` in the [the `hydrogen.config.js` file](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config). You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/seo.md
+++ b/docs/components/primitive/seo.md
@@ -4,7 +4,7 @@ title: Seo
 description: The Seo component renders SEO information on a webpage.
 ---
 
-The `Seo` component renders SEO information on a webpage.
+The `Seo` component renders SEO information on a webpage. You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/shoppaybutton.md
+++ b/docs/components/primitive/shoppaybutton.md
@@ -4,7 +4,7 @@ title: ShopPayButton
 description: The ShopPayButton component renders a button that redirects to the Shop Pay checkout.
 ---
 
-The `ShopPayButton` component renders a button that redirects to the Shop Pay checkout.
+The `ShopPayButton` component renders a button that redirects to the Shop Pay checkout. You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/components/primitive/video.md
+++ b/docs/components/primitive/video.md
@@ -4,7 +4,7 @@ title: Video
 description: The Video component renders a video for the Storefront API's Video object.
 ---
 
-The `Video` component renders a `video` for the Storefront API's [Video object](https://shopify.dev/api/storefront/reference/products/video).
+The `Video` component renders a `video` for the Storefront API's [Video object](https://shopify.dev/api/storefront/reference/products/video). You can [customize this component](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components) using passthrough props.
 
 ## Example code
 

--- a/docs/framework/react-server-components.md
+++ b/docs/framework/react-server-components.md
@@ -20,7 +20,7 @@ For example, the following React element tree is [composed of React components](
 ![A diagram that illustrates a React element tree composed of server, client, and shared components](/assets/custom-storefronts/hydrogen/react-element-tree.png)
 
 > Note:
-> You can't import a server component into a client component. However, you can pass a server component into a client component using [passthrough or render props](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components).
+> You can't import a server component into a client component. However, you can pass a server component into a client component using [passthrough props](https://shopify.dev/api/hydrogen/components#customizing-hydrogen-components).
 
 ### Component types
 


### PR DESCRIPTION
## This PR: 
- Removes references to render props, which no longer exist
- Adds cross-references to the "Customizing Hydrogen components" section from primitive components
- Relates to https://github.com/Shopify/shopify-dev/pull/21169