### PR TITLE
Add failing test for non-function JSX error

### DIFF
--- a/packages/playground/server-components/src/components/NonFunctionJsx.jsx
+++ b/packages/playground/server-components/src/components/NonFunctionJsx.jsx
@@ -1,0 +1,7 @@
+const Components = {
+  foo: [<p key="foo">Hello</p>],
+};
+
+export function Hello() {
+  return Components.foo[0];
+}

--- a/packages/playground/server-components/src/routes/index.server.jsx
+++ b/packages/playground/server-components/src/routes/index.server.jsx
@@ -1,4 +1,5 @@
 import {Link} from '@shopify/hydrogen';
+import {Hello} from '../components/NonFunctionJsx';
 
 export function api() {
   return new Response('some api response');
@@ -18,6 +19,9 @@ export default function Index() {
       <Link className="redirect-btn" to="/redirected">
         Redirect
       </Link>
+
+      {/* This should not result in a build error */}
+      <Hello />
     </>
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds a failing test which reproduces a build error we encounter when JSX is defined outside of the body of a function (e.g. in an object or array).

```
TypeError: __vite_ssr_import_0__.jsxDEV is not a function
    at /Users/joshlarson/src/github.com/Shopify/hydrogen/packages/playground/server-components/src/components/NonFunctionJsx.jsx:2:8
    at instantiateModule (/Users/joshlarson/src/github.com/Shopify/hydrogen/node_modules/vite/dist/node/chunks/dep-59dc6e00.js:59333:9)
✓ 39 modules transformed.
[vite-plugin-react-server-components] Could not load server build entries: __vite_ssr_import_0__.jsxDEV is not a function
```

Something is up with the React JSX runtime injected, and perhaps our react-dom-server-vite logic.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
