### PR TITLE
Fix tests broken due to change in data

### DIFF
--- a/packages/hydrogen/src/foundation/useUrl/tests/useUrl-ssr.test.tsx
+++ b/packages/hydrogen/src/foundation/useUrl/tests/useUrl-ssr.test.tsx
@@ -25,7 +25,7 @@ describe('useUrl() in SSR', () => {
 
   it('returns url object using useServerRequest url', () => {
     const mockUrl =
-      'https://hydrogen-preview.myshopify.com/collections/freestyle-collection';
+      'https://hydrogen-preview.myshopify.com/collections/freestyle';
 
     useEnvContextMock.mockReturnValue(mockUrl);
     const callbackSpy = jest.fn();
@@ -37,7 +37,7 @@ describe('useUrl() in SSR', () => {
 
   it(`returns url object using a parsed url from state param and origin when the pathname is ${RSC_PATHNAME}`, () => {
     const origin = 'https://hydrogen-preview.myshopify.com';
-    const state = {pathname: '/collections/freestyle-collection'};
+    const state = {pathname: '/collections/freestyle'};
 
     const mockUrl = `${origin}${RSC_PATHNAME}?state=${encodeURIComponent(
       JSON.stringify(state)

--- a/templates/demo-store-neue/src/lib/placeholders.js
+++ b/templates/demo-store-neue/src/lib/placeholders.js
@@ -10,7 +10,7 @@ export const hero = {
     value: 'Shop Now →',
   },
   url: {
-    value: '/collections/freestyle-collection',
+    value: '/collections/freestyle',
   },
   spread: {
     reference: {

--- a/templates/demo-store/src/components/account/OrderHistory.server.jsx
+++ b/templates/demo-store/src/components/account/OrderHistory.server.jsx
@@ -50,7 +50,7 @@ function EmptyOrders() {
       <div className="my-4 text-gray-500">No orders yet</div>
       <div className="flex items-center justify-between">
         <Link
-          to="/collections/freestyle-collection"
+          to="/collections/freestyle"
           className="text-center border border-gray-900 uppercase py-3 px-4 focus:shadow-outline block w-full"
         >
           Start shopping

--- a/templates/demo-store/tests/e2e/collections.test.js
+++ b/templates/demo-store/tests/e2e/collections.test.js
@@ -19,11 +19,11 @@ describe('collections', () => {
   });
 
   it('should have the correct title', async () => {
-    await session.visit('/collections/freestyle-collection');
+    await session.visit('/collections/freestyle');
     const heading = await session.page.locator('h1').first();
     expect(heading).not.toBeNull();
 
     const text = await heading.textContent();
-    expect(text).toBe('Freestyle Collection');
+    expect(text).toBe('Freestyle');
   }, 60000);
 });

--- a/templates/demo-store/tests/e2e/performance-metrics.test.js
+++ b/templates/demo-store/tests/e2e/performance-metrics.test.js
@@ -36,7 +36,7 @@ describe('Performance metrics', () => {
   }, 60000);
 
   it('should emit performance on sub load', async () => {
-    const collectionPath = '/collections/freestyle-collection';
+    const collectionPath = '/collections/freestyle';
     // Full load
     await Promise.all([
       session.page.waitForRequest(eventsEndpoint),

--- a/templates/demo-store/tests/e2e/shopify-analytics.test.js
+++ b/templates/demo-store/tests/e2e/shopify-analytics.test.js
@@ -45,7 +45,7 @@ describe('analytics', () => {
   it(
     'should emit page-view on sub load',
     async () => {
-      const collectionPath = '/collections/freestyle-collection';
+      const collectionPath = '/collections/freestyle';
       // Full load
       await Promise.all([
         session.page.waitForRequest(eventsEndpoint),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It looks like `freestyle-collection` was renamed to `freestyle` in the preview shop, and this breaks a bunch of tests and links.

---

### Before submitting the PR, please make sure you do the following:

- x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
