### PR TITLE
Further reduce CPU usage on RSC rendering

### DIFF
--- a/.changeset/big-spoons-grin.md
+++ b/.changeset/big-spoons-grin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Reduce CPU consumption when rendering React Server Components.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -276,7 +276,7 @@ async function runSSR({
       template={response.canStream() ? noScriptTemplate : template}
       hydrogenConfig={request.ctx.hydrogenConfig!}
     >
-      <ServerRequestProvider request={request} isRSC={false}>
+      <ServerRequestProvider request={request}>
         <ServerPropsProvider
           initialServerProps={state as any}
           setServerPropsForRsc={() => {}}
@@ -554,7 +554,7 @@ function runRSC({App, state, log, request, response}: RunRscParams) {
   request.ctx.router.serverProps = serverProps;
 
   const AppRSC = (
-    <ServerRequestProvider request={request} isRSC={true}>
+    <ServerRequestProvider request={request}>
       <PreloadQueries request={request}>
         <App {...serverProps} />
         <Suspense fallback={null}>

--- a/packages/hydrogen/src/foundation/Analytics/tests/Analytics.server.test.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/tests/Analytics.server.test.tsx
@@ -46,7 +46,7 @@ function SomeApiDelayServerComponent({
 
 function mountComponent(request: HydrogenRequest, children: React.ReactChild) {
   return mountWithProviders(
-    <ServerRequestProvider request={request} isRSC={true}>
+    <ServerRequestProvider request={request}>
       <Suspense fallback={null}>
         {children}
         <Suspense fallback={null}>

--- a/packages/hydrogen/src/foundation/Analytics/tests/hook.test.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/tests/hook.test.tsx
@@ -13,7 +13,7 @@ function mountComponent(analyticsData?: any) {
   const request = new HydrogenRequest(new Request('https://examples.com'));
 
   return mountWithProviders(
-    <ServerRequestProvider request={request} isRSC={true}>
+    <ServerRequestProvider request={request}>
       <Suspense fallback={null}>
         <Component />
       </Suspense>

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -19,7 +19,6 @@ function requestCacheRSC() {
 requestCacheRSC.key = Symbol.for('HYDROGEN_REQUEST');
 
 type ServerRequestProviderProps = {
-  isRSC: boolean;
   request: HydrogenRequest;
   children: JSX.Element;
 };
@@ -51,11 +50,10 @@ function getCacheForType(resource: () => Map<any, any>) {
 }
 
 export function ServerRequestProvider({
-  isRSC,
   request,
   children,
 }: ServerRequestProviderProps) {
-  if (isRSC) {
+  if (isRsc()) {
     // Save the request object in a React cache that is
     // scoped to this current rendering.
 

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -32,7 +32,7 @@ function getInternalReactDispatcher() {
 
 function isRsc() {
   // This method is only available during RSC
-  return !!getInternalReactDispatcher().getCacheForType;
+  return __HYDROGEN_TEST__ || !!getInternalReactDispatcher().getCacheForType;
 }
 
 // Note: use this only during RSC/Flight rendering. The React dispatcher

--- a/packages/hydrogen/src/hooks/useShopQuery/tests/useShopQuery.test.tsx
+++ b/packages/hydrogen/src/hooks/useShopQuery/tests/useShopQuery.test.tsx
@@ -28,7 +28,7 @@ function mountComponent() {
   };
 
   return mountWithProviders(
-    <ServerRequestProvider request={request} isRSC={true}>
+    <ServerRequestProvider request={request}>
       <Suspense fallback={null}>
         <Component />
       </Suspense>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Same workaround as in #1452 applied to another part of the code (when calling `useServerRequest`). This was about 7% of the CPU.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
