### PR TITLE
Fixes layout for FeaturedCollections and ProductGrid

### DIFF
--- a/templates/demo-store-neue/src/components/sections/FeaturedCollections.jsx
+++ b/templates/demo-store-neue/src/components/sections/FeaturedCollections.jsx
@@ -4,25 +4,32 @@ import {Heading, Section, Grid} from '~/components/elements';
 
 // TODO: This should be consolidated with Locations into a more generic presentational component
 export function FeaturedCollections({data, title = 'Collections', ...props}) {
+  const items = data.filter((item) => item.image).length;
+
   return (
     <Section heading={title} {...props}>
-      <Grid items={data.length}>
-        {data.map((collection) => (
-          <Link key={collection.id} to={`/collections/${collection.handle}`}>
-            <div className="grid gap-4">
-              {collection?.image && (
-                <Image
-                  className="rounded shadow-border overflow-clip inline-block aspect-[5/4] md:aspect-[3/2] object-cover"
-                  width={'100%'}
-                  height={336}
-                  alt={`Image of ${collection.title}`}
-                  data={collection.image}
-                />
-              )}
-              <Heading size="copy">{collection.title}</Heading>
-            </div>
-          </Link>
-        ))}
+      <Grid items={items}>
+        {data.map((collection) => {
+          if (!collection?.image) {
+            return null;
+          }
+          return (
+            <Link key={collection.id} to={`/collections/${collection.handle}`}>
+              <div className="grid gap-4">
+                {collection?.image && (
+                  <Image
+                    className="rounded shadow-border overflow-clip inline-block aspect-[5/4] md:aspect-[3/2] object-cover"
+                    width={'100%'}
+                    height={336}
+                    alt={`Image of ${collection.title}`}
+                    data={collection.image}
+                  />
+                )}
+                <Heading size="copy">{collection.title}</Heading>
+              </div>
+            </Link>
+          );
+        })}
       </Grid>
     </Section>
   );

--- a/templates/demo-store-neue/src/components/sections/FeaturedCollections.jsx
+++ b/templates/demo-store-neue/src/components/sections/FeaturedCollections.jsx
@@ -7,7 +7,7 @@ export function FeaturedCollections({data, title = 'Collections', ...props}) {
   const items = data.filter((item) => item.image).length;
 
   return (
-    <Section heading={title} {...props}>
+    <Section {...props} heading={title}>
       <Grid items={items}>
         {data.map((collection) => {
           if (!collection?.image) {

--- a/templates/demo-store-neue/src/components/sections/ProductGrid.client.jsx
+++ b/templates/demo-store-neue/src/components/sections/ProductGrid.client.jsx
@@ -59,7 +59,7 @@ export function ProductGrid({data}) {
 
   return (
     <>
-      <Grid>
+      <Grid layout="products">
         {products.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixes the layout for featured collections and product grid to account for missing images (featured collections) and the desire for 2-up product cards on collection pages on mobile)
<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
