### PR TITLE
Fix Link component prefetch when `to` prop is missing

### DIFF
--- a/.changeset/young-eyes-tie.md
+++ b/.changeset/young-eyes-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Do not trigger prefetch when `to` prop is missing in the `Link` component.

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -89,7 +89,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
        * startTransition to yield to more important updates
        */
       startTransition(() => {
-        if (prefetch) {
+        if (prefetch && !!to) {
           setMaybePrefetch(true);
         }
       });

--- a/templates/demo-store/tests/e2e/collections.test.js
+++ b/templates/demo-store/tests/e2e/collections.test.js
@@ -24,6 +24,6 @@ describe('collections', () => {
     expect(heading).not.toBeNull();
 
     const text = await heading.textContent();
-    expect(text).toBe('Freestyle');
+    expect(text).toBe('Freestyle Collection');
   }, 60000);
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1458

Getting error `Cannot read .startsWith of undefined` when using a `<Button />` without url/handleClick. This is because it turns into a `Link` component and tries to prefetch `undefined`.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
