### PR TITLE
Improve error message when storefront API is not JSON

### DIFF
--- a/.changeset/polite-years-rhyme.md
+++ b/.changeset/polite-years-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Propagate a better error message when the response from the storefront API is not JSON parseable

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -74,16 +74,23 @@ export function useShopQuery<T>({
   const body = query ? graphqlRequestBody(query, variables) : '';
   const {url, requestInit} = useCreateShopRequest(body); // eslint-disable-line react-hooks/rules-of-hooks
 
+  let text: string;
   let data: any;
   let useQueryError: any;
 
   try {
-    data = fetchSync(url, {
+    text = fetchSync(url, {
       ...requestInit,
       cache,
       preload,
       shouldCacheResponse,
-    }).json();
+    }).text();
+
+    try {
+      data = JSON.parse(text);
+    } catch (error: any) {
+      useQueryError = new Error('Unable to parse response\n' + text);
+    }
   } catch (error: any) {
     // Pass-through thrown promise for Suspense functionality
     if (error?.then) {

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -89,7 +89,7 @@ export function useShopQuery<T>({
     try {
       data = JSON.parse(text);
     } catch (error: any) {
-      useQueryError = new Error('Unable to parse response\n' + text);
+      useQueryError = new Error('Unable to parse response:\n' + text);
     }
   } catch (error: any) {
     // Pass-through thrown promise for Suspense functionality


### PR DESCRIPTION
Propagate a better error message when the response from the storefront API is not JSON parseable

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
