### PR TITLE
Remove server props from the account pages to make them snappy 🚀

### DIFF
--- a/templates/demo-store-neue/src/components/account/AccountAddressEdit.client.jsx
+++ b/templates/demo-store-neue/src/components/account/AccountAddressEdit.client.jsx
@@ -1,10 +1,10 @@
-import {useCallback, useState} from 'react';
-import {useServerProps} from '@shopify/hydrogen';
+import {useMemo, useState} from 'react';
+import {useRenderServerComponents} from '~/lib/utils';
 
 import {Button, Text} from '~/components';
 
-export function AccountAddressEdit({address, defaultAddress}) {
-  const {setServerProps} = useServerProps();
+export function AccountAddressEdit({address, defaultAddress, close}) {
+  const isNewAddress = useMemo(() => !Object.keys(address).length, [address]);
 
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState(null);
@@ -20,9 +20,8 @@ export function AccountAddressEdit({address, defaultAddress}) {
   const [phone, setPhone] = useState(address?.phone || '');
   const [isDefaultAddress, setIsDefaultAddress] = useState(defaultAddress);
 
-  const close = useCallback(() => {
-    setServerProps('editingAddress', null);
-  }, [setServerProps]);
+  // Necessary for edits to show up on the main page
+  const renderServerComponents = useRenderServerComponents();
 
   async function onSubmit(event) {
     event.preventDefault();
@@ -51,13 +50,14 @@ export function AccountAddressEdit({address, defaultAddress}) {
       return;
     }
 
+    renderServerComponents();
     close();
   }
 
   return (
     <>
       <Text className="mt-4 mb-6" as="h3" size="lead">
-        {address ? 'Edit address' : 'Add address'}
+        {isNewAddress ? 'Add address' : 'Edit address'}
       </Text>
       <div className="max-w-lg">
         <form noValidate onSubmit={onSubmit}>

--- a/templates/demo-store-neue/src/components/account/AccountDeleteAddress.client.jsx
+++ b/templates/demo-store-neue/src/components/account/AccountDeleteAddress.client.jsx
@@ -1,14 +1,9 @@
-import {useServerProps} from '@shopify/hydrogen';
-import {useCallback} from 'react';
+import {Text, Button} from '~/components/elements';
+import {useRenderServerComponents} from '~/lib/utils';
 
-import {Text, Button} from '~/components';
-
-export function AccountDeleteAddress({addressId}) {
-  const {serverProps, setServerProps} = useServerProps();
-
-  const close = useCallback(() => {
-    setServerProps('deletingAddress', null);
-  }, [setServerProps]);
+export function AccountDeleteAddress({addressId, close}) {
+  // Necessary for edits to show up on the main page
+  const renderServerComponents = useRenderServerComponents();
 
   async function deleteAddress(id) {
     const response = await callDeleteAddressApi(id);
@@ -16,7 +11,7 @@ export function AccountDeleteAddress({addressId}) {
       alert(response.error);
       return;
     }
-    setServerProps('rerender', !serverProps.rerender);
+    renderServerComponents();
     close();
   }
 
@@ -39,7 +34,7 @@ export function AccountDeleteAddress({addressId}) {
         </Button>
         <Button
           className="text-sm mt-2"
-          onClick={() => setServerProps('deletingAddress', null)}
+          onClick={close}
           variant="secondary"
           width="full"
         >

--- a/templates/demo-store-neue/src/components/account/AccountDetails.client.jsx
+++ b/templates/demo-store-neue/src/components/account/AccountDetails.client.jsx
@@ -1,43 +1,56 @@
-import {useServerProps} from '@shopify/hydrogen';
-import {useCallback} from 'react';
+import {Seo} from '@shopify/hydrogen';
+import {useState} from 'react';
+import {Modal} from '../index';
+import {AccountDetailsEdit} from '../index';
 
 export function AccountDetails({firstName, lastName, phone, email}) {
-  const {setServerProps} = useServerProps();
+  const [isEditing, setIsEditing] = useState(false);
 
-  const startEditing = useCallback(
-    () => setServerProps('editingAccount', true),
-    [setServerProps],
-  );
+  const close = () => setIsEditing(false);
 
   return (
-    <div className="grid w-full gap-4 p-4 py-6 md:gap-8 md:p-8 lg:p-12">
-      <h3 className="font-bold text-lead">Account Details</h3>
-      <div className="lg:p-8 p-6 border border-gray-200 rounded">
-        <div className="flex">
-          <h3 className="font-bold text-base flex-1">Profile & Security</h3>
-          <button
-            className="underline text-sm font-normal"
-            onClick={startEditing}
-          >
-            Edit
-          </button>
+    <>
+      {isEditing ? (
+        <Modal closeModalProp="editingAccount" close={close}>
+          <Seo type="noindex" data={{title: 'Account details'}} />
+          <AccountDetailsEdit
+            firstName={firstName}
+            lastName={lastName}
+            phone={phone}
+            email={email}
+            close={close}
+          />
+        </Modal>
+      ) : null}
+      <div className="grid w-full gap-4 p-4 py-6 md:gap-8 md:p-8 lg:p-12">
+        <h3 className="font-bold text-lead">Account Details</h3>
+        <div className="lg:p-8 p-6 border border-gray-200 rounded">
+          <div className="flex">
+            <h3 className="font-bold text-base flex-1">Profile & Security</h3>
+            <button
+              className="underline text-sm font-normal"
+              onClick={() => setIsEditing(true)}
+            >
+              Edit
+            </button>
+          </div>
+          <div className="mt-4 text-sm text-gray-500">Name</div>
+          <p className="mt-1">
+            {firstName || lastName
+              ? (firstName && firstName + ' ') + lastName
+              : 'Add name'}{' '}
+          </p>
+
+          <div className="mt-4 text-sm text-gray-500">Contact</div>
+          <p className="mt-1">{phone ?? 'Add mobile'}</p>
+
+          <div className="mt-4 text-sm text-gray-500">Email address</div>
+          <p className="mt-1">{email}</p>
+
+          <div className="mt-4 text-sm text-gray-500">Password</div>
+          <p className="mt-1">**************</p>
         </div>
-        <div className="mt-4 text-sm text-gray-500">Name</div>
-        <p className="mt-1">
-          {firstName || lastName
-            ? (firstName && firstName + ' ') + lastName
-            : 'Add name'}{' '}
-        </p>
-
-        <div className="mt-4 text-sm text-gray-500">Contact</div>
-        <p className="mt-1">{phone ?? 'Add mobile'}</p>
-
-        <div className="mt-4 text-sm text-gray-500">Email address</div>
-        <p className="mt-1">{email}</p>
-
-        <div className="mt-4 text-sm text-gray-500">Password</div>
-        <p className="mt-1">**************</p>
       </div>
-    </div>
+    </>
   );
 }

--- a/templates/demo-store-neue/src/components/account/AccountDetailsEdit.client.jsx
+++ b/templates/demo-store-neue/src/components/account/AccountDetailsEdit.client.jsx
@@ -1,17 +1,19 @@
-import {useCallback, useState} from 'react';
-import {useServerProps} from '@shopify/hydrogen';
+import {useState} from 'react';
 
 import {Text, Button} from '~/components';
-import {emailValidation, passwordValidation} from '~/lib/utils';
+import {
+  emailValidation,
+  passwordValidation,
+  useRenderServerComponents,
+} from '~/lib/utils';
 
 export function AccountDetailsEdit({
   firstName: _firstName = '',
   lastName: _lastName = '',
   phone: _phone = '',
   email: _email = '',
+  close,
 }) {
-  const {setServerProps} = useServerProps();
-
   const [saving, setSaving] = useState(false);
   const [firstName, setFirstName] = useState(_firstName);
   const [lastName, setLastName] = useState(_lastName);
@@ -23,10 +25,8 @@ export function AccountDetailsEdit({
   const [newPassword2Error, setNewPassword2Error] = useState();
   const [submitError, setSubmitError] = useState(null);
 
-  const close = useCallback(
-    () => setServerProps('editingAccount', false),
-    [setServerProps],
-  );
+  // Necessary for edits to show up on the main page
+  const renderServerComponents = useRenderServerComponents();
 
   async function onSubmit(event) {
     event.preventDefault();
@@ -91,6 +91,7 @@ export function AccountDetailsEdit({
       return;
     }
 
+    renderServerComponents();
     close();
   }
 
@@ -221,6 +222,7 @@ export function AccountDetailsEdit({
         </div>
         <div className="mb-4">
           <Button
+            type="button"
             className="text-sm"
             variant="secondary"
             width="full"

--- a/templates/demo-store-neue/src/components/global/Modal.client.jsx
+++ b/templates/demo-store-neue/src/components/global/Modal.client.jsx
@@ -1,13 +1,4 @@
-import {useCallback} from 'react';
-import {useServerProps} from '@shopify/hydrogen';
-
-export function Modal({children, closeModalProp}) {
-  const {setServerProps} = useServerProps();
-
-  const close = useCallback(() => {
-    setServerProps(closeModalProp, null);
-  }, [closeModalProp, setServerProps]);
-
+export function Modal({children, close}) {
   return (
     <div
       className="relative z-50"

--- a/templates/demo-store-neue/src/lib/utils.js
+++ b/templates/demo-store-neue/src/lib/utils.js
@@ -1,4 +1,22 @@
+// TODO: Split this into multiple files
+import {useServerProps} from '@shopify/hydrogen';
+import {useCallback} from 'react';
+
 import typographicBase from 'typographic-base';
+
+/**
+ * This is a hack until we have better built-in primitives for
+ * causing server components to re-render.
+ *
+ * @returns function when called will cause the current page to re-render on the server
+ */
+export function useRenderServerComponents() {
+  const {serverProps, setServerProps} = useServerProps();
+
+  return useCallback(() => {
+    setServerProps('renderRsc', !serverProps.renderRsc);
+  }, [serverProps, setServerProps]);
+}
 
 export function missingClass(string, prefix) {
   if (!string) {

--- a/templates/demo-store-neue/src/routes/account/index.server.jsx
+++ b/templates/demo-store-neue/src/routes/account/index.server.jsx
@@ -12,25 +12,16 @@ import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
 import {getApiErrorMessage} from '~/lib/utils';
 import {
   AccountAddressBook,
-  AccountAddressEdit,
-  AccountDeleteAddress,
   AccountDetails,
-  AccountDetailsEdit,
   AccountOrderHistory,
   FeaturedCollections,
   Layout,
   LogoutButton,
-  Modal,
   PageHeader,
   ProductSwimlane,
 } from '~/components';
 
-export default function Account({
-  response,
-  editingAccount,
-  editingAddress,
-  deletingAddress,
-}) {
+export default function Account({response}) {
   response.cache(CacheNone());
 
   const {customerAccessToken, countryCode = 'US'} = useSession();
@@ -45,7 +36,6 @@ export default function Account({
       customerAccessToken,
       language: languageCode,
       country: countryCode,
-      withAddressDetails: !!editingAddress,
     },
     cache: CacheNone(),
   });
@@ -64,77 +54,6 @@ export default function Account({
     0,
     customer.defaultAddress.id.lastIndexOf('?'),
   );
-
-  if (editingAccount) {
-    return (
-      <>
-        <AuthenticatedAccount
-          customer={customer}
-          addresses={addresses}
-          defaultAddress={defaultAddress}
-          featuredCollections={featuredCollections}
-          featuredProducts={featuredProducts}
-        />
-        <Modal closeModalProp="editingAccount">
-          <Seo type="noindex" data={{title: 'Account details'}} />
-          <AccountDetailsEdit
-            firstName={customer.firstName}
-            lastName={customer.lastName}
-            phone={customer.phone}
-            email={customer.email}
-          />
-        </Modal>
-      </>
-    );
-  }
-
-  if (editingAddress) {
-    const addressToEdit = addresses.find(
-      (address) => address.id === editingAddress,
-    );
-    return (
-      <>
-        <AuthenticatedAccount
-          customer={customer}
-          addresses={addresses}
-          defaultAddress={defaultAddress}
-          featuredCollections={featuredCollections}
-          featuredProducts={featuredProducts}
-        />
-        <Modal closeModalProp="editingAddress">
-          <Seo
-            type="noindex"
-            data={{title: addressToEdit ? 'Edit address' : 'Add address'}}
-          />
-          <AccountAddressEdit
-            address={addressToEdit}
-            defaultAddress={defaultAddress === editingAddress}
-          />
-        </Modal>
-      </>
-    );
-  }
-
-  if (deletingAddress) {
-    const addressToDelete = addresses.find(
-      (address) => address.id === deletingAddress,
-    );
-    return (
-      <>
-        <AuthenticatedAccount
-          customer={customer}
-          addresses={addresses}
-          defaultAddress={defaultAddress}
-          featuredCollections={featuredCollections}
-          featuredProducts={featuredProducts}
-        />
-        <Modal closeModalProp="deletingAddress">
-          <Seo type="noindex" data={{title: 'Delete address'}} />
-          <AccountDeleteAddress addressId={addressToDelete.originalId} />
-        </Modal>
-      </>
-    );
-  }
 
   return (
     <>
@@ -191,19 +110,11 @@ function AuthenticatedAccount({
 }
 
 export async function api(request, {session, queryShop}) {
-  if (request.method !== 'PATCH')
+  if (request.method !== 'PATCH' && request.method !== 'DELETE')
     return new Response(null, {
       status: 405,
       headers: {
-        Allow: 'PATCH',
-      },
-    });
-
-  if (request.method !== 'DELETE')
-    return new Response(null, {
-      status: 405,
-      headers: {
-        Allow: 'DELETE',
+        Allow: 'PATCH,DELETE',
       },
     });
 
@@ -241,7 +152,6 @@ const CUSTOMER_QUERY = gql`
   ${PRODUCT_CARD_FRAGMENT}
   query CustomerDetails(
     $customerAccessToken: String!
-    $withAddressDetails: Boolean!
     $country: CountryCode
     $language: LanguageCode
   ) @inContext(country: $country, language: $language) {
@@ -261,14 +171,14 @@ const CUSTOMER_QUERY = gql`
             formatted
             firstName
             lastName
-            company @include(if: $withAddressDetails)
-            address1 @include(if: $withAddressDetails)
-            address2 @include(if: $withAddressDetails)
-            country @include(if: $withAddressDetails)
-            province @include(if: $withAddressDetails)
-            city @include(if: $withAddressDetails)
-            zip @include(if: $withAddressDetails)
-            phone @include(if: $withAddressDetails)
+            company
+            address1
+            address2
+            country
+            province
+            city
+            zip
+            phone
           }
         }
       }


### PR DESCRIPTION
### Description

Server props are slow because they are a round trip to the server that re-renders the whole tree. This makes the account pages faster by using client state instead of server props.


### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
