### PR TITLE
Preload queries before starting RSC

### DIFF
--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -17,7 +17,7 @@ import {LocalizationContextValue} from '../../components/LocalizationProvider/Lo
 
 export type PreloadQueryEntry = {
   key: QueryKey;
-  fetcher: () => Promise<unknown>;
+  fetcher: (request: HydrogenRequest) => Promise<unknown>;
   preload?: PreloadOptions;
 };
 export type PreloadQueriesByURL = Map<string, PreloadQueryEntry>;

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -13,6 +13,7 @@ import {
 } from '../Cache/cache-sub-request';
 import {useRequestCacheData, useServerRequest} from '../ServerRequestProvider';
 import {CacheShort, NO_STORE} from '../Cache/strategies';
+import type {HydrogenRequest} from '../HydrogenRequest/HydrogenRequest.server';
 
 export interface HydrogenUseQueryOptions {
   /** The [caching strategy](https://shopify.dev/custom-storefronts/hydrogen/framework/cache#caching-strategies) to help you
@@ -101,10 +102,7 @@ function cachedQueryFnBuilder<T>(
   /**
    * Attempt to read the query from cache. If it doesn't exist or if it's stale, regenerate it.
    */
-  async function useCachedQueryFn() {
-    // Call this hook before running any async stuff
-    // to prevent losing the current React cycle.
-    const request = useServerRequest();
+  async function useCachedQueryFn(request: HydrogenRequest) {
     const log = getLoggerWithContext(request);
 
     const cacheResponse = await getItemFromCache(key);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed last week we had `<PreloadQueries>` in both RSC and SSR. This removes it from SSR since it seems redundant, and starts preloading before starting the React rendering.

@wizardlyhel I think you are more familiar with this, can you check these changes are correct?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
