### PR TITLE
[Hydrogen docs]: Remove references to developer preview

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,8 +4,6 @@ title: Deploy a Hydrogen storefront
 description: Learn how to deploy your Hydrogen storefront to Oxygen and other runtimes.
 ---
 
-{% include hydrogen/developer-preview.md %}
-
 You can deploy a Hydrogen storefront to most [Worker and Node.js runtimes](https://shopify.dev/custom-storefronts/hydrogen/framework#request-workflow-for-hydrogen-apps). This guide describes how to deploy a Hydrogen storefront to [Oxygen](#deploy-to-oxygen), [Node.js](#deploy-to-node-js), [Docker](#deploy-to-docker), [Cloudflare Workers](#deploy-to-cloudflare-workers), and [Netlify](#deploy-to-netlify).
 
 ## Requirements

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -4,13 +4,6 @@ title: Hydrogen framework overview
 description: Learn about the architecture and framework of Hydrogen.
 ---
 
-<aside class="note beta">
-<h4>Developer preview</h4>
-
-<p>This is a developer preview of Hydrogen. The documentation will be updated as Shopify introduces <a href="https://github.com/Shopify/hydrogen/releases">new features and refines existing functionality</a>.</p>
-
-</aside>
-
 Hydrogen includes a framework that offers a set of best practices and scaffolding for building a website. This guide provides an overview of Hydrogen's architecture and framework.
 
 ## What's the Hydrogen framework?

--- a/docs/framework/integrate-react-frameworks.md
+++ b/docs/framework/integrate-react-frameworks.md
@@ -6,7 +6,7 @@ description: Learn how to integrate Hydrogen with an existing React framework th
 
 The majority of [Hydrogen components](https://shopify.dev/api/hydrogen/components) accept data from the Storefront API and render just like regular React components. This means you can use Hydrogen components in other React frameworks like [Next.js](https://nextjs.org/) or [Gatsby](https://www.gatsbyjs.com/).
 
-Shopify hasn't optimized integrating with other frameworks for the developer preview, so you need to follow some special instructions to make it work. While the instructions in this guide are specific Next.js, you can follow a similar pattern to support other frameworks.
+Shopify hasn't optimized integrating with other frameworks, so you need to follow some special instructions to make it work. While the instructions in this guide are specific Next.js, you can follow a similar pattern to support other frameworks.
 
 ## Get started with Next.js
 


### PR DESCRIPTION
## This PR: 
- Removes references to "developer preview" in the Hydrogen docs
- Relates to https://github.com/Shopify/shopify-dev/pull/21918

### Additional context

We can ship this PR when Hydrogen moves to GA.