### PR TITLE
Demo store suspense enhancements

### DIFF
--- a/templates/demo-store/src/components/global/Header.client.tsx
+++ b/templates/demo-store/src/components/global/Header.client.tsx
@@ -83,8 +83,8 @@ function MobileHeader({
         ? 'bg-primary/80 dark:bg-contrast/60 text-contrast dark:text-primary shadow-darkHeader'
         : 'bg-contrast/80 text-primary'
     } ${
-      y > 50 && !isHome && 'shadow-lightHeader'
-    } flex lg:hidden items-center h-nav sticky backdrop-blur-lg z-40 top-0 justify-between w-full leading-none gap-4 px-4 md:px-8`,
+      y > 50 && !isHome ? 'shadow-lightHeader ' : ''
+    }flex lg:hidden items-center h-nav sticky backdrop-blur-lg z-40 top-0 justify-between w-full leading-none gap-4 px-4 md:px-8`,
   };
 
   return (
@@ -159,8 +159,8 @@ function DesktopHeader({
         ? 'bg-primary/80 dark:bg-contrast/60 text-contrast dark:text-primary shadow-darkHeader'
         : 'bg-contrast/80 text-primary'
     } ${
-      y > 50 && !isHome && 'shadow-lightHeader'
-    } hidden h-nav lg:flex items-center sticky transition duration-300 backdrop-blur-lg z-40 top-0 justify-between w-full leading-none gap-8 px-12 py-8`,
+      y > 50 && !isHome ? 'shadow-lightHeader ' : ''
+    }hidden h-nav lg:flex items-center sticky transition duration-300 backdrop-blur-lg z-40 top-0 justify-between w-full leading-none gap-8 px-12 py-8`,
   };
 
   return (

--- a/templates/demo-store/src/components/global/NotFound.server.tsx
+++ b/templates/demo-store/src/components/global/NotFound.server.tsx
@@ -5,6 +5,7 @@ import {
   useShopQuery,
 } from '@shopify/hydrogen';
 
+import {Suspense} from 'react';
 import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
 import {Button, FeaturedCollections, PageHeader, Text} from '~/components';
 import {ProductSwimlane, Layout} from '~/components/index.server';
@@ -21,11 +22,31 @@ export function NotFound({
   type?: string;
 }) {
   if (response) {
-    response.doNotStream();
     response.status = 404;
     response.statusText = 'Not found';
   }
 
+  const heading = `We’ve lost this ${type}`;
+  const description = `We couldn’t find the ${type} you’re looking for. Try checking the URL or heading back to the home page.`;
+
+  return (
+    <Layout>
+      <PageHeader heading={heading}>
+        <Text width="narrow" as="p">
+          {description}
+        </Text>
+        <Button width="auto" variant="secondary" to={'/'}>
+          Take me to the home page
+        </Button>
+      </PageHeader>
+      <Suspense>
+        <FeaturedSection />
+      </Suspense>
+    </Layout>
+  );
+}
+
+function FeaturedSection() {
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},
@@ -43,19 +64,10 @@ export function NotFound({
     preload: true,
   });
 
-  const heading = `We’ve lost this ${type}`;
-  const description = `We couldn’t find the ${type} you’re looking for. Try checking the URL or heading back to the home page.`;
   const {featuredCollections, featuredProducts} = data;
+
   return (
-    <Layout>
-      <PageHeader heading={heading}>
-        <Text width="narrow" as="p">
-          {description}
-        </Text>
-        <Button width="auto" variant="secondary" to={'/'}>
-          Take me to the home page
-        </Button>
-      </PageHeader>
+    <>
       {featuredCollections.nodes.length < 2 && (
         <FeaturedCollections
           title="Popular Collections"
@@ -63,7 +75,7 @@ export function NotFound({
         />
       )}
       <ProductSwimlane data={featuredProducts.nodes} />
-    </Layout>
+    </>
   );
 }
 

--- a/templates/demo-store/src/components/search/NoResultRecommendations.server.tsx
+++ b/templates/demo-store/src/components/search/NoResultRecommendations.server.tsx
@@ -4,7 +4,6 @@ import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
 import {FeaturedCollections} from '~/components';
 import {ProductSwimlane} from '~/components/index.server';
 import {PAGINATION_SIZE} from '~/lib/const';
-import {Suspense} from 'react';
 
 export function NoResultRecommendations({
   country,
@@ -24,7 +23,7 @@ export function NoResultRecommendations({
   });
 
   return (
-    <Suspense>
+    <>
       <FeaturedCollections
         title="Trending Collections"
         data={data.featuredCollections.nodes}
@@ -33,7 +32,7 @@ export function NoResultRecommendations({
         title="Trending Products"
         data={data.featuredProducts.nodes}
       />
-    </Suspense>
+    </>
   );
 }
 

--- a/templates/demo-store/src/components/sections/ProductSwimlane.server.tsx
+++ b/templates/demo-store/src/components/sections/ProductSwimlane.server.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {Suspense, useMemo} from 'react';
 import {gql, useShopQuery, useLocalization} from '@shopify/hydrogen';
 import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
 import {ProductCard, Section} from '~/components';
@@ -24,7 +24,11 @@ export function ProductSwimlane({
     // If the data provided is a productId, we will query the productRecommendations API.
     // To make sure we have enough products for the swimlane, we'll combine the results with our top selling products.
     if (typeof data === 'string') {
-      return <RecommendedProducts productId={data} count={count} />;
+      return (
+        <Suspense>
+          <RecommendedProducts productId={data} count={count} />
+        </Suspense>
+      );
     }
 
     // If no data is provided, we'll go and query the top products

--- a/templates/demo-store/src/routes/api/bestSellers.server.ts
+++ b/templates/demo-store/src/routes/api/bestSellers.server.ts
@@ -1,9 +1,6 @@
 import {gql} from '@shopify/hydrogen';
 import type {HydrogenApiRouteOptions, HydrogenRequest} from '@shopify/hydrogen';
-import {
-  Product,
-  ProductConnection,
-} from '@shopify/hydrogen/storefront-api-types';
+import {ProductConnection} from '@shopify/hydrogen/storefront-api-types';
 import {PRODUCT_CARD_FRAGMENT} from '~/lib/fragments';
 
 export async function api(

--- a/templates/demo-store/src/routes/cart.server.tsx
+++ b/templates/demo-store/src/routes/cart.server.tsx
@@ -1,19 +1,11 @@
 import {Seo} from '@shopify/hydrogen';
-import {Suspense} from 'react';
 import {PageHeader, Section, CartDetails} from '~/components';
 import {Layout} from '~/components/index.server';
 
 export default function Cart() {
   return (
     <Layout>
-      <Suspense>
-        <Seo
-          type="page"
-          data={{
-            title: 'Cart',
-          }}
-        />
-      </Suspense>
+      <Seo type="page" data={{title: 'Cart'}} />
       <div className="w-full mx-auto max-w-7xl xl:-translate-x-12">
         <PageHeader heading="Your Cart" />
       </div>

--- a/templates/demo-store/src/routes/collections/index.server.tsx
+++ b/templates/demo-store/src/routes/collections/index.server.tsx
@@ -1,12 +1,26 @@
+import {Suspense} from 'react';
 import {useShopQuery, useLocalization, gql, Seo} from '@shopify/hydrogen';
 import type {Collection} from '@shopify/hydrogen/storefront-api-types';
-import {Suspense} from 'react';
 
 import {PageHeader, Section, Grid} from '~/components';
 import {Layout, CollectionCard} from '~/components/index.server';
 import {getImageLoadingPriority, PAGINATION_SIZE} from '~/lib/const';
 
 export default function Collections() {
+  return (
+    <Layout>
+      <Seo type="page" data={{title: 'All Collections'}} />
+      <PageHeader heading="Collections" />
+      <Section>
+        <Suspense>
+          <CollectionGrid />
+        </Suspense>
+      </Section>
+    </Layout>
+  );
+}
+
+function CollectionGrid() {
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},
@@ -25,28 +39,15 @@ export default function Collections() {
   const collections: Collection[] = data.collections.nodes;
 
   return (
-    <Layout>
-      <Suspense>
-        <Seo
-          type="page"
-          data={{
-            title: 'All Collections',
-          }}
+    <Grid items={collections.length === 3 ? 3 : 2}>
+      {collections.map((collection, i) => (
+        <CollectionCard
+          collection={collection}
+          key={collection.id}
+          loading={getImageLoadingPriority(i, 2)}
         />
-      </Suspense>
-      <PageHeader heading="Collections" />
-      <Section>
-        <Grid items={collections.length === 3 ? 3 : 2}>
-          {collections.map((collection, i) => (
-            <CollectionCard
-              collection={collection}
-              key={collection.id}
-              loading={getImageLoadingPriority(i, 2)}
-            />
-          ))}
-        </Grid>
-      </Section>
-    </Layout>
+      ))}
+    </Grid>
   );
 }
 

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -19,6 +19,25 @@ import {
 } from '@shopify/hydrogen/storefront-api-types';
 
 export default function Homepage() {
+  useServerAnalytics({
+    shopify: {
+      pageType: ShopifyAnalyticsConstants.pageType.home,
+    },
+  });
+
+  return (
+    <Layout>
+      <Suspense>
+        <SeoForHomepage />
+      </Suspense>
+      <Suspense>
+        <HomepageContent />
+      </Suspense>
+    </Layout>
+  );
+}
+
+function HomepageContent() {
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},
@@ -44,17 +63,8 @@ export default function Homepage() {
     heroBanners.nodes,
   );
 
-  useServerAnalytics({
-    shopify: {
-      pageType: ShopifyAnalyticsConstants.pageType.home,
-    },
-  });
-
   return (
-    <Layout>
-      <Suspense>
-        <SeoForHomepage />
-      </Suspense>
+    <>
       {primaryHero && (
         <Hero {...primaryHero} height="full" top loading="eager" />
       )}
@@ -69,7 +79,7 @@ export default function Homepage() {
         title="Collections"
       />
       {tertiaryHero && <Hero {...tertiaryHero} />}
-    </Layout>
+    </>
   );
 }
 
@@ -160,6 +170,7 @@ const HOMEPAGE_CONTENT_QUERY = gql`
 const HOMEPAGE_SEO_QUERY = gql`
   query homeShopInfo {
     shop {
+      title: name
       description
     }
   }

--- a/templates/demo-store/src/routes/journal/index.server.tsx
+++ b/templates/demo-store/src/routes/journal/index.server.tsx
@@ -24,6 +24,20 @@ export default function Blog({
   response,
 }: HydrogenRouteProps) {
   response.cache(CacheLong());
+
+  return (
+    <Layout>
+      <Seo type="page" data={{title: 'All Journals'}} />
+      <PageHeader heading={BLOG_HANDLE} className="gap-0">
+        <Suspense>
+          <JournalsGrid pageBy={pageBy} />
+        </Suspense>
+      </PageHeader>
+    </Layout>
+  );
+}
+
+function JournalsGrid({pageBy}: {pageBy: number}) {
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},
@@ -55,33 +69,23 @@ export default function Blog({
     };
   });
 
-  const haveArticles = articles.length > 0;
+  if (articles.length === 0) {
+    return <p>No articles found</p>;
+  }
 
   return (
-    <Layout>
-      <Suspense>
-        {/* @ts-expect-error Blog article types are not yet supported by TS */}
-        <Seo type="page" data={articles} />
-      </Suspense>
-      <PageHeader heading={BLOG_HANDLE} className="gap-0">
-        {haveArticles ? (
-          <Grid as="ol" layout="blog" gap="blog">
-            {articles.map((article, i) => {
-              return (
-                <ArticleCard
-                  blogHandle={BLOG_HANDLE.toLowerCase()}
-                  article={article as Article}
-                  key={article.id}
-                  loading={getImageLoadingPriority(i, 2)}
-                />
-              );
-            })}
-          </Grid>
-        ) : (
-          <p>No articles found</p>
-        )}
-      </PageHeader>
-    </Layout>
+    <Grid as="ol" layout="blog" gap="blog">
+      {articles.map((article, i) => {
+        return (
+          <ArticleCard
+            blogHandle={BLOG_HANDLE.toLowerCase()}
+            article={article as Article}
+            key={article.id}
+            loading={getImageLoadingPriority(i, 2)}
+          />
+        );
+      })}
+    </Grid>
   );
 }
 

--- a/templates/demo-store/src/routes/products/index.server.tsx
+++ b/templates/demo-store/src/routes/products/index.server.tsx
@@ -1,3 +1,4 @@
+import {Suspense} from 'react';
 import {
   useShopQuery,
   gql,
@@ -12,9 +13,22 @@ import {PAGINATION_SIZE} from '~/lib/const';
 import {ProductGrid, PageHeader, Section} from '~/components';
 import {Layout} from '~/components/index.server';
 import type {Collection} from '@shopify/hydrogen/storefront-api-types';
-import {Suspense} from 'react';
 
 export default function AllProducts() {
+  return (
+    <Layout>
+      <Seo type="page" data={{title: 'All Products'}} />
+      <PageHeader heading="All Products" variant="allCollections" />
+      <Section>
+        <Suspense>
+          <AllProductsGrid />
+        </Suspense>
+      </Section>
+    </Layout>
+  );
+}
+
+function AllProductsGrid() {
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},
@@ -33,24 +47,11 @@ export default function AllProducts() {
   const products = data.products;
 
   return (
-    <Layout>
-      <Suspense>
-        <Seo
-          type="page"
-          data={{
-            title: 'All Products',
-          }}
-        />
-      </Suspense>
-      <PageHeader heading="All Products" variant="allCollections" />
-      <Section>
-        <ProductGrid
-          key="products"
-          url={`/products?country=${countryCode}`}
-          collection={{products} as Collection}
-        />
-      </Section>
-    </Layout>
+    <ProductGrid
+      key="products"
+      url={`/products?country=${countryCode}`}
+      collection={{products} as Collection}
+    />
   );
 }
 

--- a/templates/demo-store/src/routes/search.server.tsx
+++ b/templates/demo-store/src/routes/search.server.tsx
@@ -13,6 +13,7 @@ import {ProductGrid, Section, Text} from '~/components';
 import {NoResultRecommendations, SearchPage} from '~/components/index.server';
 import {PAGINATION_SIZE} from '~/lib/const';
 import type {Collection} from '@shopify/hydrogen/storefront-api-types';
+import {Suspense} from 'react';
 
 export default function Search({
   pageBy = PAGINATION_SIZE,
@@ -54,10 +55,12 @@ export default function Search({
             <Text className="opacity-50">No results, try something else.</Text>
           </Section>
         )}
-        <NoResultRecommendations
-          country={countryCode}
-          language={languageCode}
-        />
+        <Suspense>
+          <NoResultRecommendations
+            country={countryCode}
+            language={languageCode}
+          />
+        </Suspense>
       </SearchPage>
     );
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

While debugging some issue I noticed the Suspense boundaries where not very granular in the main pages. This PR aims to improve the suspense boundaries and streaming.
Each commit is self-contained so it's probably easier to check them 1 by 1. They can also be reverted if there's something wrong.
In the browser, you can set network to "Fast 3G" to see a difference in most pages (layout and headings now are shown before the other data).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
