### PR TITLE
Avoid writing to Node response if it's closed

### DIFF
--- a/.changeset/nine-trains-check.md
+++ b/.changeset/nine-trains-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Avoid writing to Node response if it has been closed early.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I've seen some random error `The destination stream closed early.` since a couple of weeks ago during development and E2E tests. It comes from React 18.2 when the Node response is closed before SSR streaming ends.
I think this can happen if the browser closes the connection, for example. This error doesn't seem to be very interesting so I'm hiding it from the logs to avoid confusion. Thoughts?

Apart from that, this adds a bunch of guards before writing to Node response.

<img width="455" alt="image" src="https://user-images.githubusercontent.com/1634092/174808730-2357b88d-a775-423b-b249-3edebbadea3f.png">


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
