### PR TITLE
[Hydrogen docs]: Convert markdown link syntax to HTML

### DIFF
--- a/docs/framework/preloaded-queries.md
+++ b/docs/framework/preloaded-queries.md
@@ -7,7 +7,7 @@ description: Learn how to configure queries to preload in your Hydrogen app.
 <aside class="note beta">
 <h4>Experimental feature</h4>
 
-<p>Preloaded queries is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by [submitting an issue in GitHub](https://github.com/Shopify/hydrogen/issues).</p>
+<p>Preloaded queries is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by <a href="https://github.com/Shopify/hydrogen/issues">submitting an issue in GitHub</a>.</p>
 
 </aside>
 
@@ -111,7 +111,7 @@ const data = fetchSync('https://my.api.com/data.json', {
 <aside class="note beta">
 <h4>Experimental feature</h4>
 
-<p>The `showQueryTiming` property is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by [submitting an issue in GitHub](https://github.com/Shopify/hydrogen/issues).</p>
+<p>The `showQueryTiming` property is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by <a href="https://github.com/Shopify/hydrogen/issues">submitting an issue in GitHub</a>.</p>
 
 </aside>
 

--- a/docs/framework/sessions.md
+++ b/docs/framework/sessions.md
@@ -7,7 +7,7 @@ description: Learn about the Hydrogen framework's built-in support for session m
 <aside class="note beta">
 <h4>Experimental feature</h4>
 
-<p>Session management is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by [submitting an issue in GitHub](https://github.com/Shopify/hydrogen/issues).</p>
+<p>Session management is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by <a href="https://github.com/Shopify/hydrogen/issues">submitting an issue in GitHub</a>.</p>
 
 </aside>
 


### PR DESCRIPTION
## This PR: 
- Converts some markdown syntax to HTML so that a link in a note renders properly