### PR TITLE
Remove status setters, and use a new `response.notFound()` method.

### DIFF
--- a/.changeset/new-feet-tell.md
+++ b/.changeset/new-feet-tell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Remove status setter on `HydrogenResponse`, and introduce `response.notFound()` to support 404 responses from the server.

--- a/docs/components/framework/route.md
+++ b/docs/components/framework/route.md
@@ -33,7 +33,8 @@ function Products({params}) {
 function Home() {
   return <h1>Home</h1>;
 }
-function NotFound() {
+function NotFound({response}) {
+  response.notFound();
   return <h1>Not found</h1>;
 }
 export default renderHydrogen(App);

--- a/docs/framework/routes.md
+++ b/docs/framework/routes.md
@@ -335,7 +335,7 @@ export default function CustomPage({response}) {
 > Tip:
 > There are [performance benefits](https://shopify.dev/custom-storefronts/hydrogen/best-practices/performance) to streaming. You shouldn't completely disable streaming for all of your storefront's routes.
 
-You can use `response` to set headers or status codes using the `Response` API:
+You can use `response` to set headers using the `Response` API:
 
 {% codeblock file %}
 
@@ -344,8 +344,6 @@ export default function CustomPage({response}) {
   response.doNotStream();
 
   response.headers.set('custom-header', 'value');
-  response.status = 201;
-
   // ...
 }
 ```
@@ -354,6 +352,25 @@ export default function CustomPage({response}) {
 
 > Caution:
 > You must call `response.doNotStream()` before any calls to `fetchSync`, `useQuery` or `useShopQuery` to prevent streaming while the Suspense data is resolved.
+
+#### `response.notFound()`
+
+By default, Hydrogen uses a 200 status for successful responses and a 500 status for errors. If you want to mark a route with a 404 response, you can call the `response.notFound()` method:
+
+{% codeblock file %}
+
+```js
+export default function NotFound({response}) {
+  response.notFound();
+
+  // ...
+}
+```
+
+{% endcodeblock %}
+
+> Caution:
+> You must call `response.doNotStream()` before `response.notFound()` if you make any calls to `fetchSync`, `useQuery` or `useShopQuery`. This is to prevent streaming while the Suspense data is resolved.
 
 #### `response.redirect()`
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -612,16 +612,16 @@ type ResponseOptions = {
 };
 
 function getResponseOptions(
-  {headers, status, statusText}: HydrogenResponse,
+  {headers, customStatus, customStatusText}: HydrogenResponse,
   error?: Error
 ) {
   const responseInit = {
     headers,
-    status: error ? 500 : status,
+    status: error ? 500 : customStatus ?? 200,
   } as ResponseOptions;
 
-  if (!error && statusText) {
-    responseInit.statusText = statusText;
+  if (!error && customStatusText) {
+    responseInit.statusText = customStatusText;
   }
 
   return responseInit;

--- a/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
@@ -7,22 +7,8 @@ export class HydrogenResponse extends Response {
   private wait = false;
   private cacheOptions: CachingStrategy = CacheSeconds();
 
-  private customStatus?: number;
-  private customStatusText?: string;
-
-  public get status() {
-    return this.customStatus ?? super.status;
-  }
-  public set status(number: number) {
-    this.customStatus = number;
-  }
-
-  public get statusText() {
-    return this.customStatusText ?? super.statusText;
-  }
-  public set statusText(text: string) {
-    this.customStatusText = text;
-  }
+  #customStatus?: number;
+  #customStatusText?: string;
 
   /**
    * Buffer the current response until all queries have resolved,
@@ -40,15 +26,28 @@ export class HydrogenResponse extends Response {
     this.cacheOptions = options;
   }
 
+  get customStatus() {
+    return this.#customStatus;
+  }
+
+  get customStatusText() {
+    return this.#customStatusText;
+  }
+
   get cacheControlHeader(): string {
     return generateCacheControlHeader(this.cacheOptions);
   }
 
   redirect(location: string, status = 307) {
-    this.status = status;
+    this.#customStatus = status;
+    this.#customStatusText = 'Redirecting';
     this.headers.set('location', location);
 
     // in the case of an RSC request, instead render a client component that will redirect
     return React.createElement(Redirect, {to: location});
+  }
+
+  notFound() {
+    this.#customStatus = 404;
   }
 }

--- a/packages/playground/server-components/src/routes/headers.server.jsx
+++ b/packages/playground/server-components/src/routes/headers.server.jsx
@@ -1,6 +1,4 @@
 export default function Headers({response}) {
-  response.status = 201;
-  response.statusText = 'hey';
   response.headers.set('Accept-Encoding', 'deflate');
   response.headers.set('Set-Cookie', 'hello=world');
   response.headers.append('Set-Cookie', 'hello2=world2');

--- a/packages/playground/server-components/src/routes/not-found.server.jsx
+++ b/packages/playground/server-components/src/routes/not-found.server.jsx
@@ -1,0 +1,5 @@
+export default function NotFound({response}) {
+  response.doNotStream();
+  response.notFound();
+  return 'Not found';
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -206,14 +206,17 @@ export default async function testCases({
   it('returns headers in response correctly', async () => {
     const response = await fetch(getServerUrl() + '/headers');
 
-    expect(response.status).toEqual(201);
-    // statusText cannot be modified in workers
-    expect(response.statusText).toEqual(isWorker ? 'Created' : 'hey');
     expect(response.headers.get('Accept-Encoding')).toBe('deflate, gzip');
     expect(response.headers.raw()['set-cookie']).toEqual([
       'hello=world',
       'hello2=world2',
     ]);
+  });
+
+  it('handles notFound', async () => {
+    const response = await fetch(getServerUrl() + '/not-found');
+
+    expect(response.status).toBe(404);
   });
 
   it('properly escapes props in the SSR flight script chunks', async () => {

--- a/templates/demo-store/src/components/NotFound.server.jsx
+++ b/templates/demo-store/src/components/NotFound.server.jsx
@@ -39,8 +39,7 @@ function NotFoundHero() {
 export default function NotFound({response}) {
   if (response) {
     response.doNotStream();
-    response.status = 404;
-    response.statusText = 'Not found';
+    response.notFound();
   }
 
   const {countryCode = 'US'} = useSession();


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #1488 

We originally replaced `HydrogenResponse.writeHead()` with `set status(value()` in #1433. However, we can't reliably override the `status` and `statusText` properties of the `Response` class we're extending, because the implementation on some hosting runtimes like Cloudflare explicitly forbids it.

This PR adds a new `HydrogenResponse.notFound()` method which developers can use to declare a 404 when inside an server component.

### Additional context

I don't anticipate developers needing to set custom response codes inside server components, so I think the removal of a custom status setter is an acceptable tradeoff.

Note that it is still possible to return a completely custom `Response` from API functions, where a custom status can be provided in the initial options:

```js
export async function api() {
  return new Response('foo', { status: 201 });
}
```

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
