### PR TITLE
[Hydrogen docs]: Remove Fastly reference and add new source framework docs

### DIFF
--- a/docs/framework/content.md
+++ b/docs/framework/content.md
@@ -1,0 +1,144 @@
+---
+gid: bf2cb121-f051-4eb2-bb37-aa1738361b23
+title: Integrate content in Hydrogen
+description: Learn how to integrate content on your Hydrogen storefront.
+feature_flag: content_platform
+---
+
+Hydrogen includes support for integrating content on storefronts. For example, you might have content about product features, specifications, or size charts. You can integrate content into your Hydrogen storefront using the [Storefront API](https://shopify.dev/api/storefront).
+
+![Product features content in a custom storefront](/assets/custom-storefronts/hydrogen/hydrogen-content.gif)
+
+## Build a content model
+
+Content models are custom object schemas that you can create and associate with Shopify resources, such as products, collections, and orders. You use content models to create and store structured content in your Hydrogen storefront. You can [build a content model](https://help.shopify.com/en/manual/content/content-models) in the **Content** section of your Shopify admin.
+
+The following example shows a content model that displays product features content:
+
+![Product feature metafields](/assets/custom-storefronts/hydrogen/product-feature-metafields.png)
+
+After you've set up the content model, you can add content:
+
+![Content associated with the product feature metafield](/assets/custom-storefronts/hydrogen/product-feature-content.png)
+
+The following example shows an individual content entry that maps to the content model:
+
+![Individual content entry](/assets/custom-storefronts/hydrogen/individual-entry-content.png)
+
+## Build a content layout
+
+The following code snippet provides an example layout of product features content on the product details page. The content model, `features`, is mapped to the layout of the page:
+
+{% codeblock file, title: '/src/routes/products/[handle].server.jsx' %}
+
+```js
+...
+<Layout>
+  <Seo type="product" data={product} />
+  <ProductDetails product={product} />
+  <section>
+    {features.map(
+      ({id, heading, tagline, description, featured_image}, i) => (
+        <div
+          key={id}
+          className={`flex flex-col ${
+            isOdd(i) ? 'md:flex-row' : 'md:flex-row-reverse'
+          } md:justify-center gap-4 p-6 md:gap-8 md:p-12`}
+        >
+          <Image
+            className={`object-cover w-full md:w-1/2 aspect-[4/3]`}
+            width={featured_image.width}
+            height={featured_image.height}
+            src={featured_image.url}
+          />
+
+          <div className="flex flex-col items-start justify-center w-full gap-4 md:w-1/2">
+            <h4 className="text-base font-bold uppercase">{heading}</h4>
+            <h3 className="text-3xl font-bold">{title(tagline)}</h3>
+            <p className="text-base">{description}</p>
+          </div>
+        </div>
+      ),
+    )}
+  </section>
+</Layout>
+...
+```
+
+{% endcodeblock %}
+
+## Retrieve content
+
+Your Hydrogen storefront can retrieve the data that's stored in a content model using the Storefront API. You can retrieve content by querying the `type` field, which is the definition or type of data that the metafield stores.
+
+All connected [metafields](https://shopify.dev/apps/metafields) have a `namespace` that matches the `type` field.
+
+### Basic example
+
+The following example shows a Storefront API query that retrieves content by its associated `handle`:
+
+{% codeblock file, title: 'POST /api/unstable/graphql.json' %}
+
+```graphql
+query {
+ content(type: "lookbook", first: 10) {
+   edges {
+     node {
+       handle
+     }
+   }
+ }
+}
+```
+
+{% endcodeblock %}
+
+### Advanced example
+
+The following GraphQL query retrieves a `references` array for product content. The query returns `nil` if no object is referenced on the product details page.
+
+{% codeblock file, title: '/src/routes/products/[handle].server.jsx' %}
+
+```graphql
+const QUERY = gql`
+  query product(
+    $handle: String!
+  ) {
+    product: product(handle: $handle) {
+      product_features: metafield(
+        namespace: "my_fields"
+        key: "product_feature"
+      ) {
+        references(first: 5) {
+          edges {
+            node {
+              ... on ContentEntry {
+                heading: field(key: "heading") {
+                  value
+                }
+                tagline: field(key: "tagline") {
+                  value
+                }
+                description: field(key: "description") {
+                  value
+                }
+                featured_image: field(key: "featured_image") {
+                  value
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+```
+
+{% endcodeblock %}
+
+![Product features content in a custom storefront](/assets/custom-storefronts/hydrogen/hydrogen-content.gif)
+
+## Next steps
+
+- Learn more about [the Content platform](https://help.shopify.com/en/manual/content).

--- a/docs/framework/integrate-react-frameworks.md
+++ b/docs/framework/integrate-react-frameworks.md
@@ -1,0 +1,90 @@
+---
+gid: 473df70d-1ca3-37v9-ab92-0d91efb8c97c
+title: Integrate with other React frameworks
+description: Learn how to integrate Hydrogen with an existing React framework that you're using.
+---
+
+The majority of [Hydrogen components](https://shopify.dev/api/hydrogen/components) accept data from the Storefront API and render just like regular React components. This means you can use Hydrogen components in other React frameworks like [Next.js](https://nextjs.org/) or [Gatsby](https://www.gatsbyjs.com/).
+
+Shopify hasn't optimized integrating with other frameworks for the developer preview, so you need to follow some special instructions to make it work. While the instructions in this guide are specific Next.js, you can follow a similar pattern to support other frameworks.
+
+## Get started with Next.js
+
+1. In your Next.js app, install Hydrogen and `next-transpile-modules`:
+
+    {% codeblock terminal %}
+
+    ```bash?filename: 'Terminal', title: 'yarn'
+    yarn add @shopify/hydrogen next-transpile-modules
+    ```
+
+    ```bash?filename: 'Terminal', title: 'npm'
+    npm install @shopify/hydrogen next-transpile-modules --save
+    ```
+
+    {% endcodeblock %}
+
+2. Instruct Next.js to compile `@shopify/hydrogen` from ESM (ES Modules) to CJS (CommonJS) by editing your `next.config.js` file:
+
+    {% codeblock file, filename: 'next.config.js' %}
+
+    ```js
+    // Hydrogen components are only exported as ESM, not CJS. Shopify will support
+    // multiple export types in a future version of Hydrogen, so the extra transpile
+    // step is a temporary workaround.
+    const withTM = require("next-transpile-modules")(["@shopify/hydrogen"]);
+
+    module.exports = withTM({
+      reactStrictMode: true,
+    });
+    ```
+
+    {% endcodeblock %}
+
+## Fetch data in Next.js
+
+Shopify recommends calling the Storefront API on the server. Hydrogen will soon introduce a mechanism to make server-to-server calls without exhausting rate limits, so it's best to structure your apps this way from the start.
+
+The following example shows the general structure of a product page in Next.js. For more information, refer to the [Hydrogen components in Next.js GitHub discussion](https://github.com/Shopify/hydrogen/discussions/240).
+
+{% codeblock file, filename: 'routes/products/[handle].js' %}
+
+```js
+import {Product} from '@shopify/hydrogen';
+
+export async function getStaticProps({params}) {
+  // Shopify recommends writing a utility like `getShopifyData({query, variables})`,
+  // which takes your Storefront API credentials and makes a GraphQL query. You can then
+  // use this in the Next.js functions.
+  const {data} = getShopifyData({query: QUERY, variables: {handle: params.handle}});
+
+  return {
+    props: data,
+    revalidate: 5,
+  };
+}
+
+export function Product({data}) {
+  return (
+    <Product product={data.product}>
+      {/** ... */}
+    </Product>
+  );
+}
+```
+
+{% endcodeblock %}
+
+## Limitations
+
+The following limitations apply when using Hydrogen components in Next.js.
+
+### You can't use `useShopQuery` in Next.js
+
+You can't use [`useShopQuery`](https://shopify.dev/api/hydrogen/hooks/global/useshopquery) in Next.js because it's a hook that is meant to be run in Hydrogen's server components. Since the stable version of Next.js doesn't allow you to render a component only on the server, you need to fetch data in a `getStaticProps` or `getServerSideProps` function instead.
+
+### You can't use server components in Next.js
+
+Hydrogen is currently using a modified version of server components which supports context and SSR (server-side rendering). This isn't yet supported in the version of server components that Next.js uses.
+
+If you want to use the Alpha version of server components in Next.js, then you need to wrap any Hydrogen component that use `Context` in `*.client.js` components. This is the only way to currently use context in Next.js server components.

--- a/docs/framework/static-assets.md
+++ b/docs/framework/static-assets.md
@@ -32,7 +32,7 @@ export default function Hero() {
 
 If you're [using Oxygen to deploy your Hydrogen custom storefront](https://shopify.dev/custom-storefronts/hydrogen/deployment#deploy-to-oxygen), then static assets are automatically deployed to Shopify's content delivery network (CDN).
 
-Shopify provides merchants with a world-class CDN backed by [Fastly](https://www.fastly.com) and [Cloudflare](https://cloudflare.com/). Using a CDN means that your custom storefront will load quickly around the globe.
+Shopify provides merchants with a world-class CDN backed by [Cloudflare](https://cloudflare.com/). Using a CDN means that your custom storefront will load quickly around the globe.
 
 Files delivered over the Shopify CDN are minified and compressed automatically using [Brotli](https://github.com/google/brotli), [Zopfli](https://github.com/google/zopfli), and [gzip](https://en.wikipedia.org/wiki/Gzip), reducing the size of the files the browser must download. Requests use [HTTP/3](https://developers.cloudflare.com/http3/) and [TLS 1.3](https://www.cloudflare.com/learning-resources/tls-1-3/) to further enhance request performance and security.
 


### PR DESCRIPTION
## This PR: 
- Removes an outdated reference to Fastly in the static assets docs
- Adds two new source framework docs: "Integrate with other React frameworks" and "Integrate content with Hydrogen" (previously only available in the `shopify-dev` repo)
- Relates to https://shopify.slack.com/archives/C028UNNRJAH/p1654723244951129 and https://github.com/Shopify/shopify-dev/pull/21360