### PR TITLE
Use the default cart fragment for BuyNowButton

### DIFF
--- a/.changeset/lazy-gifts-notice.md
+++ b/.changeset/lazy-gifts-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix `<BuyNowButton>` so it can be rendered without being nested in a `<CartProvider>`

--- a/packages/hydrogen/src/components/CartProvider/hooks.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/hooks.client.tsx
@@ -2,13 +2,12 @@ import React, {useState} from 'react';
 import {useShop} from '../../foundation';
 import {flattenConnection} from '../../utilities';
 import {CartInput} from '../../storefront-api-types';
-import {CartCreate} from './cart-queries';
+import {CartCreate, defaultCartFragment} from './cart-queries';
 import {
   CartCreateMutation,
   CartCreateMutationVariables,
 } from './graphql/CartCreateMutation';
 import {Cart} from './types';
-import {useCart} from '../../hooks/useCart';
 
 export function useCartFetch() {
   const {storeDomain, storefrontApiVersion, storefrontToken} = useShop();
@@ -50,7 +49,6 @@ export function useCartFetch() {
 }
 
 export function useInstantCheckout() {
-  const {cartFragment} = useCart();
   const [cart, updateCart] = useState<Cart | undefined>();
   const [checkoutUrl, updateCheckoutUrl] = useState<Cart['checkoutUrl']>();
   const [error, updateError] = useState<string | undefined>();
@@ -63,7 +61,7 @@ export function useInstantCheckout() {
         CartCreateMutationVariables,
         CartCreateMutation
       >({
-        query: CartCreate(cartFragment),
+        query: CartCreate(defaultCartFragment),
         variables: {
           input: cartInput,
         },
@@ -86,7 +84,7 @@ export function useInstantCheckout() {
         updateCheckoutUrl(dataCart.checkoutUrl);
       }
     },
-    [cartFragment, fetch]
+    [fetch]
   );
 
   return {cart, checkoutUrl, error, createInstantCheckout};


### PR DESCRIPTION
### Description

Fixes #1352 

The BuyNowButton doesn't need to be customized at all, so we don't need to rely on the CartProvider.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
