### PR TITLE
[Demo Store Neue] Fix country selector styling make footer divider conditional

### DIFF
--- a/templates/demo-store-neue/src/components/CountrySelector.client.jsx
+++ b/templates/demo-store-neue/src/components/CountrySelector.client.jsx
@@ -37,7 +37,7 @@ export function CountrySelector() {
               </Listbox.Button>
 
               <Listbox.Options
-                className={`bg-contrast border-t-contrast/30 border-contrast/30 absolute bottom-12 z-10 grid h-48 w-full overflow-y-scroll rounded-t border px-2 py-2 transition-[max-height] duration-150 sm:bottom-auto md:rounded-b md:rounded-t-none md:border-t-0 md:border-b
+                className={`border-t-contrast/30 border-contrast/30 absolute bottom-12 z-10 grid h-48 w-full overflow-y-scroll rounded-t border dark:border-white px-2 py-2 transition-[max-height] duration-150 sm:bottom-auto md:rounded-b md:rounded-t-none md:border-t-0 md:border-b
               ${listboxOpen ? 'max-h-48' : 'max-h-0'}`}
               >
                 {listboxOpen && (
@@ -45,7 +45,7 @@ export function CountrySelector() {
                     <Countries
                       selectedCountry={selectedCountry}
                       getClassName={(active) => {
-                        return `w-full p-2 transition rounded flex justify-start items-center text-left cursor-pointer ${
+                        return `text-white w-full p-2 transition rounded flex justify-start items-center text-left cursor-pointer ${
                           active ? 'bg-contrast/10' : null
                         }`;
                       }}

--- a/templates/demo-store-neue/src/components/elements/Section.jsx
+++ b/templates/demo-store-neue/src/components/elements/Section.jsx
@@ -7,7 +7,7 @@ export function Section({
   as: Component = 'section',
   children,
   className,
-  divider,
+  divider = 'none',
   display = 'grid',
   heading,
   padding = 'all',
@@ -21,6 +21,7 @@ export function Section({
   };
 
   const dividers = {
+    none: 'border-none',
     top: 'border-t border-primary/05',
     bottom: 'border-b border-primary/05',
     both: 'border-y border-primary/05',

--- a/templates/demo-store-neue/src/components/global/Footer.client.jsx
+++ b/templates/demo-store-neue/src/components/global/Footer.client.jsx
@@ -1,5 +1,5 @@
 import {Disclosure} from '@headlessui/react';
-import {Link} from '@shopify/hydrogen';
+import {Link, useUrl} from '@shopify/hydrogen';
 
 import {Section, Heading, IconCaret, CountrySelector} from '~/components';
 import {footer as mockData} from '~/lib/placeholders';
@@ -8,6 +8,9 @@ import {footer as mockData} from '~/lib/placeholders';
  * A server component that specifies the content of the footer on the website
  */
 export function Footer({menu = mockData}) {
+  const {pathname} = useUrl();
+  const isHome = pathname === '/';
+
   const styles = {
     footer:
       'grid items-start w-full grid-flow-row grid-cols-1 gap-6 py-8 px-6 md:px-8 lg:px-12 border-b md:gap-8 lg:gap-12 md:grid-cols-2 lg:grid-cols-4 bg-primary dark:bg-contrast dark:text-primary text-contrast',
@@ -17,9 +20,9 @@ export function Footer({menu = mockData}) {
 
   return (
     <Section
+      divider={isHome ? 'none' : 'top'}
       as="footer"
       role="contentinfo"
-      divider="top"
       className={styles.footer}
     >
       {(menu?.items || []).map((item) => (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Fixes dark/light mode country selector in the footer
- Makes footer top divider conditional. No divider in the homepage.

### Additional context

![country-dark](https://user-images.githubusercontent.com/12080141/173971264-0a9b2ada-b2ec-4f91-9806-9396c08b7bf8.jpg)
![country-light](https://user-images.githubusercontent.com/12080141/173971265-ab4d3a86-1556-4b66-aa47-e3bfe61bab71.jpg)
![footer-non-home](https://user-images.githubusercontent.com/12080141/173971266-e24469cb-54fd-41bd-952c-e726c6140c64.jpg)
![footer-home](https://user-images.githubusercontent.com/12080141/173971270-21ffe5e4-b5b3-42dc-bb95-f467f5abbcf3.jpg)


---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
