### PR TITLE
Add support for the Shop Pay CSS var, and add docs

### DIFF
--- a/.changeset/eleven-snails-brake.md
+++ b/.changeset/eleven-snails-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+The `<ShopPayButton/>` and `<CartShopPayButton/>` now take in a `width` prop to help customize how wide the `<shop-pay-button>` custom element is, by using the newly added CSS custom property (variable) `--shop-pay-button-width`.

--- a/docs/components/cart/cartshoppaybutton.md
+++ b/docs/components/cart/cartshoppaybutton.md
@@ -26,7 +26,7 @@ export default function MyComponent() {
 | Name       | Type                                                                                         | Description                                                                               |
 | ---------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | className? | <code>Omit&#60;React.ComponentProps&#60;typeof ShopPayButton&#62;, 'variantIds'&#62;)</code> | A string of classes to apply to the `div` that wraps the `shop-pay-button` web component. |
-| width? | <code>string</code> |   A string that gets applied to the CSS Custom Property (Variable) `--shop-pay-button-width` for the [Shop Pay Custom Element](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component) |
+| width? | <code>string</code> |   A string that's applied to the [CSS custom property (variable)](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) `--shop-pay-button-width` for the [Buy with Shop Pay component](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component). |
 
 ## Component type
 

--- a/docs/components/cart/cartshoppaybutton.md
+++ b/docs/components/cart/cartshoppaybutton.md
@@ -26,6 +26,7 @@ export default function MyComponent() {
 | Name       | Type                                                                                         | Description                                                                               |
 | ---------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | className? | <code>Omit&#60;React.ComponentProps&#60;typeof ShopPayButton&#62;, 'variantIds'&#62;)</code> | A string of classes to apply to the `div` that wraps the `shop-pay-button` web component. |
+| width? | <code>string</code> |   A string that gets applied to the CSS Custom Property (Variable) `--shop-pay-button-width` for the [Shop Pay Custom Element](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component) |
 
 ## Component type
 

--- a/docs/components/primitive/shoppaybutton.md
+++ b/docs/components/primitive/shoppaybutton.md
@@ -25,7 +25,7 @@ The `variantIds` and `variantIdsAndQuantities` props are mutually exclusive. You
 | variantIds              | <pre>{ <br> variantIds: string[]; <br> variantIdsAndQuantities?: never;<br>}</pre>               | An array of IDs of the variants to purchase with Shop Pay. This will only ever have a quantity of 1 for each variant. If you want to use other quantities, then use `variantIdsAndQuantities`. |
 | variantIdsAndQuantities | <pre>{ <br> variantIds: never; <br> variantIdsAndQuantities?: VariantIdAndQuantity[];<br>}</pre> | An array of variant IDs and quantities to purchase with Shop Pay.                                                                                                                              |
 | className?              | <code>string</code>                                                                              | A string of classes to apply to the `div` that wraps the Shop Pay button.                                                                                                                      |
-| width? | <code>string</code> |   A string that gets applied to the CSS Custom Property (Variable) `--shop-pay-button-width` for the [Shop Pay Custom Element](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component) |
+| width? | <code>string</code> |   A string that's applied to the [CSS custom property (variable)](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) `--shop-pay-button-width` for the [Buy with Shop Pay component](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component). |
 
 
 ## Component type

--- a/docs/components/primitive/shoppaybutton.md
+++ b/docs/components/primitive/shoppaybutton.md
@@ -25,6 +25,8 @@ The `variantIds` and `variantIdsAndQuantities` props are mutually exclusive. You
 | variantIds              | <pre>{ <br> variantIds: string[]; <br> variantIdsAndQuantities?: never;<br>}</pre>               | An array of IDs of the variants to purchase with Shop Pay. This will only ever have a quantity of 1 for each variant. If you want to use other quantities, then use `variantIdsAndQuantities`. |
 | variantIdsAndQuantities | <pre>{ <br> variantIds: never; <br> variantIdsAndQuantities?: VariantIdAndQuantity[];<br>}</pre> | An array of variant IDs and quantities to purchase with Shop Pay.                                                                                                                              |
 | className?              | <code>string</code>                                                                              | A string of classes to apply to the `div` that wraps the Shop Pay button.                                                                                                                      |
+| width? | <code>string</code> |   A string that gets applied to the CSS Custom Property (Variable) `--shop-pay-button-width` for the [Shop Pay Custom Element](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component) |
+
 
 ## Component type
 

--- a/packages/hydrogen/src/components/CartShopPayButton/CartShopPayButton.client.tsx
+++ b/packages/hydrogen/src/components/CartShopPayButton/CartShopPayButton.client.tsx
@@ -6,10 +6,9 @@ import {ShopPayButton} from '../ShopPayButton';
  * The `CartShopPayButton` component renders a `ShopPayButton` for the items in the cart.
  * It must be a descendent of a `CartProvider` component.
  */
-export function CartShopPayButton({
-  /** A string of classes to apply to the `div` that wraps the `shop-pay-button` web component. */
-  className,
-}: Omit<React.ComponentProps<typeof ShopPayButton>, 'variantIds'>) {
+export function CartShopPayButton(
+  props: Omit<React.ComponentProps<typeof ShopPayButton>, 'variantIds'>
+) {
   const {lines} = useCart();
 
   const idsAndQuantities = useMemo(() => {
@@ -21,8 +20,8 @@ export function CartShopPayButton({
 
   return (
     <ShopPayButton
-      className={className}
       variantIdsAndQuantities={idsAndQuantities}
+      {...props}
     ></ShopPayButton>
   );
 }

--- a/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
+++ b/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
@@ -6,6 +6,8 @@ import {useLoadScript} from '../../hooks/useLoadScript/useLoadScript.client';
 type ShopPayButtonProps = {
   /** A string of classes to apply to the `div` that wraps the Shop Pay button. */
   className?: string;
+  /** A string that gets applied to the CSS Custom Property (Variable) `--shop-pay-button-width` for the [Shop Pay Custom Element](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component) */
+  width?: string;
 } & (
   | {
       /** An array of IDs of the variants to purchase with Shop Pay. This will only ever have a quantity of 1 for each variant. If you want to use other quantities, then use 'variantIdsAndQuantities'. */
@@ -35,7 +37,7 @@ declare global {
   }
 }
 
-const URL = 'https://cdn.shopify.com/shopifycloud/shop-js/v0.8/client.js';
+const URL = 'https://cdn.shopify.com/shopifycloud/shop-js/v1.0/client.js';
 
 /**
  * The `ShopPayButton` component renders a button that redirects to the Shop Pay checkout.
@@ -44,6 +46,7 @@ export function ShopPayButton({
   variantIds,
   className,
   variantIdsAndQuantities,
+  width,
 }: ShopPayButtonProps) {
   const {storeDomain} = useShop();
   const shopPayLoadedStatus = useLoadScript(URL);
@@ -74,9 +77,15 @@ export function ShopPayButton({
     throw new Error(MissingPropsErrorMessage);
   }
 
+  const style = width
+    ? ({
+        '--shop-pay-button-width': width,
+      } as React.CSSProperties)
+    : undefined;
+
   return (
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-    <div className={className} tabIndex={0}>
+    <div className={className} tabIndex={0} style={style}>
       {shopPayLoadedStatus === 'done' && (
         <shop-pay-button
           store-url={`https://${storeDomain}`}

--- a/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
+++ b/packages/hydrogen/src/components/ShopPayButton/ShopPayButton.client.tsx
@@ -6,7 +6,7 @@ import {useLoadScript} from '../../hooks/useLoadScript/useLoadScript.client';
 type ShopPayButtonProps = {
   /** A string of classes to apply to the `div` that wraps the Shop Pay button. */
   className?: string;
-  /** A string that gets applied to the CSS Custom Property (Variable) `--shop-pay-button-width` for the [Shop Pay Custom Element](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component) */
+  /** A string that's applied to the [CSS custom property (variable)](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) `--shop-pay-button-width` for the [Buy with Shop Pay component](https://shopify.dev/custom-storefronts/tools/web-components#buy-with-shop-pay-component). */
   width?: string;
 } & (
   | {

--- a/packages/hydrogen/src/components/ShopPayButton/tests/ShopPayButton.client.test.tsx
+++ b/packages/hydrogen/src/components/ShopPayButton/tests/ShopPayButton.client.test.tsx
@@ -68,6 +68,19 @@ describe(`ShopPayButton`, () => {
     });
   });
 
+  it(`applies the css variable if 'width' exists`, () => {
+    const component = mountWithProviders(
+      <ShopPayButton
+        width="100%"
+        variantIdsAndQuantities={[{id: '123', quantity: 2}]}
+      />
+    );
+
+    expect(component).toContainReactComponent('div', {
+      style: {'--shop-pay-button-width': '100%'} as React.CSSProperties,
+    });
+  });
+
   describe(`getIdFromGid`, () => {
     it(`should handle undefined`, () => {
       expect(getIdFromGid()).toBe(undefined);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add support for the Shop Pay CSS var, and add docs

Also update the CartShopPayButton to just do passthrough props



---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
