### PR TITLE
Fix throwing error when `<Link>` is used outside of `<Router>`

### DIFF
--- a/.changeset/seven-plums-matter.md
+++ b/.changeset/seven-plums-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Throw error when `<Link>` component is used outside of `<Router>` component.

--- a/packages/hydrogen/src/components/CartLineProductTitle/tests/CartLineProductTitle.test.tsx
+++ b/packages/hydrogen/src/components/CartLineProductTitle/tests/CartLineProductTitle.test.tsx
@@ -3,7 +3,8 @@ import {mount} from '@shopify/react-testing';
 import {CartLineProvider} from '../../CartLineProvider';
 import {CartLineProductTitle} from '../CartLineProductTitle.client';
 import {CART_LINE} from '../../CartLineProvider/tests/fixtures';
-import {Link} from '../../Link/index';
+import {Link} from '../../Link/Link.client';
+import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 
 describe(`<CartLineProductTitle/>`, () => {
   it('displays the title', () => {
@@ -31,7 +32,7 @@ describe(`<CartLineProductTitle/>`, () => {
   });
 
   it(`validates props on components passed to the 'as' prop`, () => {
-    const wrapper = mount(
+    const wrapper = mountWithProviders(
       <CartLineProvider line={CART_LINE}>
         <CartLineProductTitle as={Link} to="/test" />
       </CartLineProvider>

--- a/packages/hydrogen/src/components/CartLineQuantity/tests/CartLineQuantity.test.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantity/tests/CartLineQuantity.test.tsx
@@ -3,7 +3,8 @@ import {mount} from '@shopify/react-testing';
 import {CartLineProvider} from '../../CartLineProvider';
 import {CartLineQuantity} from '../CartLineQuantity.client';
 import {CART_LINE} from '../../CartLineProvider/tests/fixtures';
-import {Link} from '../../Link/index';
+import {Link} from '../../Link/Link.client';
+import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 
 describe('<CartLineQuantity />', () => {
   it('displays the quantity', () => {
@@ -31,7 +32,7 @@ describe('<CartLineQuantity />', () => {
   });
 
   it(`validates props for a component passed to the 'as' prop`, () => {
-    const wrapper = mount(
+    const wrapper = mountWithProviders(
       <CartLineProvider line={CART_LINE}>
         <CartLineQuantity as={Link} to="/test" />
       </CartLineProvider>

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {useRouter} from '../../foundation/Router/BrowserRouter.client';
+import {useLocation} from '../../foundation/Router/BrowserRouter.client';
 import {createPath} from 'history';
 import {buildPath, useNavigate} from '../../foundation/useNavigate/useNavigate';
 import {RSC_PATHNAME} from '../../constants';
@@ -32,7 +32,7 @@ export interface LinkProps
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function Link(props, ref) {
     const navigate = useNavigate();
-    const {location} = useRouter();
+    const location = useLocation();
     const [_, startTransition] = (React as any).useTransition();
     const routeBasePath = useBasePath();
 
@@ -173,7 +173,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
 function Prefetch({pathname}: {pathname: string}) {
   const {getProposedLocationServerProps} = useInternalServerProps();
-  const {location} = useRouter();
+  const location = useLocation();
 
   const newPath = createPath({pathname});
 

--- a/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/components/StarRating/tests/StarRating.test.tsx
@@ -3,7 +3,8 @@ import {getRawMetafield} from '../../../../../utilities/tests/metafields';
 import {mount} from '@shopify/react-testing';
 import {StarRating, Star} from '../StarRating';
 import {Rating} from '../../../../../types';
-import {Link} from '../../../../Link/index';
+import {Link} from '../../../../Link/Link.client';
+import {mountWithProviders} from '../../../../../utilities/tests/shopifyMount';
 
 describe('<StarRating />', () => {
   it('renders the number of stars in the rating scale', () => {
@@ -42,7 +43,7 @@ describe('<StarRating />', () => {
     const rating = getRawMetafield({type: 'rating'});
     const parsedRating = JSON.parse(rating.value ?? '') as Rating;
 
-    const component = mount(
+    const component = mountWithProviders(
       <StarRating rating={parsedRating} as={Link} to="/test" />
     );
 

--- a/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
+++ b/packages/hydrogen/src/components/Metafield/tests/Metafield.test.tsx
@@ -5,7 +5,7 @@ import {mountWithProviders} from '../../../utilities/tests/shopifyMount';
 import {Image} from '../../Image';
 import {getMediaImage} from '../../../utilities/tests/media';
 import type {Rating} from '../../../types';
-import {Link} from '../../Link/index';
+import {Link} from '../../Link/Link.client';
 import {Page, Product, ProductVariant} from '../../../storefront-api-types';
 
 describe('<Metafield />', () => {

--- a/packages/hydrogen/src/components/Money/tests/Money.test.tsx
+++ b/packages/hydrogen/src/components/Money/tests/Money.test.tsx
@@ -4,7 +4,7 @@ import {CurrencyCode} from '../../../storefront-api-types';
 import {getPrice} from '../../../utilities/tests/price';
 import {getUnitPriceMeasurement} from '../../../utilities/tests/unitPriceMeasurement';
 import {Money} from '../Money.client';
-import {Link} from '../../Link/index';
+import {Link} from '../../Link/Link.client';
 
 describe('<Money />', () => {
   it('renders a formatted money string', () => {

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -19,7 +19,9 @@ type RouterContextValue = {
   location: Location;
 };
 
-export const RouterContext = createContext<RouterContextValue | {}>({});
+export const RouterContext = createContext<RouterContextValue | undefined>(
+  undefined
+);
 
 let isFirstLoad = true;
 const positions: Record<string, number> = {};
@@ -92,13 +94,15 @@ export const BrowserRouter: FC<{
 };
 
 export function useRouter() {
-  const router = useContext<RouterContextValue | {}>(RouterContext);
+  if (META_ENV_SSR) return {location: {}, history: {}} as RouterContextValue;
 
-  if (!router && META_ENV_SSR) {
-    throw new Error('useRouter must be used within a <Router> component');
-  }
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const router = useContext(RouterContext);
+  if (router) return router;
 
-  return router as RouterContextValue;
+  throw new Error(
+    'Router hooks and <Link> component must be used within a <Router> component'
+  );
 }
 
 export function useLocation() {

--- a/packages/hydrogen/src/foundation/useUrl/useUrl.ts
+++ b/packages/hydrogen/src/foundation/useUrl/useUrl.ts
@@ -1,7 +1,7 @@
-import {useMemo} from 'react';
+import {useContext, useMemo} from 'react';
 import {RSC_PATHNAME} from '../../constants';
 import {parseJSON} from '../../utilities/parse';
-import {useLocation} from '../Router/BrowserRouter.client';
+import {RouterContext} from '../Router/BrowserRouter.client';
 import {useEnvContext, META_ENV_SSR} from '../ssr-interop';
 
 /**
@@ -29,8 +29,10 @@ export function useUrl(): URL {
   /**
    * We return a `URL` object instead of passing through `location` because
    * the URL object contains important info like hostname, etc.
+   * Note: do not call `useLocation` directly here to avoid throwing errors
+   * when `useUrl` is used outside of a Router component (e.g. in <Seo>).
    */
-  const location = useLocation(); // eslint-disable-line react-hooks/rules-of-hooks
+  const location = useContext(RouterContext); // eslint-disable-line react-hooks/rules-of-hooks
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return useMemo(() => new URL(window.location.href), [location]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We were supposed to throw an error when `useRouter` or `Link` are used without a parent `Router` component but it wasn't working as expected.

@blittle Is this now the intended behavior?

@jplhomer Related to #1082 , we were calling `useLocation` within `useUrl`, but this hook was used in `Seo` which is generally not a child of `Router`. As a result, the `useLocation` call was always returning `undefined`. I'm not sure if this use case is important but this PR changes it to call `useContext` directly so it shouldn't modify the behavior. Is it ok?

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
