### PR TITLE
Fix hydration mismatch with `useId`

### DIFF
--- a/.changeset/brown-apricots-speak.md
+++ b/.changeset/brown-apricots-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix hydration issues with `useId`.

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -127,17 +127,19 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
     // Default to StrictMode on, unless explicitly turned off
     config.strictMode !== false ? StrictMode : Fragment;
 
+  // Fixes hydration in `useId`: https://github.com/Shopify/hydrogen/issues/1589
+  const ServerRequestProviderMock = () => null;
+
   hydrateRoot(
     root,
-    <>
-      <RootComponent>
-        <ErrorBoundary FallbackComponent={Error}>
-          <Suspense fallback={null}>
-            <Content clientWrapper={ClientWrapper} />
-          </Suspense>
-        </ErrorBoundary>
-      </RootComponent>
-    </>
+    <RootComponent>
+      <ServerRequestProviderMock />
+      <ErrorBoundary FallbackComponent={Error}>
+        <Suspense fallback={null}>
+          <Content clientWrapper={ClientWrapper} />
+        </Suspense>
+      </ErrorBoundary>
+    </RootComponent>
   );
 };
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, {Suspense} from 'react';
 import {
   Logger,
@@ -365,9 +366,6 @@ async function runSSR({
           <PreloadQueries request={request}>
             <Suspense fallback={null}>
               <RscConsumer />
-            </Suspense>
-            <Suspense fallback={null}>
-              <Analytics />
             </Suspense>
           </PreloadQueries>
         </ServerPropsProvider>

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, {Suspense} from 'react';
 import {
   Logger,

--- a/packages/playground/server-components/src/components/UseId.client.jsx
+++ b/packages/playground/server-components/src/components/UseId.client.jsx
@@ -1,0 +1,5 @@
+import {useId} from 'react';
+
+export function UseId() {
+  return <div id="id">{useId()}</div>;
+}

--- a/packages/playground/server-components/src/routes/useid.server.jsx
+++ b/packages/playground/server-components/src/routes/useid.server.jsx
@@ -1,0 +1,5 @@
+import {UseId} from '../components/UseId.client';
+
+export default function DisplayUseId() {
+  return <UseId />;
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -251,6 +251,21 @@ export default async function testCases({
     );
   });
 
+  it('supports React.useId()', async () => {
+    const response = await page.goto(getServerUrl() + '/useid');
+
+    // Pattern: <div id="id">:Rcm:</div>
+    const serverRenderedId = (await response.text()).match(
+      /<div id="id">(.*?)<\/div>/
+    )[1];
+
+    const clientRenderedId = await page.evaluate(() => {
+      return document.getElementById('id').innerHTML;
+    });
+
+    expect(serverRenderedId).toEqual(clientRenderedId);
+  });
+
   describe('HMR', () => {
     if (isBuild) return;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1402
Closes #1589
Needs #1588 merged for the failing test

This makes the component number consistent between server and browser:
- Remove `Analytics` component from SSR (it's already in RSC, so I think this wasn't needed).
- Add a mock for `ServerRequestProvider` (I think?) in the browser.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
