### PR TITLE
[Hydrogen docs]: Put content topic behind a `hidden` flag

### DIFF
--- a/docs/framework/content.md
+++ b/docs/framework/content.md
@@ -2,7 +2,7 @@
 gid: bf2cb121-f051-4eb2-bb37-aa1738361b23
 title: Integrate content in Hydrogen
 description: Learn how to integrate content on your Hydrogen storefront.
-feature_flag: hydrogen_tutorials
+hidden: true
 ---
 
 > Beta:


### PR DESCRIPTION
## This PR: 
- Applies the `hidden` flag to the topic on integrating content
- Relates to https://shopify.slack.com/archives/C02BA6FD7D5/p1655146886732169?thread_ts=1655129278.005829&cid=C02BA6FD7D5