### PR TITLE
Improve waterfall detection

### DIFF
--- a/.changeset/nasty-rules-knock.md
+++ b/.changeset/nasty-rules-knock.md
@@ -1,0 +1,9 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improve waterfall detection
+
+1. Show a summary in dev mode with instructions on getting details
+2. Only show the waterfall warning the second time the page is loaded
+3. Don't show the waterfall warning on preloaded queries

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -41,6 +41,7 @@ const generateId =
 
 // Stores queries by url or '*'
 const preloadCache: AllPreloadQueries = new Map();
+const previouslyLoadedUrls = new Set<string>();
 const PRELOAD_ALL = '*';
 
 /**
@@ -106,6 +107,12 @@ export class HydrogenRequest extends Request {
       scopes: new Map(),
     };
     this.cookies = this.parseCookies();
+  }
+
+  public previouslyLoadedRequest() {
+    if (previouslyLoadedUrls.has(this.normalizedUrl)) return true;
+    previouslyLoadedUrls.add(this.normalizedUrl);
+    return false;
   }
 
   private parseCookies() {

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -41,7 +41,7 @@ const generateId =
 
 // Stores queries by url or '*'
 const preloadCache: AllPreloadQueries = new Map();
-const previouslyLoadedUrls = new Set<string>();
+const previouslyLoadedUrls: Record<string, number> = {};
 const PRELOAD_ALL = '*';
 
 /**
@@ -110,8 +110,12 @@ export class HydrogenRequest extends Request {
   }
 
   public previouslyLoadedRequest() {
-    if (previouslyLoadedUrls.has(this.normalizedUrl)) return true;
-    previouslyLoadedUrls.add(this.normalizedUrl);
+    if (previouslyLoadedUrls[this.normalizedUrl] > 1) return true;
+    previouslyLoadedUrls[this.normalizedUrl] = previouslyLoadedUrls[
+      this.normalizedUrl
+    ]
+      ? 2
+      : 1;
     return false;
   }
 

--- a/packages/hydrogen/src/utilities/log/__tests__/log-query-timeline.test.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log-query-timeline.test.ts
@@ -7,23 +7,8 @@ let mockLogger: jest.Mocked<Logger>;
 const QUERY_1 = 'test1';
 const QUERY_2 = 'testing2';
 
-function expectTiming(
-  mockCall: string,
-  method: string,
-  queryName: string,
-  duration?: number
-) {
-  let regex;
-  if (duration) {
-    regex = new RegExp(
-      `│ -?[0-9]+\\.[0-9]{2}ms.*${method}.*${queryName} \\(Took ${duration}\\.00ms\\)`
-    );
-  } else {
-    regex = new RegExp(`│ -?[0-9]+\\.[0-9]{2}ms.*${method}.*${queryName}`);
-  }
-
-  expect(mockCall).toEqual(expect.stringMatching(regex));
-}
+let dateNowSpy: jest.SpyInstance;
+const time = 1640995200000;
 
 describe('cache header log', () => {
   beforeEach(() => {
@@ -36,11 +21,14 @@ describe('cache header log', () => {
       options: jest.fn(() => ({})),
     };
 
+    dateNowSpy = jest.spyOn(performance, 'now').mockImplementation(() => time);
+
     setLogger({...mockLogger, showQueryTiming: true});
   });
 
   afterEach(() => {
     setLogger(undefined);
+    dateNowSpy.mockRestore();
   });
 
   it('should log query timing', () => {
@@ -49,7 +37,8 @@ describe('cache header log', () => {
       ctx: {
         queryTimings: [],
       },
-      time: Date.now(),
+      time: 1640995200200,
+      previouslyLoadedRequest: () => false,
     } as unknown as HydrogenRequest;
     collectQueryTimings(request, QUERY_1, 'requested');
     collectQueryTimings(request, QUERY_1, 'resolved', 100);
@@ -58,13 +47,13 @@ describe('cache header log', () => {
     logQueryTimings('ssr', request);
 
     expect(mockLogger.debug).toHaveBeenCalled();
-    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(
-      `"[90m┌── Query timings for http://localhost:3000/[39m"`
-    );
-    expectTiming(mockLogger.debug.mock.calls[1][1], 'Requested', 'test1');
-    expectTiming(mockLogger.debug.mock.calls[2][1], 'Resolved', 'test1', 100);
-    expectTiming(mockLogger.debug.mock.calls[3][1], 'Rendered', 'test1');
-    expect(mockLogger.debug.mock.calls[4][1]).toMatchInlineSnapshot(`"[90m└──[39m"`);
+    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "[90m┌── Query timings for http://localhost:3000/[39m[90m
+      │ -200.00ms  [90mRequested [90m test1[39m[90m
+      │ -200.00ms  [90mResolved  [90m test1 (Took 100.00ms)[39m[90m
+      │ -200.00ms  [90mRendered  [90m test1[39m
+      [90m└──[39m"
+    `);
   });
 
   it('should detect suspense waterfall', () => {
@@ -73,7 +62,8 @@ describe('cache header log', () => {
       ctx: {
         queryTimings: [],
       },
-      time: Date.now(),
+      time: 1640995200200,
+      previouslyLoadedRequest: () => true,
     } as unknown as HydrogenRequest;
     collectQueryTimings(request, QUERY_1, 'requested');
     collectQueryTimings(request, QUERY_1, 'resolved', 100);
@@ -87,26 +77,19 @@ describe('cache header log', () => {
     logQueryTimings('ssr', request);
 
     expect(mockLogger.debug).toHaveBeenCalled();
-    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(
-      `"[90m┌── Query timings for http://localhost:3000/[39m"`
-    );
-    expectTiming(mockLogger.debug.mock.calls[1][1], 'Requested', 'test1');
-    expectTiming(mockLogger.debug.mock.calls[2][1], 'Resolved', 'test1', 100);
-    expectTiming(mockLogger.debug.mock.calls[3][1], 'Requested', 'test1');
-    expectTiming(mockLogger.debug.mock.calls[4][1], 'Rendered', 'test1');
-    expect(mockLogger.debug.mock.calls[5][1]).toMatchInlineSnapshot(
-      `"[90m│ [39m[33mSuspense waterfall detected[39m"`
-    );
-    expectTiming(mockLogger.debug.mock.calls[6][1], 'Requested', 'testing2');
-    expectTiming(
-      mockLogger.debug.mock.calls[7][1],
-      'Resolved',
-      'testing2',
-      100
-    );
-    expectTiming(mockLogger.debug.mock.calls[8][1], 'Requested', 'testing2');
-    expectTiming(mockLogger.debug.mock.calls[9][1], 'Rendered', 'testing2');
-    expect(mockLogger.debug.mock.calls[10][1]).toMatchInlineSnapshot(`"[90m└──[39m"`);
+    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "[90m┌── Query timings for http://localhost:3000/[39m[90m
+      │ -200.00ms  [90mRequested [90m test1[39m[90m
+      │ -200.00ms  [90mResolved  [90m test1 (Took 100.00ms)[39m[90m
+      │ -200.00ms  [90mRequested [90m test1[39m[90m
+      │ -200.00ms  [90mRendered  [90m test1[39m
+      [90m│ [39m[33mSuspense waterfall detected[39m[90m
+      │ -200.00ms  [90mRequested [90m testing2[39m[90m
+      │ -200.00ms  [90mResolved  [90m testing2 (Took 100.00ms)[39m[90m
+      │ -200.00ms  [90mRequested [90m testing2[39m[90m
+      │ -200.00ms  [90mRendered  [90m testing2[39m
+      [90m└──[39m"
+    `);
   });
 
   it('should detect unused query', () => {
@@ -115,7 +98,8 @@ describe('cache header log', () => {
       ctx: {
         queryTimings: [],
       },
-      time: Date.now(),
+      previouslyLoadedRequest: () => false,
+      time: 1640995200200,
     } as unknown as HydrogenRequest;
     collectQueryTimings(request, QUERY_1, 'requested');
     collectQueryTimings(request, QUERY_1, 'resolved', 100);
@@ -123,15 +107,13 @@ describe('cache header log', () => {
     logQueryTimings('ssr', request);
 
     expect(mockLogger.debug).toHaveBeenCalled();
-    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(
-      `"[90m┌── Query timings for http://localhost:3000/[39m"`
-    );
-    expectTiming(mockLogger.debug.mock.calls[1][1], 'Requested', 'test1');
-    expectTiming(mockLogger.debug.mock.calls[2][1], 'Resolved', 'test1', 100);
-    expect(mockLogger.debug.mock.calls[3][1]).toMatchInlineSnapshot(
-      `"[90m│ [39m[33mUnused query detected: test1[39m"`
-    );
-    expect(mockLogger.debug.mock.calls[4][1]).toMatchInlineSnapshot(`"[90m└──[39m"`);
+    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "[90m┌── Query timings for http://localhost:3000/[39m[90m
+      │ -200.00ms  [90mRequested [90m test1[39m[90m
+      │ -200.00ms  [90mResolved  [90m test1 (Took 100.00ms)[39m
+      [90m│ [39m[33mUnused query detected: test1[39m
+      [90m└──[39m"
+    `);
   });
 
   it('should detect multiple data load', () => {
@@ -140,7 +122,8 @@ describe('cache header log', () => {
       ctx: {
         queryTimings: [],
       },
-      time: Date.now(),
+      previouslyLoadedRequest: () => false,
+      time: 1640995200200,
     } as unknown as HydrogenRequest;
     collectQueryTimings(request, QUERY_1, 'requested');
     collectQueryTimings(request, QUERY_1, 'resolved', 100);
@@ -150,16 +133,14 @@ describe('cache header log', () => {
     logQueryTimings('ssr', request);
 
     expect(mockLogger.debug).toHaveBeenCalled();
-    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(
-      `"[90m┌── Query timings for http://localhost:3000/[39m"`
-    );
-    expectTiming(mockLogger.debug.mock.calls[1][1], 'Requested', 'test1');
-    expectTiming(mockLogger.debug.mock.calls[2][1], 'Resolved', 'test1', 100);
-    expectTiming(mockLogger.debug.mock.calls[3][1], 'Resolved', 'test1', 120);
-    expectTiming(mockLogger.debug.mock.calls[4][1], 'Rendered', 'test1');
-    expect(mockLogger.debug.mock.calls[5][1]).toMatchInlineSnapshot(
-      `"[90m│ [39m[33mMultiple data loads detected: test1[39m"`
-    );
-    expect(mockLogger.debug.mock.calls[6][1]).toMatchInlineSnapshot(`"[90m└──[39m"`);
+    expect(mockLogger.debug.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "[90m┌── Query timings for http://localhost:3000/[39m[90m
+      │ -200.00ms  [90mRequested [90m test1[39m[90m
+      │ -200.00ms  [90mResolved  [90m test1 (Took 100.00ms)[39m[90m
+      │ -200.00ms  [90mResolved  [90m test1 (Took 120.00ms)[39m[90m
+      │ -200.00ms  [90mRendered  [90m test1[39m
+      [90m│ [39m[33mMultiple data loads detected: test1[39m
+      [90m└──[39m"
+    `);
   });
 });

--- a/packages/hydrogen/src/utilities/log/log-query-timeline.ts
+++ b/packages/hydrogen/src/utilities/log/log-query-timeline.ts
@@ -41,20 +41,31 @@ export function collectQueryTimings(
 
 export function logQueryTimings(type: RenderType, request: HydrogenRequest) {
   const log = getLoggerWithContext(request);
-  if (!log.options().showQueryTiming) {
+
+  if (
+    (!__HYDROGEN_DEV__ && !log.options().showQueryTiming) ||
+    !request.previouslyLoadedRequest()
+  ) {
     return;
   }
 
-  log.debug(color(`┌── Query timings for ${parseUrl(type, request.url)}`));
+  let logMessage = color(
+    `┌── Query timings for ${parseUrl(type, request.url)}`
+  );
+
+  let firstSuspenseWaterfallQueryName = '';
 
   const queryList = request.ctx.queryTimings;
   if (queryList.length > 0) {
     const requestStartTime = request.time;
     const detectSuspenseWaterfall: Record<string, boolean> = {};
     const detectMultipleDataLoad: Record<string, number> = {};
+    const preloadedQueries: Set<string> = new Set();
     let suspenseWaterfallDetectedCount = 0;
 
     queryList.forEach((query: QueryTiming, index: number) => {
+      if (query.timingType === 'preload') preloadedQueries.add(query.name);
+
       if (query.timingType === 'requested' || query.timingType === 'preload') {
         detectSuspenseWaterfall[query.name] = true;
       } else if (query.timingType === 'rendered') {
@@ -68,18 +79,16 @@ export function logQueryTimings(type: RenderType, request: HydrogenRequest) {
       const loadColor = query.timingType === 'preload' ? green : color;
       const duration = query.duration;
 
-      log.debug(
-        color(
-          `│ ${`${(query.timestamp - requestStartTime).toFixed(2)}ms`.padEnd(
-            10
-          )} ${loadColor(TIMING_MAPPING[query.timingType].padEnd(10))} ${
-            query.name
-          }${
-            query.timingType === 'resolved'
-              ? ` (Took ${duration?.toFixed(2)}ms)`
-              : ''
-          }`
-        )
+      logMessage += color(
+        `\n│ ${`${(query.timestamp - requestStartTime).toFixed(2)}ms`.padEnd(
+          10
+        )} ${loadColor(TIMING_MAPPING[query.timingType].padEnd(10))} ${
+          query.name
+        }${
+          query.timingType === 'resolved'
+            ? ` (Took ${duration?.toFixed(2)}ms)`
+            : ''
+        }`
       );
 
       // SSR + RSC render path generates 2 `load` and `render` for each query
@@ -96,37 +105,57 @@ export function logQueryTimings(type: RenderType, request: HydrogenRequest) {
       // so the end of list index range is 3 (one less from a set entry) + 1 (zero index)
       if (
         queryList.length >= index + 4 &&
-        Object.keys(detectSuspenseWaterfall).length === 0
+        Object.keys(detectSuspenseWaterfall).length === 0 &&
+        !preloadedQueries.has(query.name)
       ) {
+        // Store the first suspense waterfall query name to display in the summary console output
+        if (!firstSuspenseWaterfallQueryName)
+          firstSuspenseWaterfallQueryName = query.name;
+
         suspenseWaterfallDetectedCount++;
         const warningColor =
           suspenseWaterfallDetectedCount === 1 ? yellow : red;
-        log.debug(
-          `${color(`│ `)}${warningColor(`Suspense waterfall detected`)}`
-        );
+        logMessage += `\n${color(`│ `)}${warningColor(
+          `Suspense waterfall detected`
+        )}`;
       }
     });
 
     const unusedQueries = Object.keys(detectSuspenseWaterfall);
     if (unusedQueries.length > 0) {
       unusedQueries.forEach((queryName: string) => {
-        log.debug(
-          `${color(`│ `)}${yellow(`Unused query detected: ${queryName}`)}`
-        );
+        logMessage += `\n${color(`│ `)}${yellow(
+          `Unused query detected: ${queryName}`
+        )}`;
       });
     }
 
     Object.keys(detectMultipleDataLoad).forEach((queryName: string) => {
       const count = detectMultipleDataLoad[queryName];
       if (count > 1) {
-        log.debug(
-          `${color(`│ `)}${yellow(
-            `Multiple data loads detected: ${queryName}`
-          )}`
-        );
+        logMessage += `\n${color(`│ `)}${yellow(
+          `Multiple data loads detected: ${queryName}`
+        )}`;
       }
     });
   }
 
-  log.debug(color('└──'));
+  logMessage += '\n' + color('└──');
+
+  if (log.options().showQueryTiming) {
+    log.debug(logMessage);
+  } else if (firstSuspenseWaterfallQueryName) {
+    log.debug(
+      yellow(
+        'Suspense waterfall detected on query: ' +
+          firstSuspenseWaterfallQueryName
+      )
+    );
+    log.debug(
+      '  Add the `showQueryTiming` property to your Hydrogen configuration to see more information:'
+    );
+    log.debug(
+      '  https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config#logger'
+    );
+  }
 }

--- a/packages/hydrogen/src/utilities/log/log-query-timeline.ts
+++ b/packages/hydrogen/src/utilities/log/log-query-timeline.ts
@@ -42,12 +42,11 @@ export function collectQueryTimings(
 export function logQueryTimings(type: RenderType, request: HydrogenRequest) {
   const log = getLoggerWithContext(request);
 
-  if (
-    (!__HYDROGEN_DEV__ && !log.options().showQueryTiming) ||
-    !request.previouslyLoadedRequest()
-  ) {
+  if (!__HYDROGEN_DEV__ && !log.options().showQueryTiming) {
     return;
   }
+
+  const previouslyLoadedRequest = request.previouslyLoadedRequest();
 
   let logMessage = color(
     `┌── Query timings for ${parseUrl(type, request.url)}`
@@ -106,7 +105,8 @@ export function logQueryTimings(type: RenderType, request: HydrogenRequest) {
       if (
         queryList.length >= index + 4 &&
         Object.keys(detectSuspenseWaterfall).length === 0 &&
-        !preloadedQueries.has(query.name)
+        !preloadedQueries.has(query.name) &&
+        previouslyLoadedRequest
       ) {
         // Store the first suspense waterfall query name to display in the summary console output
         if (!firstSuspenseWaterfallQueryName)

--- a/templates/demo-store/src/routes/products/[handle].server.jsx
+++ b/templates/demo-store/src/routes/products/[handle].server.jsx
@@ -28,7 +28,7 @@ export default function Product() {
       language: languageCode,
       handle,
     },
-    preload: false,
+    preload: true,
   });
 
   useServerAnalytics(

--- a/templates/demo-store/src/routes/products/[handle].server.jsx
+++ b/templates/demo-store/src/routes/products/[handle].server.jsx
@@ -28,7 +28,7 @@ export default function Product() {
       language: languageCode,
       handle,
     },
-    preload: true,
+    preload: false,
   });
 
   useServerAnalytics(


### PR DESCRIPTION
Improve waterfall detection

1. Show a summary in dev mode with instructions on getting details
2. Only show the waterfall warning the second time the page is loaded
3. Don't show the waterfall warning on preloaded queries
4. Don't show waterfall warnings until the page has been loaded multiple times, thereby verifying that there is a waterfall with included preloaded queries.

![image](https://user-images.githubusercontent.com/1566869/172724706-8331bd26-0ff4-46d3-89b4-15637cf88397.png)


This is a part of https://github.com/Shopify/hydrogen/issues/1477

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
