### PR TITLE
Fix basepath to not apply to fully qualified URLs

### DIFF
--- a/.changeset/stupid-jokes-taste.md
+++ b/.changeset/stupid-jokes-taste.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix basepath to not apply to fully qualified URLs.
+Fix basepath to not apply to external URLs in the `<Link` component. Also default the attribute `rel="noreferrer noopener` for external URLs.

--- a/.changeset/stupid-jokes-taste.md
+++ b/.changeset/stupid-jokes-taste.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix basepath to not apply to fully qualified URLs.

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -155,6 +155,10 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
             'scroll',
           ])}
           ref={ref}
+          rel={
+            props.rel ??
+            (to.startsWith('http') ? 'noreferrer noopener' : undefined)
+          }
           onClick={internalClick}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}

--- a/packages/hydrogen/src/components/Link/Link.client.tsx
+++ b/packages/hydrogen/src/components/Link/Link.client.tsx
@@ -157,7 +157,9 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
           ref={ref}
           rel={
             props.rel ??
-            (to.startsWith('http') ? 'noreferrer noopener' : undefined)
+            (to.startsWith('http') || to.startsWith('//')
+              ? 'noreferrer noopener'
+              : undefined)
           }
           onClick={internalClick}
           onMouseEnter={onMouseEnter}

--- a/packages/hydrogen/src/components/Link/tests/Link.test.tsx
+++ b/packages/hydrogen/src/components/Link/tests/Link.test.tsx
@@ -17,6 +17,28 @@ describe('<Link />', () => {
     );
   });
 
+  it('renders default rel for external destinations', () => {
+    const component = mountWithProviders(
+      <Link to="https://something.com/products/hydrogen">Link</Link>
+    );
+
+    expect(component).toContainReactHtml(
+      '<a rel="noreferrer noopener" href="https://something.com/products/hydrogen">Link</a>'
+    );
+  });
+
+  it('overrides default rel for external destinations', () => {
+    const component = mountWithProviders(
+      <Link rel="bookmark" to="https://something.com/products/hydrogen">
+        Link
+      </Link>
+    );
+
+    expect(component).toContainReactHtml(
+      '<a rel="bookmark" href="https://something.com/products/hydrogen">Link</a>'
+    );
+  });
+
   it('forwards the ref', (done) => {
     mountWithProviders(
       <Link

--- a/packages/hydrogen/src/foundation/useNavigate/tests/useNavigate.test.ts
+++ b/packages/hydrogen/src/foundation/useNavigate/tests/useNavigate.test.ts
@@ -18,7 +18,9 @@ describe('buildPath', () => {
     expect(buildPath('/base', 'https://website.com')).toBe(
       'https://website.com'
     );
+    expect(buildPath('/base', '//website.com')).toBe('//website.com');
     expect(buildPath('/', 'http://website.com')).toBe('http://website.com');
     expect(buildPath('/', 'https://website.com')).toBe('https://website.com');
+    expect(buildPath('/', '//website.com')).toBe('//website.com');
   });
 });

--- a/packages/hydrogen/src/foundation/useNavigate/tests/useNavigate.test.ts
+++ b/packages/hydrogen/src/foundation/useNavigate/tests/useNavigate.test.ts
@@ -1,0 +1,24 @@
+import {buildPath} from '../useNavigate';
+
+describe('buildPath', () => {
+  it('doesn\'t transform base path "/"', () => {
+    expect(buildPath('/', '/')).toBe('/');
+    expect(buildPath('/', '/path')).toBe('/path');
+    expect(buildPath('/', '/path?params')).toBe('/path?params');
+  });
+  it('transforms with base path', () => {
+    expect(buildPath('/base', '/')).toBe('/base/');
+    expect(buildPath('/base', '/path')).toBe('/base/path');
+    expect(buildPath('/base', 'path')).toBe('/base/path');
+    expect(buildPath('/base/', '/path')).toBe('/base/path');
+    expect(buildPath('/base', '/path?params')).toBe('/base/path?params');
+  });
+  it("doesn't transform fully qualified URLs", () => {
+    expect(buildPath('/base', 'http://website.com')).toBe('http://website.com');
+    expect(buildPath('/base', 'https://website.com')).toBe(
+      'https://website.com'
+    );
+    expect(buildPath('/', 'http://website.com')).toBe('http://website.com');
+    expect(buildPath('/', 'https://website.com')).toBe('https://website.com');
+  });
+});

--- a/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
+++ b/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
@@ -45,11 +45,18 @@ export function useNavigate() {
 }
 
 export function buildPath(basePath: string, path: string) {
+  if (path.startsWith('http')) return path;
+
   let builtPath = path;
   if (basePath !== '/') {
+    const pathFirstChar = path.charAt(0);
+    const basePathLastChar = basePath.charAt(basePath.length - 1);
+
     builtPath =
-      path.charAt(0) === '/' && basePath.charAt(0) === '/'
+      pathFirstChar === '/' && basePathLastChar === '/'
         ? basePath + path.substring(1)
+        : basePathLastChar !== '/' && pathFirstChar !== '/'
+        ? basePath + '/' + path
         : basePath + path;
   }
   return builtPath;

--- a/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
+++ b/packages/hydrogen/src/foundation/useNavigate/useNavigate.ts
@@ -45,7 +45,7 @@ export function useNavigate() {
 }
 
 export function buildPath(basePath: string, path: string) {
-  if (path.startsWith('http')) return path;
+  if (path.startsWith('http') || path.startsWith('//')) return path;
 
   let builtPath = path;
   if (basePath !== '/') {


### PR DESCRIPTION
### Description

If within a `<FileRoutes basPath="/ca" />` component there is a `<Link to='http://somewebsite.com'>`, without this change, the base path would still get prepended and the link would be `/ca/http://somewebsite.com`. This fixes that and adds some tests.

### Additional context



### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
