### PR TITLE
[Hydrogen docs]: Remove `caches.default` references

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -305,7 +305,7 @@ You can deploy your Hydrogen storefront to Cloudflare Workers, a serverless appl
 
         return await handleRequest(event.request, {
           indexTemplate,
-          cache: await caches.open('oxygen'),
+          cache: caches.default,
           context: event,
           // Buyer IP varies by hosting provider and runtime. You should provide this
           // as an argument to the `handleRequest` function for your runtime.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -305,7 +305,7 @@ You can deploy your Hydrogen storefront to Cloudflare Workers, a serverless appl
 
         return await handleRequest(event.request, {
           indexTemplate,
-          cache: caches.default,
+          cache: await caches.open('oxygen'),
           context: event,
           // Buyer IP varies by hosting provider and runtime. You should provide this
           // as an argument to the `handleRequest` function for your runtime.

--- a/docs/framework/cache.md
+++ b/docs/framework/cache.md
@@ -205,8 +205,8 @@ For Worker-based runtimes, you can provide a `cache` option to `handleRequest`:
 addEventListener('fetch', (event) => {
   event.respondWith(
     handleEvent(event, {
-      // Your implementation of `Cache`. Defaults to `caches.default` for Oxygen support.
-      cache: caches.default,
+      // Your implementation of `Cache`. Defaults to `await caches.open` for Oxygen support.
+      cache: await caches.open('oxygen'),
 
       // ...
     })


### PR DESCRIPTION
## This PR: 
- Updates the cache and deployment docs to remove references to the unsupported `caches.default` API
- Relates to https://shopify.slack.com/archives/C02A5S8LNP9/p1655826731675269