### PR TITLE
[Hydrogen docs]: Capitalize `Yarn` and prioritize `npm` commands

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,12 +30,12 @@ Hydrogen provides a [built-in Node entrypoint](https://github.com/Shopify/hydrog
 
     {% codeblock terminal %}
 
-    ```bash?title: 'yarn'
-    yarn add body-parser compression serve-static
-    ```
-
     ```bash?title: 'npm'
     npm install body-parser compression serve-static
+    ```
+
+    ```bash?title: 'Yarn'
+    yarn add body-parser compression serve-static
     ```
 
     {% endcodeblock %}
@@ -139,7 +139,7 @@ If you want to use a different Node.js framework like [Express](https://expressj
 
     {% codeblock terminal %}
 
-    ```bash?title: 'yarn'
+    ```bash?title: 'Yarn'
     yarn preview --target node
     ```
 

--- a/docs/framework/css-support.md
+++ b/docs/framework/css-support.md
@@ -60,17 +60,6 @@ If you don't want to build with Tailwind's library and instead want to write you
 
     {% codeblock terminal %}
 
-    ```bash?filename: 'Terminal', title: 'yarn'
-    // Switch to your app's directory
-    cd <directory>
-
-    // Install dependencies
-    yarn
-
-    // Start the development server
-    yarn dev
-    ```
-
     ```bash?filename: 'Terminal', title: 'npm'
     // Switch to your app's directory
     cd <directory>
@@ -80,6 +69,17 @@ If you don't want to build with Tailwind's library and instead want to write you
 
     // Start the development server
     npm run dev
+    ```
+
+    ```bash?filename: 'Terminal', title: 'Yarn'
+    // Switch to your app's directory
+    cd <directory>
+
+    // Install dependencies
+    yarn
+
+    // Start the development server
+    yarn dev
     ```
 
     {% endcodeblock %}

--- a/docs/framework/integrate-react-frameworks.md
+++ b/docs/framework/integrate-react-frameworks.md
@@ -14,12 +14,12 @@ Shopify hasn't optimized integrating with other frameworks for the developer pre
 
     {% codeblock terminal %}
 
-    ```bash?filename: 'Terminal', title: 'yarn'
-    yarn add @shopify/hydrogen next-transpile-modules
-    ```
-
     ```bash?filename: 'Terminal', title: 'npm'
     npm install @shopify/hydrogen next-transpile-modules --save
+    ```
+
+    ```bash?filename: 'Terminal', title: 'Yarn'
+    yarn add @shopify/hydrogen next-transpile-modules
     ```
 
     {% endcodeblock %}

--- a/docs/framework/third-party-dependencies.md
+++ b/docs/framework/third-party-dependencies.md
@@ -12,12 +12,12 @@ To install third party dependencies, run the following command:
 
 {% codeblock terminal %}
 
-```bash?title: 'yarn'
-yarn add <dependency>
-```
-
 ```bash?title: 'npm'
 npm install <dependency>
+```
+
+```bash?title: 'Yarn'
+yarn add <dependency>
 ```
 
 {% endcodeblock %}


### PR DESCRIPTION
## This PR: 
- Capitalizes instances of `Yarn` where it refers to the package manager
- Re-orders some commands to prioritize `npm` in the docs
- Relates to https://github.com/Shopify/shopify-dev/pull/21933