### PR TITLE
Add loadConfig function for CLI

### DIFF
--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -22,6 +22,10 @@
       "import": "./dist/esnext/framework/middleware.js",
       "require": "./dist/node/framework/middleware.js"
     },
+    "./load-config": {
+      "import": "./dist/esnext/framework/load-config.js",
+      "require": "./dist/node/framework/load-config.js"
+    },
     "./web-polyfills": {
       "import": "./dist/esnext/utilities/web-api-polyfill",
       "require": "./dist/node/utilities/web-api-polyfill"

--- a/packages/hydrogen/src/framework/load-config.ts
+++ b/packages/hydrogen/src/framework/load-config.ts
@@ -1,0 +1,16 @@
+// Provide Hydrogen config loader to external tools like the CLI
+
+import {VIRTUAL_PROXY_HYDROGEN_CONFIG_ID} from './plugins/vite-plugin-hydrogen-virtual-files';
+import {viteception} from './viteception';
+
+export async function loadConfig(options = {root: process.cwd()}) {
+  const {loaded} = await viteception(
+    [VIRTUAL_PROXY_HYDROGEN_CONFIG_ID],
+    options
+  );
+
+  return {
+    configuration: loaded[0].default,
+    configurationPath: loaded[0].configPath,
+  };
+}

--- a/packages/hydrogen/src/framework/viteception.ts
+++ b/packages/hydrogen/src/framework/viteception.ts
@@ -1,12 +1,13 @@
-import {createServer} from 'vite';
+import {createServer, InlineConfig} from 'vite';
 
-export async function viteception(paths: string[]) {
+export async function viteception(paths: string[], options?: InlineConfig) {
   const isWorker = process.env.WORKER;
   delete process.env.WORKER;
 
   const server = await createServer({
     clearScreen: false,
     server: {middlewareMode: 'ssr'},
+    ...options,
   });
 
   if (isWorker) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

@cartogram This is more or less what I was talking about. The code in the CLI could be something like:

```js
import {loadConfig} from '@shopify/hydrogen/load-config'
...

    const {configuration, configurationPath} = await loadConfig({root: this.directory})
    this.appDirectory = path.dirname(configurationPath)
```

I'm not sure if `this.appDirectory` should be using the path to the hydrogen config, though. The config might not be at the root if the user provided a different path. However, files like `tsconfig.json` are always going to be at the root, I think, so perhaps `this.directory` is a better fit than `configurationPath` 🤔 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
