### PR TITLE
Remove original templates from `dist`

### DIFF
--- a/scripts/compile-template-for-dist.mjs
+++ b/scripts/compile-template-for-dist.mjs
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 
   await compileTemplate(template, {source, destination});
   copy(`${source}/${template}`, `${source}/${template}-ts`);
+  fs.removeSync(`${source}/${template}`);
 })();
 
 function copyDir(srcDir, destDir) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR removes the original (not-suffixed) folder name from the [dist](https://github.com/Shopify/hydrogen/tree/dist/templates) branch in the `compile-templates-for-dist` script.

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
