### PR TITLE
Improve CPU performance in RSC

### DIFF
--- a/.changeset/five-cougars-begin.md
+++ b/.changeset/five-cougars-begin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Reduce CPU consumption when rendering React Server Components.

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-client-proxy.js
@@ -8,7 +8,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useState } from 'react';
+import React from 'react';
 
 // Store of components discovered during RSC to load
 // them later when consuming the response in SSR.
@@ -21,12 +21,8 @@ var STRING_SIZE_LIMIT = 64;
 var FN_RSC_ERROR = 'Functions exported from client components cannot be called or used as constructors from a server component.'; // TODO what's a better way to detect Flight runtime?
 
 function isRsc() {
-  try {
-    useState();
-    return false;
-  } catch (error) {
-    return error.message.endsWith('Server Components.');
-  }
+  // This method is only available during RSC
+  return !!React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher.current.getCacheForType;
 }
 
 function createModuleReference(id, value, name, isDefault) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This change takes the median CPU time in workers for the demo-store down from 25-40ms to 10-17ms.

Before:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/1634092/172345663-4f7be560-900c-4684-ae06-c1c0528b5250.png">

After:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/1634092/172345713-a67de511-20ca-4b3f-9304-910b2a9a2baf.png">


The change itself is simple but we need to read from React internals. Originally, we were relying on the fact that `useState` is not implemented in RSC, which is not very performant.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
