### PR TITLE
[Demo Store Neue] Create `Drawer` UI component

### DIFF
--- a/templates/demo-store-neue/src/components/blocks/Drawer.client.jsx
+++ b/templates/demo-store-neue/src/components/blocks/Drawer.client.jsx
@@ -1,0 +1,75 @@
+import {Dialog, Transition} from '@headlessui/react';
+import {Fragment, useState} from 'react';
+
+/**
+ * Drawer component that opens on user click.
+ * @param open - boolean state. if true opens the drawer.
+ * @param onClose - function should set the open state.
+ * @param title - title to set aria-labelledby.
+ * @param children - react children node.
+ */
+export function Drawer({open, onClose, title, children}) {
+  return (
+    <Transition appear show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0 left-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-hidden">
+          <div className="absolute inset-0 overflow-hidden">
+            <div className="fixed inset-y-0 right-0 flex max-w-full pl-10">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <Dialog.Panel className="w-full max-w-md transform overflow-hidden bg-white p-6 text-left align-middle shadow-xl transition-all">
+                  {title && (
+                    <Dialog.Title
+                      as="h3"
+                      className="text-lg font-medium leading-6 text-gray-900"
+                    >
+                      {title}
+                    </Dialog.Title>
+                  )}
+                  {children}
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}
+
+export function useDrawer(openDefault = false) {
+  const [isOpen, setIsOpen] = useState(openDefault);
+
+  function openDrawer() {
+    setIsOpen(true);
+  }
+
+  function closeDrawer() {
+    setIsOpen(false);
+  }
+
+  return {
+    isOpen,
+    openDrawer,
+    closeDrawer,
+  };
+}

--- a/templates/demo-store-neue/src/components/blocks/index.js
+++ b/templates/demo-store-neue/src/components/blocks/index.js
@@ -2,3 +2,4 @@ export {CountrySelector} from './CountrySelector.client';
 export {LocationCard} from './LocationCard';
 export {OrderCard} from './OrderCard.client';
 export {ProductCard} from './ProductCard.client';
+export {Drawer} from './Drawer.client';

--- a/templates/demo-store-neue/src/components/sections/Header.client.jsx
+++ b/templates/demo-store-neue/src/components/sections/Header.client.jsx
@@ -9,23 +9,50 @@ import {
   Input,
   Heading,
 } from '~/components/elements';
+import {Drawer, useDrawer} from '../blocks/Drawer.client';
 
 /**
  * A client component that specifies the content of the header on the website
  */
 export function Header({title, menu}) {
   const {pathname} = useUrl();
+  const {isOpen, openDrawer, closeDrawer} = useDrawer();
+
   const isHome = pathname === '/';
 
   return (
     <>
-      <DesktopHeader isHome={isHome} title={title} menu={menu} />
-      <MobileHeader isHome={isHome} title={title} />
+      {/* TODO: Drawer will be removed and added into a Cart component. left it here for reviewing purposes */}
+      <Drawer open={isOpen} onClose={closeDrawer} title="Cart">
+        <div className="mt-2">
+          <p className="text-sm text-gray-500">
+            Your payment has been successfully submitted. We’ve sent you an
+            email with all of the details of your order.
+          </p>
+        </div>
+
+        <div className="mt-4">
+          <button
+            type="button"
+            className="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            onClick={closeDrawer}
+          >
+            Got it, thanks!
+          </button>
+        </div>
+      </Drawer>
+      <DesktopHeader
+        isHome={isHome}
+        title={title}
+        menu={menu}
+        openDrawer={openDrawer}
+      />
+      <MobileHeader isHome={isHome} title={title} openDrawer={openDrawer} />
     </>
   );
 }
 
-function MobileHeader({title, isHome}) {
+function MobileHeader({title, isHome, openDrawer}) {
   const styles = {
     button: 'relative flex items-center justify-center w-8 h-8',
     container: `${
@@ -74,16 +101,16 @@ function MobileHeader({title, isHome}) {
         <button className={styles.button}>
           <IconAccount />
         </button>
-        <Link to={'/cart'} className={styles.button}>
+        <button onClick={openDrawer} className={styles.button}>
           <IconBag />
           <CartBadge dark={isHome} />
-        </Link>
+        </button>
       </div>
     </header>
   );
 }
 
-function DesktopHeader({title, isHome, menu}) {
+function DesktopHeader({title, isHome, menu, openDrawer}) {
   const styles = {
     button: 'relative flex items-center justify-center w-8 h-8',
     container: `${
@@ -132,10 +159,10 @@ function DesktopHeader({title, isHome, menu}) {
         <Link to={'/account'} className={styles.button}>
           <IconAccount />
         </Link>
-        <Link to={'/cart'} className={styles.button}>
+        <button onClick={openDrawer} className={styles.button}>
           <IconBag />
           <CartBadge dark={isHome} />
-        </Link>
+        </button>
       </div>
     </header>
   );


### PR DESCRIPTION
### Description
Creates a new Drawer component for the new demo store


<img src="https://user-images.githubusercontent.com/1143424/172845549-d571f4f5-6f42-492f-be09-fa692f3e6bf7.gif" width="400" alt="gif of drawer opening and closing"/>

**Next PRs:**
- Abstract more into a Global Cart UI component
- Fix styling details

### Additional context
I used tailwind headless dialog to create the sidebar quick, this has the nice side-effect of including accessibility by default.

I made it a client component since tailwind uses js state in the components.

Interesting for the future: could we have made this more of a server component?

