### PR TITLE
Remove worker `formData` polyfill

### DIFF
--- a/.changeset/swift-crabs-reflect.md
+++ b/.changeset/swift-crabs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Remove `formData` polyfill in worker environments.

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -195,7 +195,7 @@ export class HydrogenRequest extends Request {
 
   public async formData(): Promise<FormData> {
     // @ts-ignore
-    if (!__HYDROGEN_WORKER__ && super.formData) return super.formData();
+    if (__HYDROGEN_WORKER__ || super.formData) return super.formData();
 
     const contentType = this.headers.get('Content-Type') || '';
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Our check for worker environment was wrong. This should enable tree shaking for the FormData polyfill.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
