### PR TITLE
Fix header issues with drawer components

### DIFF
--- a/templates/demo-store/src/components/global/CartDrawer.client.tsx
+++ b/templates/demo-store/src/components/global/CartDrawer.client.tsx
@@ -11,9 +11,6 @@ export function CartDrawer({
   return (
     <Drawer open={isOpen} onClose={onClose} heading="Cart" openFrom="right">
       <div className="grid">
-        <Drawer.Title>
-          <h2 className="sr-only">Cart Drawer</h2>
-        </Drawer.Title>
         <CartDetails layout="drawer" onClose={onClose} />
       </div>
     </Drawer>

--- a/templates/demo-store/src/components/global/Drawer.client.tsx
+++ b/templates/demo-store/src/components/global/Drawer.client.tsx
@@ -68,9 +68,11 @@ function Drawer({
                     }`}
                   >
                     {heading && (
-                      <Heading as="h2" size="lead" id="cart-contents">
-                        {heading}
-                      </Heading>
+                      <Dialog.Title>
+                        <Heading as="span" size="lead" id="cart-contents">
+                          {heading}
+                        </Heading>
+                      </Dialog.Title>
                     )}
                     <button
                       type="button"

--- a/templates/demo-store/src/components/global/MenuDrawer.client.tsx
+++ b/templates/demo-store/src/components/global/MenuDrawer.client.tsx
@@ -15,9 +15,6 @@ export function MenuDrawer({
   return (
     <Drawer open={isOpen} onClose={onClose} openFrom="left" heading="Menu">
       <div className="grid">
-        <Drawer.Title>
-          <h2 className="sr-only">Menu Drawer</h2>
-        </Drawer.Title>
         <MenuMobileNav menu={menu} onClose={onClose} />
       </div>
     </Drawer>


### PR DESCRIPTION
### Description
We are having an `h2` inside another `h2` causing console errors and incorrect html. 

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1143424/174770556-53649af9-9310-4beb-9e85-626e54ceb756.png">

Quick fix for this
