### PR TITLE
Fix `og:url` url

### DIFF
--- a/.changeset/metal-dolls-lie.md
+++ b/.changeset/metal-dolls-lie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix `og:rul` for product and collection pages

--- a/packages/hydrogen/src/components/Seo/CollectionSeo.client.tsx
+++ b/packages/hydrogen/src/components/Seo/CollectionSeo.client.tsx
@@ -1,23 +1,30 @@
 import React from 'react';
-
+import {Head} from '../../foundation/Head';
 import {TitleSeo} from './TitleSeo.client';
 import {DescriptionSeo} from './DescriptionSeo.client';
 import {TwitterSeo} from './TwitterSeo.client';
 import {ImageSeo} from './ImageSeo.client';
-import type {Collection as CollectionType} from '../../storefront-api-types';
+import type {
+  Scalars,
+  Collection as CollectionType,
+} from '../../storefront-api-types';
 import type {PartialDeep} from 'type-fest';
 
 export function CollectionSeo({
+  url,
   title,
   description,
   seo,
   image,
-}: PartialDeep<CollectionType>) {
+}: PartialDeep<CollectionType> & {url: Scalars['URL']}) {
   const seoTitle = seo?.title ?? title;
   const seoDescription = seo?.description ?? description;
 
   return (
     <>
+      <Head>
+        <meta property="og:url" content={url} />
+      </Head>
       <TitleSeo title={seoTitle} />
       <DescriptionSeo description={seoDescription} />
       <TwitterSeo title={seoTitle} description={seoDescription} />

--- a/packages/hydrogen/src/components/Seo/ProductSeo.client.tsx
+++ b/packages/hydrogen/src/components/Seo/ProductSeo.client.tsx
@@ -78,6 +78,7 @@ export function ProductSeo({
   return (
     <>
       <Head>
+        <meta property="og:url" content={url} />
         <meta property="og:type" content="og:product" />
         {firstVariantPrice && (
           <meta

--- a/packages/hydrogen/src/components/Seo/Seo.client.tsx
+++ b/packages/hydrogen/src/components/Seo/Seo.client.tsx
@@ -26,7 +26,7 @@ type Props =
     }
   | {
       type: 'collection';
-      data: ComponentProps<typeof CollectionSeo>;
+      data: Omit<ComponentProps<typeof CollectionSeo>, 'url'>;
     }
   | {
       type: 'page';
@@ -51,7 +51,7 @@ export function Seo(props: Props) {
     case 'product':
       return <ProductSeo {...{url, ...props.data}} />;
     case 'collection':
-      return <CollectionSeo {...props.data} />;
+      return <CollectionSeo {...{url, ...props.data}} />;
     case 'page':
       return <PageSeo {...props.data} />;
     case 'noindex':


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For some reason, collection and production pages does not have the correct `og:url`. They all defaulted to home page url

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
