### PR TITLE
Fix LOCAL_DEV env var

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,8 +1,7 @@
 # Contributing to Hydrogen
 
-## Releasing
-
-See [Releasing](releasing.md).
+> Tip:
+> Looking for [releasing instructions](releasing.md)?
 
 **Requirements:**
 
@@ -32,6 +31,14 @@ To make changes to the Demo Store template, edit the files in `templates/demo-st
 To modify Hydrogen framework, components, and hooks, edit the files in `packages/hydrogen`.
 
 You can [inspect Vite plugin](https://github.com/antfu/vite-plugin-inspect) transformations by visiting `http://localhost:3000/__inspect`.
+
+During local development, you can use `LOCAL_DEV` environment variable to enable
+Hydrogen file watching when running templates or examples. This variable also disables file hashing and minification when building locally.
+
+```bash
+$ export LOCAL_DEV=true
+$ yarn [dev|build]
+```
 
 ## Context
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -1,6 +1,12 @@
 import {Plugin} from 'vite';
 import type {BuildOptions} from 'vite';
 
+// About LOCAL_DEV environment variable:
+// It enables hydrogen/* file watching for local development and
+// disables hashing and minification for local builds. Usage in terminal:
+// $ export LOCAL_DEV=true
+// $ yarn [dev|build]
+
 export default () => {
   const rollupOptions: BuildOptions['rollupOptions'] = {
     output: {},
@@ -19,7 +25,7 @@ export default () => {
     };
   }
 
-  if (process.env.NODE_ENV !== 'development') {
+  if (process.env.NODE_ENV !== 'development' && !process.env.LOCAL_DEV) {
     /**
      * Ofuscate production asset name - To prevent ad blocker logics that blocks
      * certain files due to how it is named.
@@ -43,7 +49,8 @@ export default () => {
       },
 
       build: {
-        minify: config.build?.minify ?? 'esbuild',
+        minify:
+          config.build?.minify ?? (process.env.LOCAL_DEV ? false : 'esbuild'),
         sourcemap: true,
         rollupOptions: config.build?.rollupOptions
           ? Object.assign(rollupOptions, config.build.rollupOptions)

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-config.ts
@@ -1,12 +1,6 @@
 import {Plugin} from 'vite';
 import type {BuildOptions} from 'vite';
 
-// About LOCAL_DEV environment variable:
-// It enables hydrogen/* file watching for local development and
-// disables hashing and minification for local builds. Usage in terminal:
-// $ export LOCAL_DEV=true
-// $ yarn [dev|build]
-
 export default () => {
   const rollupOptions: BuildOptions['rollupOptions'] = {
     output: {},


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Minor change to fix the `LOCAL_DEV` variable behavior.
I personally tend to disable file hashing and minification veeery often when debugging Hydrogen, and this env variable is a nice shortcut. It's also useful to watch files during development so we don't need to restart the server.

Originally we had this in `package.json` but it's been removed a few times. I think the easiest way to use it is by manually running `export LOCAL_DEV=true` in the terminal before any dev/build commands.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
