### PR TITLE
Use graphql-playground

### DIFF
--- a/.changeset/eight-dots-sleep.md
+++ b/.changeset/eight-dots-sleep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Replace graphiql with graphql/graphql-playground in local development at '/graphql` route.

--- a/packages/hydrogen/src/foundation/DevTools/components/Heading.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Heading.tsx
@@ -10,9 +10,7 @@ export function Heading({
   children: string;
 }) {
   return (
-    <span
-      style={{display: 'flex', alignItems: 'baseline', padding: '0 0 0.5em'}}
-    >
+    <span style={{display: 'flex', alignItems: 'baseline', padding: '0 0 0em'}}>
       <span style={{paddingRight: '0em', flex: 1, fontWeight: 'bold'}}>
         {children}{' '}
       </span>

--- a/packages/hydrogen/src/foundation/DevTools/components/Panels.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Panels.tsx
@@ -102,7 +102,13 @@ export function Panels({settings}: Props) {
             );
           }
           return (
-            <a style={style} href={panel.url} key={panel.url}>
+            <a
+              style={style}
+              target="_blank"
+              rel="noreferrer"
+              href={panel.url}
+              key={panel.url}
+            >
               {panel.content}
               <span>↗</span>
             </a>
@@ -128,7 +134,7 @@ function getPanels({settings, performance}: Props) {
     },
     graphiql: {
       content: 'GraphiQL',
-      url: '/graphiql',
+      url: '/___graphql',
     },
   };
 

--- a/packages/hydrogen/src/foundation/DevTools/components/Panels.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Panels.tsx
@@ -8,19 +8,29 @@ export interface Props {
   performance: ComponentProps<typeof Performance>;
 }
 
-interface Panel {
+interface BasePanel {
   content: string;
-  panel: React.ReactNode;
-  icon: React.ReactNode;
+}
+
+interface ExternalPanel extends BasePanel {
+  url: string;
+}
+
+interface ComponentPanel extends BasePanel {
+  component: React.ReactNode;
 }
 
 type Navigations = Props['performance']['navigations'];
 
 interface Panels {
-  performance: Panel;
-  settings: Panel;
-  graphql?: Panel;
+  performance: ComponentPanel;
+  settings: ComponentPanel;
+  graphiql: ExternalPanel;
 }
+
+const isComponentPanel = (
+  panel: ComponentPanel | ExternalPanel
+): panel is ComponentPanel => (panel as ComponentPanel).component !== undefined;
 
 export function Panels({settings}: Props) {
   const [selectedPanel, setSelectedPanel] = useState<number>(0);
@@ -55,61 +65,70 @@ export function Panels({settings}: Props) {
   }, [setNavigations, navigations]);
 
   const panels = getPanels({settings, performance: {navigations}});
-  const panelComponents = panels.map((obj, index) => (
-    <div
-      key={obj.content}
-      style={{display: selectedPanel === index ? 'block' : 'none'}}
-    >
-      {obj.panel}
-    </div>
-  ));
+  const panelComponents = panels.map((obj, index) =>
+    isComponentPanel(obj) ? (
+      <div
+        key={obj.content}
+        style={{display: selectedPanel === index ? 'block' : 'none'}}
+      >
+        {obj.component}
+      </div>
+    ) : null
+  );
 
   return (
     <div style={{display: 'flex', height: '100%'}}>
       <div style={{borderRight: '1px solid', padding: '1em 0em'}}>
-        {panels.map(({content, icon, id}, index) => {
+        {panels.map((panel, index) => {
           const active = selectedPanel === index;
+          const style = {
+            padding: '0em 1.25em',
+            fontWeight: 'bold',
+            textDecoration: active ? 'underline' : 'none',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          };
+          if (isComponentPanel(panel)) {
+            return (
+              <button
+                key={panel.id}
+                type="button"
+                style={style}
+                onClick={() => setSelectedPanel(index)}
+              >
+                <span>{panel.content}</span>
+              </button>
+            );
+          }
           return (
-            <button
-              key={id}
-              type="button"
-              style={{
-                lineHeight: 2,
-                padding: '0em 1.25em',
-                fontWeight: active ? 'bold' : 'normal',
-                display: 'flex',
-                alignItems: 'center',
-              }}
-              onClick={() => setSelectedPanel(index)}
-            >
-              <span style={{paddingRight: '0.4em'}}>{icon}</span>
-              <span style={{fontFamily: 'monospace'}}>{content}</span>
-            </button>
+            <a style={style} href={panel.url} key={panel.url}>
+              {panel.content}
+              <span>↗</span>
+            </a>
           );
         })}
       </div>
-      <div style={{padding: '1.25em', width: '100%'}}>
+      <div style={{padding: '1em', width: '100%'}}>
         {panelComponents[selectedPanel ? selectedPanel : 0]}
       </div>
     </div>
   );
 }
 
-function Panel({children}: {children: React.ReactNode}) {
-  return <div>{children}</div>;
-}
-
 function getPanels({settings, performance}: Props) {
   const panels: Panels = {
     settings: {
       content: 'Settings',
-      panel: <Settings {...settings} />,
-      icon: '🎛',
+      component: <Settings {...settings} />,
     },
     performance: {
       content: 'Performance',
-      panel: <Performance {...performance} />,
-      icon: '⏱',
+      component: <Performance {...performance} />,
+    },
+    graphiql: {
+      content: 'GraphiQL',
+      url: '/graphiql',
     },
   };
 

--- a/packages/hydrogen/src/foundation/DevTools/components/Performance.client.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Performance.client.tsx
@@ -53,7 +53,6 @@ const Item = ({label, value, unit}: PillProps) => {
       style={{
         fontFamily: 'monospace',
         padding: '0 2em 0 0',
-        fontSize: '0.75em',
       }}
     >
       {label && label.padEnd(10)}

--- a/packages/hydrogen/src/foundation/DevTools/components/Settings.client.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Settings.client.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Heading} from './Heading';
 import {Table} from './Table';
 
 interface Props {
@@ -23,10 +22,5 @@ export function Settings(props: Props) {
     };
   });
 
-  return (
-    <>
-      <Heading>Config</Heading>
-      <Table items={items} />
-    </>
-  );
+  return <Table items={items} />;
 }

--- a/packages/hydrogen/src/foundation/DevTools/components/Table.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Table.tsx
@@ -11,15 +11,12 @@ interface TableProps {
 
 export function Table({items}: TableProps) {
   const itemsMarkup = items.map(({key, value}) => (
-    <div key={key} style={{display: 'flex'}}>
-      <span
-        style={{width: '30%', fontFamily: 'monospace', paddingRight: '1em'}}
-      >
-        {key}
-      </span>
-      <span style={{width: '70%', fontFamily: 'monospace', fontWeight: 'bold'}}>
-        {value}
-      </span>
+    <div
+      key={key}
+      style={{display: 'flex', paddingBottom: '1em', flexDirection: 'column'}}
+    >
+      <span style={{fontWeight: 'bold'}}>{key}</span>
+      <span style={{width: '70%', fontFamily: 'monospace'}}>{value}</span>
     </div>
   ));
   return <ul>{itemsMarkup}</ul>;

--- a/packages/hydrogen/src/framework/graphiql.ts
+++ b/packages/hydrogen/src/framework/graphiql.ts
@@ -1,38 +1,34 @@
 export function graphiqlHtml(shop: string, token: string, apiVersion: string) {
-  return `<html>
-  <head>
-    <title>Shopify Storefront API</title>
-    <link href="https://unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
-  </head>
-  <body style="margin: 0;">
-    <div id="graphiql" style="height: 100vh;"></div>
-    <script
-      crossorigin
-      src="https://unpkg.com/react/umd/react.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-    ></script>
-    <script>
-      const fetcher = GraphiQL.createFetcher({
-        url: 'https://${shop}/api/${apiVersion}/graphql.json',
-        headers: {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=utf-8/>
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+  <title>Shopify Storefront API</title>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+</head>
+<body>
+  <div id="root">
+  <script>window.addEventListener('load', function (event) {
+    GraphQLPlayground.init(document.getElementById('root'), {
+      endpoint:'https://${shop}/api/${apiVersion}/graphql.json',
+      settings:{
+        'request.globalHeaders': {
           Accept: 'application/json',
           'Content-Type': 'application/graphql',
           'X-Shopify-Storefront-Access-Token': '${token}'
         }
-      });
-      ReactDOM.render(
-        React.createElement(GraphiQL, { fetcher: fetcher }),
-        document.getElementById('graphiql'),
-      );
-    </script>
-  </body>
+      },
+      tabs: [{
+        endpoint: 'https://${shop}/api/${apiVersion}/graphql.json',
+        query: '{ shop { name } }'
+      }]
+    })
+  })</script>
+</body>
 </html>
 `;
 }

--- a/packages/hydrogen/src/framework/graphiql.ts
+++ b/packages/hydrogen/src/framework/graphiql.ts
@@ -11,7 +11,7 @@ export function graphiqlHtml(shop: string, token: string, apiVersion: string) {
   <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
 </head>
 <body>
-  <div id="root">
+  <div id="root"></div>
   <script>window.addEventListener('load', function (event) {
     GraphQLPlayground.init(document.getElementById('root'), {
       endpoint:'https://${shop}/api/${apiVersion}/graphql.json',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds the `graphql-playground` UI to the rendered HTML GraphiQL response from `/graphql`. It also adds a handy link from the DevTools component.


https://user-images.githubusercontent.com/462077/174936767-0828fd86-3634-4a82-9750-cc5741f6e781.mov



### Additional context

This component is fairly customisable and styleable. The [types in this file](https://github.com/graphql/graphql-playground/blob/main/packages/graphql-playground-html/src/render-playground-page.ts) provide the best documentation I could find for what is possible.

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
