### PR TITLE
Fix `useProductOptions` export

### DIFF
--- a/.changeset/wise-flies-switch.md
+++ b/.changeset/wise-flies-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix `useProductOptions` export to avoid erros at build time.

--- a/.changeset/wise-flies-switch.md
+++ b/.changeset/wise-flies-switch.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix `useProductOptions` export to avoid erros at build time.
+Fix `useProductOptions` export to avoid errors at build time.

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -131,7 +131,7 @@
     "node-fetch": "^2.6.7",
     "path-to-regexp": "^6.2.0",
     "react-error-boundary": "^3.1.3",
-    "react-helmet-async": "^1.2.3",
+    "react-helmet-async": "^1.3.0",
     "serve-static": "^1.15.0",
     "set-cookie-parser": "^2.5.0",
     "undici": "^5.5.1",

--- a/packages/hydrogen/src/client.ts
+++ b/packages/hydrogen/src/client.ts
@@ -1,9 +1,14 @@
 export * from './components';
 export * from './hooks';
-export * from './foundation/useServerProps';
-export * from './foundation/useShop';
-export * from './foundation/ServerPropsProvider';
-export * from './foundation/useUrl';
+export {useServerProps} from './foundation/useServerProps';
+export {useShop} from './foundation/useShop';
+export {
+  ServerPropsProvider,
+  ServerPropsContext,
+  type ServerProps,
+  type ServerPropsContextValue,
+} from './foundation/ServerPropsProvider';
+export {useUrl} from './foundation/useUrl';
 export {Head} from './foundation/Head';
 export * from './utilities';
 export {gql} from './utilities/graphql-tag';

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {useCart} from '../CartProvider';
-import {useProductOptions} from '../ProductOptionsProvider';
+import {useProductOptions} from '../../hooks/useProductOptions';
 import {BaseButton, BaseButtonProps} from '../BaseButton';
 
 interface AddToCartButtonProps {

--- a/packages/hydrogen/src/components/ProductOptionsProvider/ProductOptionsProvider.client.tsx
+++ b/packages/hydrogen/src/components/ProductOptionsProvider/ProductOptionsProvider.client.tsx
@@ -11,7 +11,7 @@ import {
   getSelectedVariant,
   getOptions,
 } from '../../hooks/useProductOptions/helpers';
-import {
+import type {
   SelectedOptions,
   ProductOptionsHookValue,
 } from '../../hooks/useProductOptions/types';

--- a/packages/hydrogen/src/components/ProductOptionsProvider/context.ts
+++ b/packages/hydrogen/src/components/ProductOptionsProvider/context.ts
@@ -1,5 +1,5 @@
 import {createContext} from 'react';
-import {ProductOptionsHookValue} from '../../hooks';
+import type {ProductOptionsHookValue} from '../../hooks';
 
 export const ProductOptionsContext =
   createContext<ProductOptionsHookValue | null>(null);

--- a/packages/hydrogen/src/components/ProductOptionsProvider/index.ts
+++ b/packages/hydrogen/src/components/ProductOptionsProvider/index.ts
@@ -1,2 +1,1 @@
 export {ProductOptionsProvider} from './ProductOptionsProvider.client';
-export {useProductOptions} from '../../hooks/useProductOptions/useProductOptions.client';

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -26,10 +26,7 @@ export type {
   CartWithActions,
   CartAction,
 } from './CartProvider';
-export {
-  ProductOptionsProvider,
-  useProductOptions,
-} from './ProductOptionsProvider';
+export {ProductOptionsProvider} from './ProductOptionsProvider';
 export {ProductPrice} from './ProductPrice';
 export {BuyNowButton} from './BuyNowButton';
 export {ShopPayButton} from './ShopPayButton';

--- a/packages/hydrogen/src/components/index.ts
+++ b/packages/hydrogen/src/components/index.ts
@@ -33,5 +33,4 @@ export {
 export {ProductPrice} from './ProductPrice';
 export {BuyNowButton} from './BuyNowButton';
 export {ShopPayButton} from './ShopPayButton';
-export {useLocalization} from '../hooks/useLocalization/useLocalization';
 export {Seo} from './Seo';

--- a/packages/hydrogen/src/foundation/Analytics/connectors/Shopify/ShopifyAnalytics.client.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/connectors/Shopify/ShopifyAnalytics.client.tsx
@@ -68,7 +68,7 @@ function updateCookie(
   const cookieString = stringify(cookieName, value, {
     maxage,
     domain: getCookieDomain(cookieDomain),
-    secure: process.env.NODE_ENV === 'production',
+    secure: import.meta.env.PROD,
     samesite: 'Lax',
     path: '/',
   });

--- a/packages/hydrogen/src/foundation/ServerPropsProvider/index.ts
+++ b/packages/hydrogen/src/foundation/ServerPropsProvider/index.ts
@@ -1,2 +1,6 @@
-export {ServerPropsProvider, ServerPropsContext} from './ServerPropsProvider';
-export type {ServerProps, ServerPropsContextValue} from './ServerPropsProvider';
+export {
+  ServerPropsProvider,
+  ServerPropsContext,
+  type ServerProps,
+  type ServerPropsContextValue,
+} from './ServerPropsProvider';

--- a/packages/hydrogen/src/hooks/index.ts
+++ b/packages/hydrogen/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useProductOptions/types';
 export {useMoney} from './useMoney';
 export {useMeasurement} from './useMeasurement';
 export {useLoadScript} from './useLoadScript';
+export {useLocalization} from './useLocalization/useLocalization';

--- a/packages/hydrogen/src/hooks/useProductOptions/helpers.ts
+++ b/packages/hydrogen/src/hooks/useProductOptions/helpers.ts
@@ -45,7 +45,7 @@ export function getOptions(
 ): OptionWithValues[] {
   const map = variants.reduce((memo, variant) => {
     if (!variant.selectedOptions) {
-      throw new Error(`getOptions requires 'variant.selectedOptions`);
+      throw new Error(`'getOptions' requires 'variant.selectedOptions'`);
     }
     variant?.selectedOptions?.forEach((opt) => {
       memo[opt?.name ?? ''] = memo[opt?.name ?? ''] || new Set();

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -10,10 +10,23 @@ export * from './client';
  * The following are exported from this file because they are intended to be available
  * *only* on the server.
  */
-export * from './foundation/';
-export * from './hooks/useShopQuery/hooks';
-export * from './foundation/useQuery/hooks';
-export * from './foundation/useServerProps';
+export {
+  ServerPropsProvider,
+  ServerPropsContext,
+  type ServerProps,
+  type ServerPropsContextValue,
+} from './foundation/ServerPropsProvider';
+export {useShop} from './foundation/useShop';
+export {useUrl} from './foundation/useUrl';
+export {
+  useShopQuery,
+  type UseShopQueryResponse,
+} from './hooks/useShopQuery/hooks';
+export {
+  useQuery,
+  type HydrogenUseQueryOptions,
+} from './foundation/useQuery/hooks';
+export {useServerProps} from './foundation/useServerProps';
 export {FileRoutes} from './foundation/FileRoutes/FileRoutes.server';
 export {Route} from './foundation/Route/Route.server';
 export {Router} from './foundation/Router/Router.server';
@@ -32,7 +45,6 @@ export {useServerAnalytics} from './foundation/Analytics/hook';
 export {ShopifyAnalytics} from './foundation/Analytics/connectors/Shopify/ShopifyAnalytics.server';
 export {ShopifyAnalyticsConstants} from './foundation/Analytics/connectors/Shopify/const';
 export {useSession} from './foundation/useSession/useSession';
-export {useLocalization} from './hooks/useLocalization/useLocalization';
 export {Cookie} from './foundation/Cookie/Cookie';
 
 /**

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   session: CookieSessionStorage('__session', {
     path: '/',
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: import.meta.env.PROD,
     sameSite: 'Strict',
     maxAge: 60 * 60 * 24 * 30,
   }),

--- a/templates/demo-store/src/App.server.tsx
+++ b/templates/demo-store/src/App.server.tsx
@@ -17,7 +17,7 @@ import {HeaderFallback} from '~/components';
 import type {CountryCode} from '@shopify/hydrogen/storefront-api-types';
 import {DefaultSeo, NotFound} from '~/components/index.server';
 
-function App({routes, request}: HydrogenRouteProps) {
+function App({request}: HydrogenRouteProps) {
   const pathname = new URL(request.normalizedUrl).pathname;
   const localeMatch = /^\/([a-z]{2})(\/|$)/i.exec(pathname);
   const countryCode = localeMatch ? localeMatch[1] : undefined;
@@ -35,7 +35,6 @@ function App({routes, request}: HydrogenRouteProps) {
             <Router>
               <FileRoutes
                 basePath={countryCode ? `/${countryCode}/` : undefined}
-                routes={routes}
               />
               <Route path="*" page={<NotFound />} />
             </Router>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11057,7 +11057,7 @@ react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet-async@^1.2.3:
+react-helmet-async@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.3.0.tgz#7bd5bf8c5c69ea9f02f6083f14ce33ef545c222e"
   integrity sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

These are a bunch of minor changes and one that is currently blocking standalone app builds. Reexports are evil 🙈 

<img width="760" alt="Screen Shot 2022-06-24 at 16 51 58" src="https://user-images.githubusercontent.com/1634092/175490967-b538b3dd-d788-47bd-909d-91f68b7b27db.png">


Also, updating to latest `react-helmet-async` version to avoid peerDependencies warnings during installation (previous version did not support React 18).

<img width="873" alt="image" src="https://user-images.githubusercontent.com/1634092/175511823-15525d2b-1908-487f-997e-fabec29bb4d9.png">


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
