### PR TITLE
[Demo Store Neue]: Render HTML on ProductDetails

### DIFF
--- a/templates/demo-store/src/components/product/ProductDetail.client.tsx
+++ b/templates/demo-store/src/components/product/ProductDetail.client.tsx
@@ -32,7 +32,10 @@ export function ProductDetail({
           </Disclosure.Button>
 
           <Disclosure.Panel className={'pb-4 pt-2 grid gap-2'}>
-            <Text as="div">{content}</Text>
+            <div
+              className="prose dark:prose-invert"
+              dangerouslySetInnerHTML={{__html: content}}
+            />
             {learnMore && (
               <div className="">
                 <Link

--- a/templates/demo-store/src/lib/utils.ts
+++ b/templates/demo-store/src/lib/utils.ts
@@ -64,8 +64,8 @@ export function isDiscounted(price: MoneyV2, compareAtPrice: MoneyV2) {
 
 export function getExcerpt(text: string) {
   const regex = /<p.*>(.*?)<\/p>/;
-  const correspondingText = regex.exec(text);
-  return correspondingText ? correspondingText[1] : '';
+  const match = regex.exec(text);
+  return match?.length ? match[0] : text;
 }
 
 function resolveToFromType(

--- a/templates/demo-store/src/routes/products/[handle].server.tsx
+++ b/templates/demo-store/src/routes/products/[handle].server.tsx
@@ -52,7 +52,7 @@ export default function Product() {
     },
   });
 
-  const {media, title, vendor, description, id} = product;
+  const {media, title, vendor, descriptionHtml, id} = product;
   const {shippingPolicy, refundPolicy} = shop;
 
   return (
@@ -79,10 +79,10 @@ export default function Product() {
                 </div>
                 <ProductForm />
                 <div className="grid gap-4 py-4">
-                  {description && (
+                  {descriptionHtml && (
                     <ProductDetail
                       title="Product Details"
-                      content={description}
+                      content={descriptionHtml}
                     />
                   )}
                   {shippingPolicy?.body && (
@@ -123,7 +123,7 @@ const PRODUCT_QUERY = gql`
       id
       title
       vendor
-      description
+      descriptionHtml
       media(first: 7) {
         nodes {
           ...Media


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Render html in `ProductDetails` with `dangerouslySetInnerHTML` 

`Shipping` and `Returns` will render the first `<p>` 

### Before
![Screen Shot 2022-06-22 at 9 05 37 AM](https://user-images.githubusercontent.com/12080141/175079822-9cb63a3e-4238-4b41-91b3-63bae80befc2.png)


### After
![after](https://user-images.githubusercontent.com/12080141/175079294-230dea25-643c-4c76-8ca3-8c7832e1db10.png)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
