### PR TITLE
Allow previous minor NPM versions of Hydrogen to be patched

### DIFF
--- a/.github/releasing.md
+++ b/.github/releasing.md
@@ -49,6 +49,22 @@ A new snapshot release will be created with your changes and tagged on NPM with 
 yarn add @shopify/hydrogen@experimental
 ```
 
+## Patching previous minor versions with updates
+
+Occasionally, we will need to patch a previous minor release of Hydrogen to address a security issue or to fix a critical bug which affects developers who cannot easily update to the latest major or minor version.
+
+To do so, follow these steps for each minor version you need to patch:
+
+1. Determine what the branch name would be for your desired version.
+
+   > Example:<br><br>
+   > If the latest release is `v1.2.3` on branch `v1.x-2022-07`, and you need to patch `v1.1.x`, your branch would be `v1.1.x-2022-07`.
+
+2. _If a branch already exists for your desired minor release, you can skip this step._ To create your release branch, check out the Git tag created for the most recent release in that minor range. You can view the list of tags using `git tag`.
+
+   > Example:<br><br>
+   > If the latest release for `v1.1.x` was `v1.1.5`, then you would run `git checkout v1.1.x`, your branch would be `v1.1.x-2022-07`.
+
 ## Common problems
 
 **After merging the auto-generated changeset PR, my GitHub Action encountered an Error with the message `No commits between X and changeset-release/Y`**

--- a/.github/releasing.md
+++ b/.github/releasing.md
@@ -60,10 +60,21 @@ To do so, follow these steps for each minor version you need to patch:
    > Example:<br><br>
    > If the latest release is `v1.2.3` on branch `v1.x-2022-07`, and you need to patch `v1.1.x`, your branch would be `v1.1.x-2022-07`.
 
-2. _If a branch already exists for your desired minor release, you can skip this step._ To create your release branch, check out the Git tag created for the most recent release in that minor range. You can view the list of tags using `git tag`.
+2. _If a branch already exists for your desired minor release, you can skip to step 4._ To create your release branch, check out the Git tag created for the most recent release in that minor range and create the desired branch name. You can view the list of tags using `git tag`.
 
    > Example:<br><br>
-   > If the latest release for `v1.1.x` was `v1.1.5`, then you would run `git checkout v1.1.x`, your branch would be `v1.1.x-2022-07`.
+   > If the latest release for `v1.1.x` was `v1.1.5`, then you would run `git checkout @shopify/hydrogen@1.1.5 -b v1.1.x-2022-07`.
+
+3. Update `.changesets/config.json` to set `baseBranch` to your new release branch. This tells Changesets which base branch to use when preparing the "Release" PR which you will eventually merge to publish the release. Be sure to push this branch to GitHub.
+
+   > Example:<br><br>
+   > Update would be `"baseBranch": "v1.1.x-2022-07"`
+
+4. Create a new branch off of your desired release branch, apply your fix, and push that branch to GitHub.
+5. Create a pull request for your fix branch, and **use the release branch determined above as your base branch**. [Here is an example of backport fix PR](https://github.com/Shopify/hydrogen/pull/1728).
+6. Ensure tests pass on your branch, and get approval from someone on the Hydrogen team. Then, merge your PR.
+7. Changesets will create a new pull request called `Release <branch name>`. When you've applied all the patches you need to that specific minor version, merge that PR. Changesets will release a new version to NPM and to GitHub Releases.
+8. Developers can now install the latest patch version for the minor version: `yarn add @shopify/hydrogen@^v1.1`.
 
 ## Common problems
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install the packages
         run: yarn install --frozen-lockfile --ignore-engines
 
-      - name: Create Release Pull Request or Publish (latest)
+      - name: Create Release Pull Request or Publish (for latest release)
         if: steps.flags.outputs.latest == 'true'
         id: changesets
         uses: changesets/action@v1
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Create Release Pull Request or Publish (legacy)
+      - name: Create Release Pull Request or Publish (for legacy patch release)
         if: steps.flags.outputs.latest != 'true'
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'v[0-9].x-[0-9]+-[0-9]+'
+      - 'v[0-9].[0-9].x-[0-9]+-[0-9]+'
 
 concurrency:
   group: changeset-${{ github.head_ref }}
@@ -40,12 +41,26 @@ jobs:
       - name: Install the packages
         run: yarn install --frozen-lockfile --ignore-engines
 
-      - name: Create Release Pull Request or Publish
+      - name: Create Release Pull Request or Publish (latest)
+        if: steps.flags.outputs.latest == 'true'
         id: changesets
         uses: changesets/action@v1
         with:
           version: yarn run version
           publish: yarn changeset publish
+          commit: '[ci] release ${{ github.ref_name }}'
+          title: '[ci] release ${{ github.ref_name }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release Pull Request or Publish (legacy)
+        if: steps.flags.outputs.latest != 'true'
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: yarn run version
+          publish: yarn changeset publish --tag legacy
           commit: '[ci] release ${{ github.ref_name }}'
           title: '[ci] release ${{ github.ref_name }}'
         env:

--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - unstable
       - 'v[0-9].x-[0-9]+-[0-9]+'
+      - 'v[0-9].[0-9].x-[0-9]+-[0-9]+'
   pull_request:
     branches:
       - unstable
       - 'v[0-9].x-[0-9]+-[0-9]+'
+      - 'v[0-9].[0-9].x-[0-9]+-[0-9]+'
 
 concurrency:
   group: hydrogen-${{ github.head_ref }}-${{ github.ref }}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR updates our Changesets actions to support patching previous minor versions of Hydrogen. It also adds instructions for doing so.

### Additional context

In our changeset action, we check to see if the current branch is the latest version. If not, we run an alternate release and publish command, ensuring that the `legacy` tag is used as to not overwrite the `latest` tag on NPM.

See https://github.com/Shopify/hydrogen/pull/1728 as an example.