### PR TITLE
Add Custom Changeset formatter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
-  "changelog": [
-    ".changeset/hydrogen-changelog-config.ts",
-    {"repo": "shopify/hydrogen"}
-  ],
+  "changelog": ".changeset/hydrogen-changelog-config.js",
   "commit": false,
   "fixed": [["@shopify/hydrogen", "create-hydrogen-app"]],
   "linked": [],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
-  "changelog": ["@changesets/changelog-github", {"repo": "shopify/hydrogen"}],
+  "changelog": [
+    ".changeset/hydrogen-changelog-config.ts",
+    {"repo": "shopify/hydrogen"}
+  ],
   "commit": false,
   "fixed": [["@shopify/hydrogen", "create-hydrogen-app"]],
   "linked": [],

--- a/.changeset/hydrogen-changelog-config.js
+++ b/.changeset/hydrogen-changelog-config.js
@@ -1,21 +1,11 @@
-import {ChangelogFunctions} from '@changesets/types';
-// @ts-ignore
 import {config} from 'dotenv';
 import {getInfo, getInfoFromPullRequest} from '@changesets/get-github-info';
 
 config();
 
-const changelogFunctions: ChangelogFunctions = {
-  getDependencyReleaseLine: async (
-    changesets,
-    dependenciesUpdated,
-    options
-  ) => {
-    if (!options.repo) {
-      throw new Error(
-        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
-      );
-    }
+const changelogFunctions = {
+  getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
+    const repo = 'shopify/hydrogen';
     if (dependenciesUpdated.length === 0) return '';
 
     const changesetLink = `- Updated dependencies [${(
@@ -23,7 +13,7 @@ const changelogFunctions: ChangelogFunctions = {
         changesets.map(async (cs) => {
           if (cs.commit) {
             let {links} = await getInfo({
-              repo: options.repo,
+              repo,
               commit: cs.commit,
             });
             return links.commit;
@@ -41,15 +31,9 @@ const changelogFunctions: ChangelogFunctions = {
     return [changesetLink, ...updatedDepenenciesList].join('\n');
   },
   getReleaseLine: async (changeset, type, options) => {
-    if (!options || !options.repo) {
-      throw new Error(
-        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
-      );
-    }
-
-    let prFromSummary: number | undefined;
-    let commitFromSummary: string | undefined;
-    let usersFromSummary: string[] = [];
+    let prFromSummary;
+    let commitFromSummary;
+    let usersFromSummary = [];
 
     const replacedChangelog = changeset.summary
       .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
@@ -74,13 +58,13 @@ const changelogFunctions: ChangelogFunctions = {
     const links = await (async () => {
       if (prFromSummary !== undefined) {
         let {links} = await getInfoFromPullRequest({
-          repo: options.repo,
+          repo,
           pull: prFromSummary,
         });
         if (commitFromSummary) {
           links = {
             ...links,
-            commit: `[\`${commitFromSummary}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+            commit: `[\`${commitFromSummary}\`](https://github.com/${repo}/commit/${commitFromSummary})`,
           };
         }
         return links;
@@ -88,7 +72,7 @@ const changelogFunctions: ChangelogFunctions = {
       const commitToFetchFrom = commitFromSummary || changeset.commit;
       if (commitToFetchFrom) {
         let {links} = await getInfo({
-          repo: options.repo,
+          repo,
           commit: commitToFetchFrom,
         });
         return links;

--- a/.changeset/hydrogen-changelog-config.ts
+++ b/.changeset/hydrogen-changelog-config.ts
@@ -1,0 +1,123 @@
+import {ChangelogFunctions} from '@changesets/types';
+// @ts-ignore
+import {config} from 'dotenv';
+import {getInfo, getInfoFromPullRequest} from '@changesets/get-github-info';
+
+config();
+
+const changelogFunctions: ChangelogFunctions = {
+  getDependencyReleaseLine: async (
+    changesets,
+    dependenciesUpdated,
+    options
+  ) => {
+    if (!options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
+      );
+    }
+    if (dependenciesUpdated.length === 0) return '';
+
+    const changesetLink = `- Updated dependencies [${(
+      await Promise.all(
+        changesets.map(async (cs) => {
+          if (cs.commit) {
+            let {links} = await getInfo({
+              repo: options.repo,
+              commit: cs.commit,
+            });
+            return links.commit;
+          }
+        })
+      )
+    )
+      .filter((_) => _)
+      .join(', ')}]:`;
+
+    const updatedDepenenciesList = dependenciesUpdated.map(
+      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`
+    );
+
+    return [changesetLink, ...updatedDepenenciesList].join('\n');
+  },
+  getReleaseLine: async (changeset, type, options) => {
+    if (!options || !options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
+      );
+    }
+
+    let prFromSummary: number | undefined;
+    let commitFromSummary: string | undefined;
+    let usersFromSummary: string[] = [];
+
+    const replacedChangelog = changeset.summary
+      .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+        let num = Number(pr);
+        if (!isNaN(num)) prFromSummary = num;
+        return '';
+      })
+      .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+        commitFromSummary = commit;
+        return '';
+      })
+      .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+        usersFromSummary.push(user);
+        return '';
+      })
+      .trim();
+
+    const [firstLine, ...futureLines] = replacedChangelog
+      .split('\n')
+      .map((l) => l.trimRight());
+
+    const links = await (async () => {
+      if (prFromSummary !== undefined) {
+        let {links} = await getInfoFromPullRequest({
+          repo: options.repo,
+          pull: prFromSummary,
+        });
+        if (commitFromSummary) {
+          links = {
+            ...links,
+            commit: `[\`${commitFromSummary}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+          };
+        }
+        return links;
+      }
+      const commitToFetchFrom = commitFromSummary || changeset.commit;
+      if (commitToFetchFrom) {
+        let {links} = await getInfo({
+          repo: options.repo,
+          commit: commitToFetchFrom,
+        });
+        return links;
+      }
+      return {
+        commit: null,
+        pull: null,
+        user: null,
+      };
+    })();
+
+    const users = usersFromSummary.length
+      ? usersFromSummary
+          .map(
+            (userFromSummary) =>
+              `[@${userFromSummary}](https://github.com/${userFromSummary})`
+          )
+          .join(', ')
+      : links.user;
+
+    const prefix = [
+      links.pull === null ? '' : ` (${links.pull})`,
+      users === null ? '' : ` by ${users}`,
+    ].join('');
+
+    return `\n\n- ${firstLine}${prefix ? `${prefix} \n` : ''}\n${futureLines
+      .map((l) => `  ${l}`)
+      .join('\n')}`;
+  },
+};
+
+export default changelogFunctions;


### PR DESCRIPTION
Reverts Shopify/hydrogen#1609

TODO:

- [x] Change to JS
- [x] Change the `config.json` reference to just a string, e.g. `"changelog": ".changeset/my-changelog-config.js"`. Need to update the script with the hardcoded repo name instead.