### PR TITLE
Add stackblitzrc for demo-store

### DIFF
--- a/templates/demo-store/.stackblitzrc
+++ b/templates/demo-store/.stackblitzrc
@@ -1,0 +1,5 @@
+{
+  "installDependencies": true,
+  "startCommand": "yarn vite",
+  "compileTrigger": "save"
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This ensures StackBlitz uses `yarn vite` instead of `shopify hydrogen dev` since it is currently broken: #1395 