### PR TITLE
Fix `Image` component tests

### DIFF
--- a/packages/hydrogen/src/components/Image/tests/Image.test.tsx
+++ b/packages/hydrogen/src/components/Image/tests/Image.test.tsx
@@ -153,6 +153,27 @@ describe('<Image />', () => {
         .join(', ');
       const image = getPreviewImage({
         url: mockUrl,
+        width: 2560,
+        height: 2560,
+      });
+
+      const component = mount(<Image data={image} />);
+
+      expect(component).toContainReactComponent('img', {
+        srcSet: expectedSrcset,
+      });
+    });
+
+    it('generates a default srcset up to the image height and width', () => {
+      const mockUrl = 'https://cdn.shopify.com/someimage.jpg';
+      const sizes = [352, 832];
+      const expectedSrcset = sizes
+        .map((size) => `${mockUrl}?width=${size} ${size}w`)
+        .join(', ');
+      const image = getPreviewImage({
+        url: mockUrl,
+        width: 832,
+        height: 832,
       });
 
       const component = mount(<Image data={image} />);


### PR DESCRIPTION
### Description
`Image` component seems to be having intermittent test issues 
![image](https://user-images.githubusercontent.com/1143424/172904356-572ad911-0c73-4d9b-93ff-50d9eab2bad1.png)


### Additional context
The issue is causes because the image source set is generated up to the width and height values provided to the `Image` component.

Faker was generating sometimes lower values and causing tests to fail. 
Fixed the test and added a test for a lower image size generating less source set sizes.
