### PR TITLE
Fix Oxygen project creation

### DIFF
--- a/.changeset/shaggy-bees-wait.md
+++ b/.changeset/shaggy-bees-wait.md
@@ -1,0 +1,5 @@
+---
+'create-hydrogen-app': patch
+---
+
+Store copy of demostore files before publishing for use in hydrogen project creation in admin.

--- a/packages/create-hydrogen-app/package.json
+++ b/packages/create-hydrogen-app/package.json
@@ -10,5 +10,13 @@
   "bin": {
     "create-hydrogen": "index.js",
     "create-hydrogen-app": "index.js"
+  },
+  "files": [
+    "index.js",
+    "scripts",
+    "template-*"
+  ],
+  "scripts": {
+    "prepack": "node ./scripts/tmp-copy-template-from-dev.js"
   }
 }

--- a/packages/create-hydrogen-app/scripts/tmp-copy-template-from-dev.js
+++ b/packages/create-hydrogen-app/scripts/tmp-copy-template-from-dev.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+/**
+ * This is a temporary script meant to copy `templates/demo-store` to `./template-hydrogen`
+ * while we are actively developing H2 in `templates/demo-store`. Eventually, something else might happen.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const devPath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'templates',
+  'demo-store'
+);
+const templatePath = path.resolve(__dirname, '..', './template-hydrogen');
+const skipFiles = ['node_modules', 'dist', '.stackblitzrc'];
+
+// Remove the symlink and replace it with a folder
+fs.unlinkSync(templatePath);
+fs.mkdirSync(templatePath, {recursive: true});
+
+copy(devPath, templatePath, skipFiles);
+
+function copyDir(srcDir, destDir, skipFiles = []) {
+  fs.mkdirSync(destDir, {recursive: true});
+  for (const file of fs.readdirSync(srcDir)) {
+    const srcFile = path.resolve(srcDir, file);
+    const destFile = path.resolve(destDir, file);
+    copy(srcFile, destFile, skipFiles);
+  }
+}
+
+function copy(src, dest, skipFiles = []) {
+  if (skipFiles.some((file) => src.includes(file))) return;
+
+  const stat = fs.statSync(src);
+
+  if (stat.isDirectory()) {
+    copyDir(src, dest, skipFiles);
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Due to the way Hydrogen projects are bootstrapped in the admin, we need to temporarily continue storing templates in the deprecated `create-hydrogen-app` package. 

This PR revives a prepack script that was removed in https://github.com/Shopify/hydrogen/pull/1475. This script copies the demo-store template into this package where it is later used by the Oxygen admin to seed new projects.

In the future, the Oxygen admin should use our templates directly from this github repo in the `stackblitz` branch to seed new projects. (cc @gustavo-sanchez @Shopify/oxygen-admin)

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
