### PR TITLE
Fix analytics object existence

### DIFF
--- a/.changeset/dry-carrots-nail.md
+++ b/.changeset/dry-carrots-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix ClientAnalytics losing subscriber object when passed as a param

--- a/packages/hydrogen/src/foundation/Analytics/ClientAnalytics.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/ClientAnalytics.tsx
@@ -44,7 +44,6 @@ function publish(eventname: string, guardDup = false, payload = {}) {
   if (isInvokedFromServer()) return;
 
   const namedspacedEventname = getNamedspacedEventname(eventname);
-  const subs = subscribers[namedspacedEventname];
 
   // De-dup events due to re-renders
   if (guardDup) {
@@ -55,27 +54,16 @@ function publish(eventname: string, guardDup = false, payload = {}) {
     }
 
     const namespacedTimeout = setTimeout(() => {
-      publishEvent(
-        namedspacedEventname,
-        subs,
-        mergeDeep(pageAnalyticsData, payload)
-      );
+      publishEvent(namedspacedEventname, mergeDeep(pageAnalyticsData, payload));
     }, 100);
     guardDupEvents[namedspacedEventname] = namespacedTimeout;
   } else {
-    publishEvent(
-      namedspacedEventname,
-      subs,
-      mergeDeep(pageAnalyticsData, payload)
-    );
+    publishEvent(namedspacedEventname, mergeDeep(pageAnalyticsData, payload));
   }
 }
 
-function publishEvent(
-  eventname: string,
-  subs: Record<string, SubscriberFunction>,
-  payload: any
-) {
+function publishEvent(eventname: string, payload: any) {
+  const subs = subscribers[eventname];
   if (!isFirstPageViewSent && eventname === eventNames.PAGE_VIEW) {
     isFirstPageViewSent = true;
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Weird bug where ClientAnalytics object is unable to get entries to the subscribers object when passed in as a function parameter. Seems to happen only when the page is simple (ie. no queries or complex layouts)

Bug origin PR: https://github.com/Shopify/hydrogen/pull/1416

No idea how to explain this bug but essentially ...

```
// Closure variable
const subscribers = {
  "page-view": {
     id: () => {...}
  }
}

function publishEvent(eventname, sub) {
  console.log(sub);                          // <= undefined
  console.log(subscribers);                  // <= expected object
  console.log(subscribers[eventname]);       // <= expected object
}

publishEvent("page-view", subscribers["page-view"]);
```

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
