### PR TITLE
Add experimental `useRequestContext`

### DIFF
--- a/.changeset/warm-tips-refuse.md
+++ b/.changeset/warm-tips-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Added an experimental hook `useRequestContext` that provides server-only context for third party integrations.

--- a/docs/hooks/framework/userequestcontext.md
+++ b/docs/hooks/framework/userequestcontext.md
@@ -1,0 +1,63 @@
+---
+gid: 3fd2294b-4172-4185-81c9-501a41c6bd6c
+title: useRequestContext
+description: The useRequestContext hook provides access to a request-scoped context.
+---
+
+<aside class="note beta">
+<h4>Experimental feature</h4>
+
+<p>Request context is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by [submitting an issue in GitHub](https://github.com/Shopify/hydrogen/issues).</p>
+
+</aside>
+
+The `useRequestContext` hook provides access to a request-scoped context to share data across multiple React Server Components while running on the server. It is useful for writing plugins and third-party libraries.
+
+## Example code
+
+{% codeblock file, filename: 'App.server.jsx' %}
+
+```jsx
+import {useRequestContext} from '@shopify/hydrogen';
+
+const pluginName = 'my-plugin';
+
+function installMyPlugin() {
+  const context = useRequestContext(pluginName);
+  context.installed = true; 
+}
+
+function useMyPlugin() {
+  return useRequestContext(pluginName);
+}
+
+function App() {
+  installMyPlugin();
+  
+  return /* ... */;
+}
+
+function SomeOtherServerComponent() {
+  const data = useMyPlugin(); 
+  return <div>{data.installed}</div>
+}
+```
+
+{% endcodeblock %}
+
+## Arguments
+
+The `useRequestContext` hook takes the following arguments:
+
+| Key     | Required | Description                                                              |
+| ------- | -------- | ------------------------------------------------------------------------ |
+| `scope` | No       | A string to encapsulate data so that it's not modified by other scopes.  |
+
+## Return value
+
+The `useRequestContext` hook returns an object that can be mutated to store data.
+
+## Considerations
+
+- Consider using the `useRequestContext` hook only where appropriate. Generally, you should pass props down to the components instead.
+- The `useRequestContext` hook is only available when running on the server (Server Components, or Client Components during SSR), and never shared in the browser.

--- a/docs/hooks/framework/userequestcontext.md
+++ b/docs/hooks/framework/userequestcontext.md
@@ -59,5 +59,5 @@ The `useRequestContext` hook returns an object that can be mutated to store data
 
 ## Considerations
 
-- Consider using the `useRequestContext` hook only where appropriate. Generally, you should pass props down to the components instead.
+- Consider using the `useRequestContext` hook only where appropriate. Generally, you should pass props down to the components instead. Use it to cache data across multiple React rendering cycles, or to share data across components that are located in different tree branches.
 - The `useRequestContext` hook is only available when running on the server in server components or client components during server-side rendering (SSR). The hook is never shared in the browser.

--- a/docs/hooks/framework/userequestcontext.md
+++ b/docs/hooks/framework/userequestcontext.md
@@ -11,7 +11,7 @@ description: The useRequestContext hook provides access to a request-scoped cont
 
 </aside>
 
-The `useRequestContext` hook provides access to a request-scoped context to share data across multiple React Server Components while running on the server. It is useful for writing plugins and third-party libraries.
+The `useRequestContext` hook provides access to a request-scoped context to share data across multiple React Server Components while running on the server. It's useful for writing plugins and third-party libraries.
 
 ## Example code
 
@@ -60,4 +60,4 @@ The `useRequestContext` hook returns an object that can be mutated to store data
 ## Considerations
 
 - Consider using the `useRequestContext` hook only where appropriate. Generally, you should pass props down to the components instead.
-- The `useRequestContext` hook is only available when running on the server (Server Components, or Client Components during SSR), and never shared in the browser.
+- The `useRequestContext` hook is only available when running on the server in server components or client components during server-side rendering (SSR). The hook is never shared in the browser.

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -69,6 +69,7 @@ export class HydrogenRequest extends Request {
     buyerIpHeader?: string;
     session?: SessionSyncApi;
     runtime?: RuntimeContext;
+    scopes: Map<string, Record<string, any>>;
     [key: string]: any;
   };
 
@@ -102,6 +103,7 @@ export class HydrogenRequest extends Request {
         normalizedRscUrl: this.normalizedUrl,
       },
       preloadQueries: new Map(),
+      scopes: new Map(),
     };
     this.cookies = this.parseCookies();
   }

--- a/packages/hydrogen/src/foundation/useRequestContext/index.ts
+++ b/packages/hydrogen/src/foundation/useRequestContext/index.ts
@@ -1,0 +1,31 @@
+import {META_ENV_SSR, useEnvContext} from '../ssr-interop';
+
+type ScopedContext = Record<string, any>;
+
+/**
+ * Provides access to the current request context.
+ * @param scope - An optional string used to scope the request context. It is recommended to
+ * prevent modifying the properties added by other plugins.
+ * @returns A request-scoped object that can be modified to provide and consume information
+ * across different React components in the tree.
+ * @example
+ * ```js
+ * import {useRequestContext} from '@shopify/hydrogen';
+ * useRequestContext('my-plugin-name');
+ * ```
+ */
+export function useRequestContext<T extends ScopedContext>(
+  scope = 'default'
+): T {
+  if (__HYDROGEN_DEV__ && !META_ENV_SSR) {
+    throw new Error('useRequestContext can only be used in the server');
+  }
+
+  const scopes = useEnvContext((req) => req.ctx.scopes);
+
+  if (!scopes.has(scope)) {
+    scopes.set(scope, Object.create(null));
+  }
+
+  return scopes.get(scope) as T;
+}

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -31,6 +31,7 @@ export {
   CacheMonths,
   CacheCustom,
 } from './foundation/Cache/strategies';
+export {useRequestContext} from './foundation/useRequestContext';
 export {useServerAnalytics} from './foundation/Analytics/hook';
 export {ShopifyAnalytics} from './foundation/Analytics/connectors/Shopify/ShopifyAnalytics.server';
 export {ShopifyAnalyticsConstants} from './foundation/Analytics/connectors/Shopify/const';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -51,3 +51,6 @@ export {CartQuery} from './components/CartProvider/cart-queries';
  * Override the client version of `fetchSync` with the server version.
  */
 export {fetchSync} from './foundation/fetchSync/server/fetchSync';
+
+export {type HydrogenRequest} from './foundation/HydrogenRequest/HydrogenRequest.server';
+export {type HydrogenResponse} from './foundation/HydrogenResponse/HydrogenResponse.server';

--- a/packages/playground/server-components/src/App.server.jsx
+++ b/packages/playground/server-components/src/App.server.jsx
@@ -1,5 +1,11 @@
 import renderHydrogen from '@shopify/hydrogen/entry-server';
-import {Route, Router, FileRoutes, ShopifyProvider} from '@shopify/hydrogen';
+import {
+  Route,
+  Router,
+  FileRoutes,
+  ShopifyProvider,
+  useRequestContext,
+} from '@shopify/hydrogen';
 import {Suspense} from 'react';
 import Custom1 from './customRoutes/custom1.server';
 import Custom2 from './customRoutes/custom2.server';
@@ -10,6 +16,9 @@ export default renderHydrogen(({request, response}) => {
   if (request.headers.get('user-agent') === 'custom bot') {
     response.doNotStream();
   }
+
+  useRequestContext().test1 = true;
+  useRequestContext('scope').test2 = true;
 
   return (
     <Suspense fallback={'Loading...'}>

--- a/packages/playground/server-components/src/routes/request-context.server.jsx
+++ b/packages/playground/server-components/src/routes/request-context.server.jsx
@@ -1,0 +1,17 @@
+import {useRequestContext} from '@shopify/hydrogen';
+
+export default function RequestContext() {
+  const defaultContext = useRequestContext();
+  const scopedContext = useRequestContext('scope');
+
+  return (
+    <>
+      <h1>Request Context</h1>
+
+      <div>
+        <div id="default-context">{JSON.stringify(defaultContext)}</div>
+        <div id="scoped-context">{JSON.stringify(scopedContext)}</div>
+      </div>
+    </>
+  );
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -77,6 +77,16 @@ export default async function testCases({
     expect(secretsClient).toContain('PRIVATE_VARIABLE:|'); // Missing private var in client bundle
   });
 
+  it('has access to request context', async () => {
+    await page.goto(getServerUrl() + '/request-context');
+    expect(await page.textContent('h1')).toContain('Request Context');
+
+    const defaultContext = await page.textContent('#default-context');
+    expect(defaultContext).toContain('{"test1":true}');
+    const scopedContext = await page.textContent('#scoped-context');
+    expect(scopedContext).toContain('{"test2":true}');
+  });
+
   it.skip('should render server props in client component', async () => {
     await page.goto(getServerUrl() + '/test-server-props');
     expect(await page.textContent('#server-props')).toMatchInlineSnapshot(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1429

This adds a small wrapper around `useServerRequest` / `useEnvContext` to provide a public (and experimental) API for 3p integrations.

It also exposes `HydrogenRequest` and `HydrogenResponse` types.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
