### PR TITLE
Docs: Fix `fetchSync` hook name in example

### DIFF
--- a/docs/framework/work-with-rsc.md
+++ b/docs/framework/work-with-rsc.md
@@ -70,7 +70,7 @@ To make a third-party HTTP request on the client, use the [`fetchSync`](https://
 {% codeblock file, filename: 'PostDetails.client.jsx' %}
 
 ```js
-import {syncFetch} from '@shopify/hydrogen';
+import {fetchSync} from '@shopify/hydrogen';
 import {Suspense, useState} from 'react';
 export default function PostDetails() {
   const [show, setShow] = useState(false);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Quick docs fix for this here: https://github.com/Shopify/shopify-dev/pull/21460

> ## Problem
> Incorrect Hydrogen `syncFetch` hook name in example here:
> https://shopify.dev/custom-storefronts/hydrogen/framework/work-with-rsc#fetching-data-on-the-client
> 
> ## Solution
> The correct hook name is `fetchSync` 😄  - [docs for reference](https://shopify.dev/api/hydrogen/hooks/global/fetchsync)
> 
> | Before        | After         |
> | ---------- | ----------- | 
> | ![10-50-oa2lp-9e094](https://user-images.githubusercontent.com/48892838/172986969-061c2e5d-f0d8-40b4-a07b-17721de2a1a7.png) | ![10-49-3rgwf-ewu8p](https://user-images.githubusercontent.com/48892838/172986692-bbf5c23d-6c06-4adc-a121-92178d8b3889.png) |

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
