### PR TITLE
Adds cart route CSS and fixes layout issues

### DIFF
--- a/templates/demo-store/src/components/cart/CartDetails.client.tsx
+++ b/templates/demo-store/src/components/cart/CartDetails.client.tsx
@@ -36,7 +36,7 @@ export function CartDetails({
 
   const summary = {
     drawer: 'grid gap-6 p-6 border-t md:px-12',
-    page: 'sticky top-nav grid gap-6 p-4 md:px-6 md:translate-y-4 bg-primary/5 rounded',
+    page: 'sticky top-nav grid gap-6 p-4 md:px-6 md:translate-y-4 bg-primary/5 rounded w-full max-w-md',
   };
 
   return (

--- a/templates/demo-store/src/components/cart/CartDetails.client.tsx
+++ b/templates/demo-store/src/components/cart/CartDetails.client.tsx
@@ -9,7 +9,13 @@ import {
 
 import {Button, Text, CartLineItem, CartEmpty} from '~/components';
 
-export function CartDetails({onClose}: {onClose?: () => void}) {
+export function CartDetails({
+  layout,
+  onClose,
+}: {
+  layout: 'drawer' | 'page';
+  onClose?: () => void;
+}) {
   const {lines} = useCart();
   const scrollRef = useRef(null);
   const {y} = useScroll(scrollRef);
@@ -18,14 +24,27 @@ export function CartDetails({onClose}: {onClose?: () => void}) {
     return <CartEmpty onClose={onClose} />;
   }
 
+  const container = {
+    drawer: 'grid grid-cols-1 h-screen-no-nav grid-rows-[1fr_auto]',
+    page: 'pb-12 max-w-7xl mx-auto w-full flex flex-col md:flex-row md:items-start gap-4 md:gap-8 lg:gap-12',
+  };
+
+  const content = {
+    drawer: 'px-6 pb-6 sm-max:pt-2 overflow-auto transition md:px-12',
+    page: 'flex-grow md:translate-y-4',
+  };
+
+  const summary = {
+    drawer: 'grid gap-6 p-6 border-t md:px-12',
+    page: 'sticky top-nav grid gap-6 p-4 md:px-6 md:translate-y-4 bg-primary/5 rounded',
+  };
+
   return (
-    <form className="grid grid-cols-1 h-screen-no-nav grid-rows-[1fr_auto]">
+    <form className={container[layout]}>
       <section
         ref={scrollRef}
         aria-labelledby="cart-contents"
-        className={`px-6 pb-6 sm-max:pt-2 overflow-auto transition md:px-12 ${
-          y > 0 && 'border-t'
-        }`}
+        className={`${content[layout]} ${y > 0 && 'border-t'}`}
       >
         <ul className="grid gap-6 md:gap-10">
           {lines.map((line) => {
@@ -37,10 +56,7 @@ export function CartDetails({onClose}: {onClose?: () => void}) {
           })}
         </ul>
       </section>
-      <section
-        aria-labelledby="summary-heading"
-        className="grid gap-6 p-6 border-t md:px-12"
-      >
+      <section aria-labelledby="summary-heading" className={summary[layout]}>
         <h2 id="summary-heading" className="sr-only">
           Order summary
         </h2>
@@ -78,14 +94,6 @@ function OrderSummary() {
             ) : (
               '-'
             )}
-          </Text>
-        </div>
-        <div className="flex items-center justify-between">
-          <Text as="dt" className="flex items-center">
-            <span>Shipping estimate</span>
-          </Text>
-          <Text as="dd" className="text-green-600">
-            Free and carbon neutral
           </Text>
         </div>
       </dl>

--- a/templates/demo-store/src/components/global/CartDrawer.client.tsx
+++ b/templates/demo-store/src/components/global/CartDrawer.client.tsx
@@ -14,7 +14,7 @@ export function CartDrawer({
         <Drawer.Title>
           <h2 className="sr-only">Cart Drawer</h2>
         </Drawer.Title>
-        <CartDetails onClose={onClose} />
+        <CartDetails layout="drawer" onClose={onClose} />
       </div>
     </Drawer>
   );

--- a/templates/demo-store/src/components/global/Drawer.client.tsx
+++ b/templates/demo-store/src/components/global/Drawer.client.tsx
@@ -19,7 +19,7 @@ function Drawer({
   openFrom = 'right',
   children,
 }: {
-  heading?: string;
+  heading: string;
   open: boolean;
   onClose: () => void;
   openFrom: 'right' | 'left';

--- a/templates/demo-store/src/components/global/Header.client.tsx
+++ b/templates/demo-store/src/components/global/Header.client.tsx
@@ -74,12 +74,16 @@ function MobileHeader({
   openCart: () => void;
   openMenu: () => void;
 }) {
+  const {y} = useWindowScroll();
+
   const styles = {
     button: 'relative flex items-center justify-center w-8 h-8',
     container: `${
       isHome
         ? 'bg-primary/80 dark:bg-contrast/60 text-contrast dark:text-primary shadow-darkHeader'
         : 'bg-contrast/80 text-primary'
+    } ${
+      y > 50 && !isHome && 'shadow-lightHeader'
     } flex lg:hidden items-center h-nav sticky backdrop-blur-lg z-40 top-0 justify-between w-full leading-none gap-4 px-4 md:px-8`,
   };
 
@@ -148,7 +152,8 @@ function DesktopHeader({
   const {y} = useWindowScroll();
 
   const styles = {
-    button: 'relative flex items-center justify-center w-8 h-8',
+    button:
+      'relative flex items-center justify-center w-8 h-8 focus:ring-primary/5',
     container: `${
       isHome
         ? 'bg-primary/80 dark:bg-contrast/60 text-contrast dark:text-primary shadow-darkHeader'

--- a/templates/demo-store/src/routes/cart.server.tsx
+++ b/templates/demo-store/src/routes/cart.server.tsx
@@ -14,7 +14,9 @@ export default function Cart() {
           }}
         />
       </Suspense>
-      <PageHeader heading="Your Cart" />
+      <div className="w-full mx-auto max-w-7xl xl:-translate-x-12">
+        <PageHeader heading="Your Cart" />
+      </div>
       <Section padding="x">
         <CartDetails layout="page" />
       </Section>

--- a/templates/demo-store/src/styles/index.css
+++ b/templates/demo-store/src/styles/index.css
@@ -15,6 +15,7 @@
   --color-shop-pay: #5a31f4;
   --shop-pay-button--width: 100%; /* Sets the width for the shop-pay-button web component */
   --height-nav: 3rem;
+  --screen-height: 100vh;
 
   @media (min-width: 32em) {
     --height-nav: 4rem;
@@ -24,11 +25,8 @@
     --font-size-heading: 2.25rem; /* text-4xl */
     --font-size-display: 3.75rem; /* text-6xl */
   }
-  @media (min-width: 64em) {
-  }
-  @media (min-width: 80em) {
-  }
-  @media (min-width: 96em) {
+  @supports (height: 100lvh) {
+    --screen-height: 100lvh;
   }
 }
 

--- a/templates/demo-store/tailwind.config.js
+++ b/templates/demo-store/tailwind.config.js
@@ -35,6 +35,7 @@ module.exports = {
       },
       spacing: {
         nav: 'var(--height-nav)',
+        screen: 'var(--screen-height, 100vh)',
       },
       fontFamily: {
         sans: ['Helvetica Neue', 'ui-sans-serif', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
Adds classes to the CartDetails component, which now accepts a `layout` prop which can resolve to `drawer` or `page` — that then allows us to switch through the needed CSS for the layout.

Also adds an override to the default `screen` spacing property in Tailwind to use `100lvh` when it's supported.