### PR TITLE
Default to 'US' CountryCode if locale cannot be parsed correctly

### DIFF
--- a/.changeset/brown-timers-lay.md
+++ b/.changeset/brown-timers-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Default to 'US' CountryCode if locale cannot be parsed correctly

--- a/packages/hydrogen/src/components/LocalizationProvider/LocalizationProvider.server.tsx
+++ b/packages/hydrogen/src/components/LocalizationProvider/LocalizationProvider.server.tsx
@@ -2,6 +2,7 @@ import React, {ReactNode} from 'react';
 import LocalizationClientProvider from './LocalizationClientProvider.client';
 import {useShop} from '../../foundation/useShop';
 import {useServerRequest} from '../../foundation/ServerRequestProvider';
+import {CountryCode} from '../../storefront-api-types';
 
 export interface LocalizationProviderProps {
   /** A `ReactNode` element. */
@@ -27,7 +28,7 @@ export interface LocalizationProviderProps {
  */
 export function LocalizationProvider(props: LocalizationProviderProps) {
   const {languageCode: defaultLanguageCode, locale} = useShop();
-  const defaultCountryCode = locale.split(/[-_]/)[1] || '';
+  const defaultCountryCode = locale.split(/[-_]/)[1] || CountryCode.Us;
 
   const languageCode = (
     props.languageCode ?? defaultLanguageCode


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes an issue where Oxygen injects `en` instead of `en-US` for `hydrogenConfig#defaultLocale`.