### PR TITLE
Migrate _gitignore to .gitignore for CLI builds

### DIFF
--- a/scripts/compile-template.mjs
+++ b/scripts/compile-template.mjs
@@ -78,7 +78,10 @@ async function createProcessor(from, to, template) {
       case '.stackblitzrc':
       case '_gitignore':
         await fs.mkdirp(resolve(destination, '..'));
-        await fs.writeFile(destination, content);
+        await fs.writeFile(
+          destination.replace('_gitignore', '.gitignore'),
+          content
+        );
         return;
       case 'tsconfig.json':
         destination = destination.replace('ts', 'js');


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This happens during NPM publish, but we need to make sure it happens during template compilation.
