### PR TITLE
Support renaming client component exports in intermediate files

### DIFF
--- a/.changeset/cold-buses-argue.md
+++ b/.changeset/cold-buses-argue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Support renaming client component exports in intermediate/facade files.

--- a/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
@@ -409,21 +409,61 @@ var hashImportsPlugin = {
     }
   }
 };
+
 /**
  * A client module should behave as a client boundary
  * if it is imported by the server before encountering
  * another boundary in the process.
- * Traverse the module graph upwards to find non client
- * components that import the current module.
+ * This traverses the module graph upwards to find non client
+ * components that import the `originalMod`.
+ *
+ * The `accModInfo` represents the exported members from the
+ * `originalMod` but renamed accordingly to all the intermediate/facade
+ * files in the import chain from the `originalMod` to every parent importer.
  */
-
-function isDirectImportInServer(currentMod, originalMod) {
+function isDirectImportInServer(originalMod, currentMod, accModInfo) {
   // TODO: this should use recursion in any module that exports
   // the original one, not only in full facade files.
-  if (!originalMod || (currentMod.meta || {}).isFacade) {
-    return Array.from(currentMod.importers).some(function (importer) {
+  if (!currentMod || (currentMod.meta || {}).isFacade) {
+    if (!accModInfo && originalMod.meta && originalMod.meta.namedExports) {
+      // First iteration in the recursion, initialize the
+      // acumulator with data from the original module.
+      accModInfo = {
+        file: originalMod.file,
+        exports: originalMod.meta.namedExports
+      };
+    }
+
+    if (currentMod && accModInfo) {
+      // Update accumulator in subsequent iterations with
+      // whatever the current module is re-exporting.
+      var lastModExports = accModInfo.exports;
+      var lastModImports = currentMod.meta.imports.filter(function (importMeta) {
+        return importMeta.action === 'export' && importMeta.from === accModInfo.file;
+      });
+      accModInfo = {
+        file: currentMod.file,
+        exports: []
+      };
+      lastModImports.forEach(function (mod) {
+        mod.variables.forEach(function (_ref2) {
+          var name = _ref2[0],
+              alias = _ref2[1];
+
+          if (name === '*' && !alias) {
+            var _accModInfo$exports;
+
+            (_accModInfo$exports = accModInfo.exports).push.apply(_accModInfo$exports, lastModExports);
+          } else {
+            accModInfo.exports.push(alias || name);
+          }
+        });
+      });
+    }
+
+    return Array.from((currentMod || originalMod).importers).some(function (importer) {
       return (// eslint-disable-next-line no-unused-vars
-        isDirectImportInServer(importer, originalMod || currentMod)
+        isDirectImportInServer(originalMod, importer, accModInfo)
       );
     });
   } // Not enough information: safer to assume it is
@@ -439,14 +479,12 @@ function isDirectImportInServer(currentMod, originalMod) {
   // However, due to the lack of tree-shaking in the dev module graph,
   // we need to manually make sure this module is importing something from
   // the original module before marking it as client boundary.
-  // -- TODO: this only checks namedExports right now. It should
-  // consider default exports and variable renaming in facade modules.
 
   return currentMod.meta.imports.some(function (imp) {
-    return imp.action === 'import' && (imp.from === originalMod.file || (imp.variables || []).some(function (_ref2) {
-      var name = _ref2[0];
-      return originalMod.meta.namedExports.includes(name);
-    }));
+    return imp.action === 'import' && imp.from === accModInfo.file && (imp.variables || []).some(function (_ref3) {
+      var name = _ref3[0];
+      return accModInfo.exports.includes(name);
+    });
   });
 }
 
@@ -482,12 +520,12 @@ function augmentModuleGraph(moduleGraph, id, code, root, resolveAlias) {
 
 
   var imports = [];
-  rawImports.forEach(function (_ref3) {
-    var startMod = _ref3.s,
-        endMod = _ref3.e,
-        dynamicImportIndex = _ref3.d,
-        startStatement = _ref3.ss,
-        endStatement = _ref3.se;
+  rawImports.forEach(function (_ref4) {
+    var startMod = _ref4.s,
+        endMod = _ref4.e,
+        dynamicImportIndex = _ref4.d,
+        startStatement = _ref4.ss,
+        endStatement = _ref4.se;
     if (dynamicImportIndex !== -1) return; // Skip dynamic imports for now
 
     var rawModPath = code.slice(startMod, endMod);
@@ -513,7 +551,7 @@ function augmentModuleGraph(moduleGraph, id, code, root, resolveAlias) {
       action: action,
       // 'import' or 'export'
       variables: variables // [['originalName', 'alias']]
-      .replace(/[{}]/gm, '').trim().split(/\s*,\s*/m).filter(Boolean).map(function (s) {
+      .trim().replace(/^[^{*]/, 'default as $&').replace(/[{}]/gm, '').trim().split(/\s*,\s*/m).filter(Boolean).map(function (s) {
         return s.split(/\s+as\s+/m);
       }),
       from: resolvedPath,

--- a/packages/playground/server-components/src/components/index.ts
+++ b/packages/playground/server-components/src/components/index.ts
@@ -1,0 +1,1 @@
+export {default as Counter} from './Counter.client';

--- a/packages/playground/server-components/src/components/index2.ts
+++ b/packages/playground/server-components/src/components/index2.ts
@@ -1,0 +1,1 @@
+export {Counter as ClientCounter} from './index';

--- a/packages/playground/server-components/src/components/index3.ts
+++ b/packages/playground/server-components/src/components/index3.ts
@@ -1,0 +1,1 @@
+export * from './index2';

--- a/packages/playground/server-components/src/routes/about.server.jsx
+++ b/packages/playground/server-components/src/routes/about.server.jsx
@@ -1,4 +1,4 @@
-import Counter from '../components/Counter.client';
+import {ClientCounter as Counter} from '../components/index3';
 
 export default function About() {
   return (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

A better module resolution was implemented in #1361. As mentioned in that PR, renaming exports in intermediate files (e.g. `export {default as XYZ} from './component.client.jsx`) wasn't supported.
Building on top of that code, this PR implements the export renaming behavior with all the variants: `export {X as Y} from`, `export * from`, `export * as XYZ from`.

cc @benjaminsehl @juanpprieto 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
