### PR TITLE
Add optimizeDeps to avoid early refresh

### DIFF
--- a/templates/demo-store-neue/vite.config.js
+++ b/templates/demo-store-neue/vite.config.js
@@ -6,4 +6,7 @@ export default defineConfig({
   resolve: {
     alias: [{find: /^~\/(.*)/, replacement: '/src/$1'}],
   },
+  optimizeDeps: {
+    include: ['@headlessui/react', 'clsx', 'react-use', 'typographic-base'],
+  },
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This prevents Vite from refreshing at server start, which can cause problems.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
