### PR TITLE
[Hydrogen docs]: Typo fixes

### DIFF
--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -207,7 +207,7 @@ export default defineConfig({
     error: async (request, error) => {
       console.error(error);
       // Methods can return promises. Hydrogen won't block the current
-      // request but it will await for them before the runtime instance ends.
+      // request but it will wait for the promises to be returned before the runtime instance ends.
       await myErrorTrackingService.send(request, error);
     },
     /* ... */

--- a/docs/framework/seo.md
+++ b/docs/framework/seo.md
@@ -154,11 +154,11 @@ By default, all routes in Hydrogen are stream rendered. However, Hydrogen suppor
 
 ### Imitating robot behavior
 
-To imitate the behaviour of a SEO robot and show the page content fully from server render for initial render, add the `?_bot` query parameter at the end of the webpage's URL.
+To imitate the behaviour of an SEO robot and show the page content fully from server render for an initial render, add the `?_bot` query parameter at the end of the webpage's URL.
 
 ### Checking for custom robots
 
-If you find a bot that's not recognized by Hydrogen's bot detection algorithm, you can [manually disable streaming](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#response-donotstream) to buffer the response and make the content immediately available to bots:
+If you find a bot that's not recognized by Hydrogen's bot detection algorithm, then you can [manually disable streaming](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#response-donotstream) to buffer the response and make the content immediately available to bots:
 
 {% codeblock file, filename: 'App.server.jsx' %}
 

--- a/docs/hooks/framework/usenavigate.md
+++ b/docs/hooks/framework/usenavigate.md
@@ -34,7 +34,7 @@ The `useNavigate` hook returns a function which accepts the following values:
 | Name    | Description                                                                                                                                                                                                                  |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | path    | The path you want to navigate to.                                                                                                                                                                                            |
-| options | The options for the configuration object: `replace`, `reloadDocument`, `clientState`, `scroll`. For more information the options, refer to the [Link component](https://shopify.dev/api/hydrogen/components/framework/link). |
+| options | The options for the configuration object: `replace`, `reloadDocument`, `clientState`, `scroll`. For more information on the options, refer to the [Link component](https://shopify.dev/api/hydrogen/components/framework/link). |
 
 ## Considerations
 


### PR DESCRIPTION
## This PR: 
- Fixes some small typos in the Hydrogen reference docs
- Relates to https://github.com/Shopify/shopify-dev/pull/21225