### PR TITLE
Lint changesets

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -93,6 +93,11 @@ yarn changeset add
 
 Follow the prompts to select which package(s) are affected by your change, and whether the change is a major, minor or patch change. This will create a file in the `.changesets` directory of the repo. This change should be committed and included with your PR.
 
+Considerations:
+
+- You can use markdown in your changeset to include code examples, headings, and more. However, **please use plain text for the first line of your changeset**. The formatting of the GitHub release notes does not support headings as the first line of the changeset.
+- When selecting packages for the changesets, only select packages which are published. Do not include private packages, as it will cause the build to fail. _Hopefully these are removed from the list of options in a [future Changesets release](https://github.com/changesets/changesets/issues/436)_.
+
 > **Important**: Until our official release, we will only release `minor` and `patch` updates. This means that breaking changes will be included in minor releases. Once we officially launch Hydrogen, we'll switch to `1.0.0` and follow a normal semantic release pattern.
 
 ## Contributing Examples

--- a/.github/workflows/changesets_linter.yml
+++ b/.github/workflows/changesets_linter.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+
+name: Changelog Linter
+jobs:
+  lint:
+    name: Lint Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint changesets
+        run: node scripts/lint-changesets.mjs

--- a/scripts/lint-changesets.mjs
+++ b/scripts/lint-changesets.mjs
@@ -35,7 +35,7 @@ function lint() {
       );
     }
 
-    console.log(`No ignored packages found in changeset ${filePath}.`);
+    console.log(`✅ No ignored packages found in changeset ${filePath}.`);
 
     /**
      * Ensure the first line of the changeset is NOT a markdown header:
@@ -54,14 +54,16 @@ function lint() {
       );
     }
 
-    console.log(`First line begins with plain text in changeset ${filePath}.`);
+    console.log(
+      `✅ First line begins with plain text in changeset ${filePath}.`
+    );
   });
 }
 
 try {
   lint();
 } catch (e) {
-  console.error(e.message);
+  console.error(`❌ ${e.message}`);
   // eslint-disable-next-line no-process-exit
   process.exit(1);
 }

--- a/scripts/lint-changesets.mjs
+++ b/scripts/lint-changesets.mjs
@@ -62,6 +62,7 @@ function lint() {
 
 try {
   lint();
+  console.log(`✅ No changeset issues detected.`);
 } catch (e) {
   console.error(`❌ ${e.message}`);
   // eslint-disable-next-line no-process-exit

--- a/scripts/lint-changesets.mjs
+++ b/scripts/lint-changesets.mjs
@@ -35,7 +35,7 @@ function lint() {
       );
     }
 
-    console.log(`✅ No ignored packages found in changeset ${filePath}.`);
+    console.log(`No ignored packages found in changeset ${filePath}.`);
 
     /**
      * Ensure the first line of the changeset is NOT a markdown header:
@@ -54,16 +54,14 @@ function lint() {
       );
     }
 
-    console.log(
-      `✅ First line begins with plain text in changeset ${filePath}.`
-    );
+    console.log(`First line begins with plain text in changeset ${filePath}.`);
   });
 }
 
 try {
   lint();
 } catch (e) {
-  console.error(`❌ ${e.message}`);
+  console.error(e.message);
   // eslint-disable-next-line no-process-exit
   process.exit(1);
 }

--- a/scripts/lint-changesets.mjs
+++ b/scripts/lint-changesets.mjs
@@ -1,0 +1,44 @@
+import fs from 'fs';
+
+function lint() {
+  // Get the list of ignored packages from .changeset/config.json
+  const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
+  const ignoredPackages = config.ignore;
+
+  // Iterate through all the .md files in the .changeset directory
+  var changesetFiles = fs.readdirSync('.changeset');
+  changesetFiles.forEach(function (file) {
+    if (file.indexOf('.md') < 0) return;
+
+    var filePath = '.changeset/' + file;
+    var fileContents = fs.readFileSync(filePath, 'utf8');
+
+    // Check to see if any of the ignored packages exist in the frontmatter
+    const frontmatter = fileContents.match(/^---\n([\s\S]*?)\n---/m);
+    if (!frontmatter) return;
+
+    let foundPackage;
+
+    if (
+      (foundPackage = ignoredPackages.find((ignoredPackage) =>
+        frontmatter[1].includes(ignoredPackage)
+      ))
+    ) {
+      throw new Error(
+        `The changeset ${filePath} contains an ignored package: ${foundPackage}. ` +
+          `Please remove it from the changeset. If it is the only package in the changeset, ` +
+          `remove the changeset entirely.`
+      );
+    }
+  });
+
+  console.log('No ignored packages found in changesets.');
+}
+
+try {
+  lint();
+} catch (e) {
+  console.error(e.message);
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+}

--- a/scripts/lint-changesets.mjs
+++ b/scripts/lint-changesets.mjs
@@ -19,6 +19,10 @@ function lint() {
 
     let foundPackage;
 
+    /**
+     * We have to manually lint for this due to an issue with changesets:
+     * @see https://github.com/changesets/changesets/issues/436
+     */
     if (
       (foundPackage = ignoredPackages.find((ignoredPackage) =>
         frontmatter[1].includes(ignoredPackage)
@@ -28,6 +32,22 @@ function lint() {
         `The changeset ${filePath} contains an ignored package: ${foundPackage}. ` +
           `Please remove it from the changeset. If it is the only package in the changeset, ` +
           `remove the changeset entirely.`
+      );
+    }
+
+    /**
+     * Ensure the first line of the changeset is NOT a markdown header:
+     */
+    const fileContentsWithoutFrontmatter = fileContents
+      .replace(/^---\n([\s\S]*?)\n---/m, '')
+      .trim();
+
+    if (fileContentsWithoutFrontmatter.startsWith('#')) {
+      throw new Error(
+        `The first line of changeset ${filePath} begins with a header: \n\n${
+          fileContentsWithoutFrontmatter.split('\n')[0]
+        }\n\n` +
+          `Changesets must begin with plain text. You may use markdown headers later in the body if desired.`
       );
     }
   });

--- a/scripts/lint-changesets.mjs
+++ b/scripts/lint-changesets.mjs
@@ -35,6 +35,8 @@ function lint() {
       );
     }
 
+    console.log(`✅ No ignored packages found in changeset ${filePath}.`);
+
     /**
      * Ensure the first line of the changeset is NOT a markdown header:
      */
@@ -47,18 +49,21 @@ function lint() {
         `The first line of changeset ${filePath} begins with a header: \n\n${
           fileContentsWithoutFrontmatter.split('\n')[0]
         }\n\n` +
-          `Changesets must begin with plain text. You may use markdown headers later in the body if desired.`
+          `Changesets must begin with plain text. Please replace the header in the first line with a plain string. ` +
+          `You may use markdown headers later in the body if desired.`
       );
     }
-  });
 
-  console.log('No ignored packages found in changesets.');
+    console.log(
+      `✅ First line begins with plain text in changeset ${filePath}.`
+    );
+  });
 }
 
 try {
   lint();
 } catch (e) {
-  console.error(e.message);
+  console.error(`❌ ${e.message}`);
   // eslint-disable-next-line no-process-exit
   process.exit(1);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

One frustrating limitation of changesets is that it includes private packages as part of the CLI selection process, and it does not error when you create changesets with those private packages: https://github.com/changesets/changesets/issues/436

This leads to an error when the next release is attempted, which then causes lots of headaches with rolling back PRs, etc.

This PR adds a linter step to our changesets until this issue is resolved.

### Additional context

I'm also adding a linter and guidance around headers in changesets, as they don't behave in the automated GitHub Release notes. We can use headers — they just can't be the first line.