### PR TITLE
Fix writable status in CFW

### DIFF
--- a/.changeset/funny-horses-look.md
+++ b/.changeset/funny-horses-look.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix read-only request.status in worker environments.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1488

In CFW, it's not possible to make `request.status` readable by just overriding the property in a class (perhaps a bug in the implementation). This workaround uses a Proxy to intercept `status` and `statusText` and read it from a local object instead of reading from the request itself.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
