### PR TITLE
Fix formData in Node 16-17

### DIFF
--- a/.changeset/strong-parrots-sneeze.md
+++ b/.changeset/strong-parrots-sneeze.md
@@ -1,0 +1,16 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add support for `Request.formData()` within API Routes for Node 16-17. Example:
+
+```ts
+export async function api(request) {
+  const formData = await request.formData();
+
+  const username = formData.get('user');
+  const password = formData.get('pass');
+
+  ...
+}
+```

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -129,6 +129,7 @@
     "uuid": "^8.3.2",
     "vite-plugin-inspect": "^0.3.6",
     "web-streams-polyfill": "^3.2.0",
-    "worktop": "^0.7.3"
+    "worktop": "^0.7.3",
+    "undici": "^5.5.1"
   }
 }

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -185,7 +185,7 @@ export class HydrogenRequest extends Request {
 
   public async formData(): Promise<FormData> {
     // @ts-ignore
-    if (super.formData) return super.formData();
+    if (!__HYDROGEN_WORKER__ && super.formData) return super.formData();
 
     const contentType = this.headers.get('Content-Type') || '';
 
@@ -199,10 +199,10 @@ export class HydrogenRequest extends Request {
       let entries;
       try {
         entries = new URLSearchParams(await this.text());
-      } catch (err) {
+      } catch (err: any) {
         // istanbul ignore next: Unclear when new URLSearchParams can fail on a string.
         // 2. If entries is failure, then throw a TypeError.
-        throw Object.assign(new TypeError(), {cause: err});
+        throw new TypeError(undefined, {cause: err as Error});
       }
 
       // 3. Return a new FormData object whose entries are entries.

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -101,6 +101,7 @@ export default () => {
           'react/jsx-runtime',
           // https://github.com/nfriedly/set-cookie-parser/issues/50
           'set-cookie-parser',
+          'undici',
         ],
       },
 

--- a/packages/hydrogen/src/utilities/web-api-polyfill.ts
+++ b/packages/hydrogen/src/utilities/web-api-polyfill.ts
@@ -5,6 +5,7 @@ import {
   WritableStream,
   TransformStream,
 } from 'web-streams-polyfill/ponyfill';
+import {FormData} from 'undici';
 
 if (!globalThis.fetch) {
   Object.assign(globalThis, {
@@ -13,6 +14,12 @@ if (!globalThis.fetch) {
     Response,
     Headers,
     AbortController,
+  });
+}
+
+if (!globalThis.FormData) {
+  Object.assign(globalThis, {
+    FormData,
   });
 }
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -437,7 +437,7 @@ export default async function testCases({
       expect(data).toEqual({data: {shop: {name: 'Snowdevil'}}});
     });
 
-    it.skip('supports form request on API routes', async () => {
+    it('supports form request on API routes', async () => {
       await page.goto(getServerUrl() + '/form');
       await page.type('#fname', 'sometext');
       await page.click('#fsubmit');

--- a/yarn.lock
+++ b/yarn.lock
@@ -14518,6 +14518,11 @@ undici@5.3.0, undici@^5.1.0:
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.3.0.tgz#869d47bafa7f72ccaf8738258f0283bf3dd179ca"
   integrity sha512-8LxC/xmR2GCE4q1heE1sJxVnnf5S6yQ2dObvMFBBWkB8aQlaqNuWovgRFWRMB7KUdLPGZfOTTmUeeLEJYX56iQ==
 
+undici@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.5.1.tgz#baaf25844a99eaa0b22e1ef8d205bffe587c8f43"
+  integrity sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==
+
 unherit@^1.0.4:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"


### PR DESCRIPTION
Resolves https://github.com/Shopify/hydrogen/issues/1505

Add support for `Request.formData()` within API Routes for Node 16-17. Example:

```ts
export async function api(request) {
  const formData = await request.formData();

  const username = formData.get('user');
  const password = formData.get('pass');

  ...
}
```

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
