### PR TITLE
[Demo Store Neue] Add ProductInfo accordion open/close icon

### DIFF
--- a/templates/demo-store-neue/src/components/elements/Icon.jsx
+++ b/templates/demo-store-neue/src/components/elements/Icon.jsx
@@ -1,16 +1,13 @@
-function Icon({
-  children,
-  className = 'w-5 h-5',
-  fill = 'currentColor',
-  ...props
-}) {
+import clsx from 'clsx';
+
+function Icon({children, className, fill = 'currentColor', ...props}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       {...props}
       fill={fill}
-      className={className}
+      className={clsx('w-5 h-5', className)}
     >
       {children}
     </svg>

--- a/templates/demo-store-neue/src/components/product/ProductInfo.client.jsx
+++ b/templates/demo-store-neue/src/components/product/ProductInfo.client.jsx
@@ -1,6 +1,6 @@
 import {Disclosure} from '@headlessui/react';
 
-import {Text} from '~/components';
+import {Text, IconClose} from '~/components';
 import {productInfo} from '~/lib/placeholders';
 
 export function ProductInfo({data = productInfo}) {
@@ -13,15 +13,26 @@ export function ProductInfo({data = productInfo}) {
           id={section.id}
           className="grid w-full gap-2"
         >
-          <Disclosure.Button className="text-left">
-            <Text size="lead" as="h4">
-              {section.title}
-            </Text>
-          </Disclosure.Button>
+          {({open}) => (
+            <>
+              <Disclosure.Button className="text-left">
+                <div className="flex justify-between">
+                  <Text size="lead" as="h4">
+                    {section.title}
+                  </Text>
+                  <IconClose
+                    className={`${
+                      open ? '' : 'rotate-[45deg]'
+                    } transition-transform transform-gpu duration-200`}
+                  />
+                </div>
+              </Disclosure.Button>
 
-          <Disclosure.Panel className={'pb-4'}>
-            <Text>{section.content}</Text>
-          </Disclosure.Panel>
+              <Disclosure.Panel className={'pb-4'}>
+                <Text>{section.content}</Text>
+              </Disclosure.Panel>
+            </>
+          )}
         </Disclosure>
       ))}
     </section>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds missing accordion open/close icon to the product page info panels
![caret](https://user-images.githubusercontent.com/12080141/173879486-8e7705e2-f481-48b1-ab35-9ec89e3b7a27.gif)


### Additional context

Just matching the figma design


### Update
Adam suggested we change the icon to `IconCadet` matching the country selector

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
