### PR TITLE
Add basic E2E test for index page

### DIFF
--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -63,3 +63,9 @@ jobs:
         run: yarn test-e2e
         env:
           CI: true
+
+      - name: Run template E2E tests
+        run: yarn test:ci
+        working-directory: ./templates/demo-store
+        env:
+          CI: true

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -9,7 +9,9 @@
     "build": "shopify hydrogen build",
     "preview": "shopify hydrogen preview",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src",
-    "lint-ts": "tsc --noEmit"
+    "lint-ts": "tsc --noEmit",
+    "test": "WATCH=true vitest",
+    "test:ci": "yarn build -t node && vitest run"
   },
   "devDependencies": {
     "@shopify/cli": "^3.0.11",
@@ -20,13 +22,15 @@
     "@types/react": "^18.0.14",
     "eslint": "^8.18.0",
     "eslint-plugin-hydrogen": "^0.12.2",
+    "playwright": "^1.22.2",
     "postcss": "^8.4.14",
     "postcss-import": "^14.1.0",
     "postcss-preset-env": "^7.6.0",
     "prettier": "^2.3.2",
     "tailwindcss": "^3.0.24",
     "typescript": "^4.7.2",
-    "vite": "^2.9.0"
+    "vite": "^2.9.0",
+    "vitest": "^0.15.2"
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {

--- a/templates/demo-store/tests/e2e/index.test.ts
+++ b/templates/demo-store/tests/e2e/index.test.ts
@@ -1,0 +1,29 @@
+import {
+  startHydrogenServer,
+  type HydrogenServer,
+  type HydrogenSession,
+} from '../utils';
+import Index from '../../src/routes/index.server';
+
+describe('index', () => {
+  let hydrogen: HydrogenServer;
+  let session: HydrogenSession;
+
+  beforeAll(async () => {
+    hydrogen = await startHydrogenServer();
+    hydrogen.watchForUpdates(Index);
+  });
+
+  beforeEach(async () => {
+    session = await hydrogen.newPage();
+  });
+
+  afterAll(async () => {
+    await hydrogen.cleanUp();
+  });
+
+  it('should be a 200 response', async () => {
+    const response = await session.visit('/');
+    expect(response!.status()).toBe(200);
+  }, 60000);
+});

--- a/templates/demo-store/tests/utils.ts
+++ b/templates/demo-store/tests/utils.ts
@@ -1,0 +1,80 @@
+import {
+  chromium,
+  type Page,
+  type Response as PlaywrightResponse,
+} from 'playwright';
+import type {Server} from 'http';
+import {createServer as createViteDevServer} from 'vite';
+
+export const DEFAULT_DELAY = 60000;
+
+export interface HydrogenSession {
+  page: Page;
+  visit: (pathname: string) => Promise<PlaywrightResponse | null>;
+}
+
+export interface HydrogenServer {
+  url: (pathname: string) => string;
+  newPage: () => Promise<HydrogenSession>;
+  cleanUp: () => Promise<void>;
+  watchForUpdates: (_module: any) => void;
+}
+
+export async function startHydrogenServer(): Promise<HydrogenServer> {
+  const app = import.meta.env.WATCH
+    ? await createDevServer()
+    : await createNodeServer();
+
+  const browser = await chromium.launch();
+  const url = (pathname: string) => `http://localhost:${app.port}${pathname}`;
+
+  const newPage = async () => {
+    const page = await browser.newPage();
+    return {
+      page,
+      visit: async (pathname: string) => page.goto(url(pathname)),
+    };
+  };
+
+  const cleanUp = async () => {
+    await browser.close();
+    await app.server?.close();
+  };
+
+  return {url, newPage, cleanUp, watchForUpdates: () => {}};
+}
+
+async function createNodeServer() {
+  // @ts-ignore
+  const {createServer} = await import('../dist/node');
+  const app = (await createServer()).app;
+  const server = app.listen(0) as Server;
+  const port: number = await new Promise((resolve) => {
+    server.on('listening', () => {
+      resolve(getPortFromAddress(server.address()));
+    });
+  });
+
+  return {server, port};
+}
+
+async function createDevServer() {
+  const app = await createViteDevServer({
+    server: {force: true},
+    logLevel: 'silent',
+  });
+  const server = await app.listen(0);
+
+  return {
+    server: server.httpServer,
+    port: getPortFromAddress(server.httpServer!.address()),
+  };
+}
+
+function getPortFromAddress(address: string | any): number {
+  if (typeof address === 'string') {
+    return parseInt(address.split(':').pop()!);
+  } else {
+    return address.port;
+  }
+}

--- a/templates/demo-store/tsconfig.json
+++ b/templates/demo-store/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node16",
     "lib": ["dom", "dom.iterable", "scripthost", "es2020"],
     "jsx": "react-jsx",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals"],
     "strict": true,
     "esModuleInterop": true,
     "isolatedModules": true,

--- a/templates/demo-store/vite.config.ts
+++ b/templates/demo-store/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import {defineConfig} from 'vite';
 import hydrogen from '@shopify/hydrogen/plugin';
 
@@ -8,5 +9,10 @@ export default defineConfig({
   },
   optimizeDeps: {
     include: ['@headlessui/react', 'clsx', 'react-use', 'typographic-base'],
+  },
+  test: {
+    globals: true,
+    testTimeout: 10000,
+    hookTimeout: 10000,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10467,6 +10467,13 @@ playwright-core@1.22.2:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.22.2.tgz#ed2963d79d71c2a18d5a6fd25b60b9f0a344661a"
   integrity sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==
 
+playwright@^1.22.2:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.22.2.tgz#353a7c29f89ca9600edc7a9a30aed790823c797d"
+  integrity sha512-hUTpg7LytIl3/O4t0AQJS1V6hWsaSY5uZ7w1oCC8r3a1AQN5d6otIdCkiB3cbzgQkcMaRxisinjMFMVqZkybdQ==
+  dependencies:
+    playwright-core "1.22.2"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -12747,7 +12754,7 @@ through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tinypool@^0.1.2:
+tinypool@^0.1.2, tinypool@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
   integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
@@ -12756,6 +12763,11 @@ tinyspy@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.2.tgz#2f95cb14c38089ca690385f339781cd35faae566"
   integrity sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==
+
+tinyspy@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.3.tgz#8b57f8aec7fe1bf583a3a49cb9ab30c742f69237"
+  integrity sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==
 
 title-case@^3.0.3:
   version "3.0.3"
@@ -13740,6 +13752,18 @@ vite@^2.9.0, vite@^2.9.5, vite@^2.9.6:
   optionalDependencies:
     fsevents "~2.3.2"
 
+vite@^2.9.12:
+  version "2.9.12"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.12.tgz#b1d636b0a8ac636afe9d83e3792d4895509a941b"
+  integrity sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==
+  dependencies:
+    esbuild "^0.14.27"
+    postcss "^8.4.13"
+    resolve "^1.22.0"
+    rollup "^2.59.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 vite@^2.9.9:
   version "2.9.10"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.10.tgz#f574d96655622c2e0fbc662edd0ed199c60fe91a"
@@ -13751,6 +13775,21 @@ vite@^2.9.9:
     rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vitest@^0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.15.2.tgz#3931c390685ff03331298c7719d27d691f79e782"
+  integrity sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==
+  dependencies:
+    "@types/chai" "^4.3.1"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    chai "^4.3.6"
+    debug "^4.3.4"
+    local-pkg "^0.4.1"
+    tinypool "^0.1.3"
+    tinyspy "^0.3.3"
+    vite "^2.9.12"
 
 vitest@^0.9.4:
   version "0.9.4"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds back a basic E2E test from our previous demo store.

I opted only to do `index` this time, with a simple 200 status check. Developers should feel empowered to extend, create more, etc. We could also provide tooling to scaffold new tests a la Rails/Laravel someday ✨ 

We also had Analytics and Performance tests. But we should migrate these to framework-level E2E tests instead.