### PR TITLE
Add x-powered-by header

### DIFF
--- a/.changeset/olive-icons-allow.md
+++ b/.changeset/olive-icons-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add a `x-powered-by: Shopify-Hydrogen` header which can be disabled with the Hydrogen config property: `poweredByHeader: false`

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -45,6 +45,7 @@ The following groupings of configuration properties can exist in Hydrogen:
 - [`serverAnalyticsConnectors`](#serveranalyticsconnectors)
 - [`logger`](#logger)
 - [`strictMode`](#strictmode)
+- [`poweredByHeader`](#poweredbyheader)
 
 ### `routes`
 
@@ -252,6 +253,20 @@ export default defineConfig({
 
 > Caution:
 > If you turn off strict mode, then we recommended that you still include the `StrictMode` component at as high of a level as possible in your React tree to catch errors.
+
+### `poweredByHeader`
+
+By default, hydrogen responds with the `x-powered-by: Shopify-Hydrogen` header. Disable this by adding `poweredByHeader: false` to your config:
+
+{% codeblock file, filename: 'hydrogen.config.ts' %}
+
+```tsx
+export default defineConfig({
+  poweredByHeader: false,
+});
+```
+
+{% endcodeblock %}
 
 ## Changing the configuration file location
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -103,7 +103,7 @@ export const renderHydrogen = (App: any) => {
 
     if (hydrogenConfig.poweredByHeader ?? true) {
       // If not defined in the config, always show the header
-      response.headers.set('x-powered-by', 'Shopify-Hydrogen');
+      response.headers.set('powered-by', 'Shopify-Hydrogen');
     }
 
     const sessionApi = hydrogenConfig.session

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -100,6 +100,12 @@ export const renderHydrogen = (App: any) => {
     const log = getLoggerWithContext(request);
 
     const response = new HydrogenResponse();
+
+    if (hydrogenConfig.poweredByHeader ?? true) {
+      // If not defined in the config, always show the header
+      response.headers.set('x-powered-by', 'Shopify-Hydrogen');
+    }
+
     const sessionApi = hydrogenConfig.session
       ? hydrogenConfig.session(log)
       : undefined;

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -80,6 +80,7 @@ export type InlineHydrogenConfig = ClientConfig & {
   serverAnalyticsConnectors?: Array<ServerAnalyticsConnector>;
   logger?: LoggerConfig;
   session?: (log: Logger) => SessionStorageAdapter;
+  poweredByHeader?: boolean;
   __EXPERIMENTAL__devTools?: boolean;
 };
 

--- a/packages/playground/async-config/hydrogen.config.js
+++ b/packages/playground/async-config/hydrogen.config.js
@@ -24,4 +24,5 @@ export default defineConfig({
   session: CookieSessionStorage('__session', {
     expires: new Date(1749343178614),
   }),
+  poweredByHeader: false,
 });

--- a/packages/playground/async-config/tests/e2e-test-cases.ts
+++ b/packages/playground/async-config/tests/e2e-test-cases.ts
@@ -47,9 +47,9 @@ export default async function testCases({
     expect(await page.url()).toContain('/es/productos');
   });
 
-  it('does not x-powered-by header when disabled', async () => {
+  it('does not powered-by header when disabled', async () => {
     const response = await fetch(getServerUrl() + '/');
-    expect(response.headers.has('x-powered-by')).toBe(false);
+    expect(response.headers.has('powered-by')).toBe(false);
   });
 
   if (!isBuild) {

--- a/packages/playground/async-config/tests/e2e-test-cases.ts
+++ b/packages/playground/async-config/tests/e2e-test-cases.ts
@@ -1,3 +1,5 @@
+import fetch from 'node-fetch';
+
 type TestOptions = {
   getServerUrl: () => string;
   isWorker?: boolean;
@@ -43,6 +45,11 @@ export default async function testCases({
 
     await page.goto(getServerUrl() + '/es/products');
     expect(await page.url()).toContain('/es/productos');
+  });
+
+  it('does not x-powered-by header when disabled', async () => {
+    const response = await fetch(getServerUrl() + '/');
+    expect(response.headers.has('x-powered-by')).toBe(false);
   });
 
   if (!isBuild) {

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -226,6 +226,11 @@ export default async function testCases({
     ]);
   });
 
+  it('returns x-powered-by header', async () => {
+    const response = await fetch(getServerUrl() + '/');
+    expect(response.headers.get('x-powered-by')).toBe('Shopify-Hydrogen');
+  });
+
   it('properly escapes props in the SSR flight script chunks', async () => {
     await page.goto(getServerUrl() + '/escaping');
     expect(await page.textContent('body')).toContain(

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -226,9 +226,9 @@ export default async function testCases({
     ]);
   });
 
-  it('returns x-powered-by header', async () => {
+  it('returns powered-by header', async () => {
     const response = await fetch(getServerUrl() + '/');
-    expect(response.headers.get('x-powered-by')).toBe('Shopify-Hydrogen');
+    expect(response.headers.get('powered-by')).toBe('Shopify-Hydrogen');
   });
 
   it('properly escapes props in the SSR flight script chunks', async () => {


### PR DESCRIPTION
### Description

Add a `x-powered-by: Shopify-Hydrogen` header which can be disabled with the Hydrogen config property: `poweredByHeader: false`

### Additional context

A future PR might add the hydrogen version

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
