### PR TITLE
Remove configPath from loadConfig

### DIFF
--- a/packages/hydrogen/src/framework/load-config.ts
+++ b/packages/hydrogen/src/framework/load-config.ts
@@ -9,8 +9,5 @@ export async function loadConfig(options = {root: process.cwd()}) {
     options
   );
 
-  return {
-    configuration: loaded[0].default,
-    configurationPath: loaded[0].configPath,
-  };
+  return {configuration: loaded[0].default};
 }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
@@ -24,14 +24,11 @@ export const VIRTUAL_PROXY_HYDROGEN_ROUTES_ID =
 export default (pluginOptions: HydrogenVitePluginOptions) => {
   let config: ResolvedConfig;
   let server: ViteDevServer;
-  let resolvedConfigPath: string;
 
   return {
     name: 'hydrogen:virtual-files',
     configResolved(_config) {
       config = _config;
-      // @ts-ignore
-      config.plugins.push(addPathToConfigProxy());
     },
     configureServer(_server) {
       server = _server;
@@ -41,12 +38,11 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
         return findHydrogenConfigPath(
           config.root,
           pluginOptions.configPath
-        ).then((hcPath: string) => {
-          resolvedConfigPath = hcPath;
+        ).then((hcPath: string) =>
           // This direct dependency on a real file
           // makes HMR work for the virtual module.
-          return this.resolve(hcPath, importer, {skipSelf: true});
-        });
+          this.resolve(hcPath, importer, {skipSelf: true})
+        );
       }
 
       if (
@@ -118,21 +114,6 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
 
     const {loaded} = await viteception([VIRTUAL_PROXY_HYDROGEN_CONFIG_ID]);
     return loaded[0].default;
-  }
-
-  function addPathToConfigProxy() {
-    return {
-      name: 'hydrogen:virtual-files-post',
-      enforce: 'post',
-      transform(code: string, id: string) {
-        if (id === '\0' + VIRTUAL_PROXY_HYDROGEN_CONFIG_ID) {
-          // The CLI needs to import the Hydrogen config path
-          return (
-            code + ` export const configPath = '${resolvedConfigPath || ''}';`
-          );
-        }
-      },
-    };
   }
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removing `configPath` from `loadConfig` because it's not needed anymore in the CLI.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
