### PR TITLE
Fix buyerIdentityUpdate effect to run on country change

### DIFF
--- a/.changeset/empty-beans-lay.md
+++ b/.changeset/empty-beans-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Ensure the effect that updates the `cart.buyerIdenity.countryCode` is run when `countyCode` prop changes

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -273,6 +273,10 @@ export function CartProvider({
   );
   const fetchCart = useCartFetch();
 
+  const countryChanged =
+    state.status === 'idle' &&
+    countryCode !== state?.cart?.buyerIdentity?.countryCode;
+
   const cartFetch = useCallback(
     async (cartId: string) => {
       dispatch({type: 'cartFetch'});
@@ -680,12 +684,15 @@ export function CartProvider({
   }, [cartFetch, state]);
 
   useEffect(() => {
-    if (state.status !== 'idle') {
-      return;
-    }
+    if (!countryChanged) return;
     buyerIdentityUpdate({countryCode, customerAccessToken}, state);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [countryCode, customerAccessToken]);
+  }, [
+    state,
+    buyerIdentityUpdate,
+    countryCode,
+    customerAccessToken,
+    countryChanged,
+  ]);
 
   const cartContextValue = useMemo<CartWithActions>(() => {
     return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Ensure the effect that updates the `cart.buyerIdenity.countryCode` is run when `countyCode` props changes

### Additional context

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
