### PR TITLE
Making the E2E tests more resilient to changes

### DIFF
--- a/packages/playground/server-components/src/routes/api-queryshop.server.js
+++ b/packages/playground/server-components/src/routes/api-queryshop.server.js
@@ -1,5 +1,5 @@
 export async function api(request, {queryShop}) {
   return await queryShop({
-    query: `query ShopName { shop { name } }`,
+    query: `query ShopName { shop { id } }`,
   });
 }

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -434,7 +434,9 @@ export default async function testCases({
       const data = await response.json();
 
       expect(response.status()).toBe(200);
-      expect(data).toEqual({data: {shop: {name: 'Hydrogen'}}});
+      expect(data).toEqual({
+        data: {shop: {id: 'gid://shopify/Shop/55145660472'}},
+      });
     });
 
     it('supports form request on API routes', async () => {

--- a/templates/demo-store/src/components/ProductDetails.client.jsx
+++ b/templates/demo-store/src/components/ProductDetails.client.jsx
@@ -142,7 +142,10 @@ export default function ProductDetails({product}) {
 
           <div>
             <div className="hidden md:block">
-              <h1 className="text-5xl font-bold text-black mb-4">
+              <h1
+                className="text-5xl font-bold text-black mb-4"
+                data-test-id={product.id}
+              >
                 {product.title}
               </h1>
               {product.vendor && (

--- a/templates/demo-store/src/components/ProductDetails.client.jsx
+++ b/templates/demo-store/src/components/ProductDetails.client.jsx
@@ -124,7 +124,10 @@ export default function ProductDetails({product}) {
       >
         <div className="grid grid-cols-1 md:grid-cols-[2fr,1fr] gap-x-8 my-16">
           <div className="md:hidden mt-5 mb-8">
-            <h1 className="text-4xl font-bold text-black mb-4">
+            <h1
+              className="text-4xl font-bold text-black mb-4"
+              data-test-id={product.id}
+            >
               {product.title}
             </h1>
             {product.vendor && (

--- a/templates/demo-store/src/routes/collections/[handle].server.jsx
+++ b/templates/demo-store/src/routes/collections/[handle].server.jsx
@@ -52,7 +52,10 @@ export default function Collection({collectionProductCount = 24, params}) {
     <Layout>
       {/* the seo object will be expose in API version 2022-04 or later */}
       <Seo type="collection" data={collection} />
-      <h1 className="font-bold text-4xl md:text-5xl text-gray-900 mb-6 mt-6">
+      <h1
+        className="font-bold text-4xl md:text-5xl text-gray-900 mb-6 mt-6"
+        data-test-id={collection.id}
+      >
         {collection.title}
       </h1>
       <div

--- a/templates/demo-store/tests/e2e/collections.test.js
+++ b/templates/demo-store/tests/e2e/collections.test.js
@@ -23,7 +23,7 @@ describe('collections', () => {
     const heading = await session.page.locator('h1').first();
     expect(heading).not.toBeNull();
 
-    const text = await heading.textContent();
-    expect(text).toBe('Freestyle Collection');
+    const text = await heading.getAttribute('data-test-id');
+    expect(text).toBe('gid://shopify/Collection/276668186680');
   }, 60000);
 });

--- a/templates/demo-store/tests/e2e/products.test.js
+++ b/templates/demo-store/tests/e2e/products.test.js
@@ -23,7 +23,7 @@ describe('products', () => {
     const heading = await session.page.locator('h1').first();
     expect(heading).not.toBeNull();
 
-    const text = await heading.textContent();
-    expect(text).toBe('The Hydrogen Snowboard');
+    const text = await heading.getAttribute('data-test-id');
+    expect(text).toBe('gid://shopify/Product/6730850828344');
   }, 60000);
 });


### PR DESCRIPTION
This should hopefully let people change the names of the store, collections, and products without our e2e tests failing suddenly. 
