### PR TITLE
[Hydrogen docs]: Skip `docs/decisions` directory in docs generation script

### DIFF
--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -18,7 +18,7 @@ const CONFIG = {
     'deployment.md': 'content/custom-storefronts/hydrogen/deployment.md',
   },
   // Array of file paths to skip.
-  skip: ['docs/images', 'docs/contributing', 'docs/README.md'],
+  skip: ['docs/images', 'docs/contributing', 'docs/README.md', 'docs/decisions'],
   // require a path entry to be copied. If true files will still be copied by default
   // and appear in the same directory structure as their source file.
   enableDefaultPaths: true,

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -18,7 +18,12 @@ const CONFIG = {
     'deployment.md': 'content/custom-storefronts/hydrogen/deployment.md',
   },
   // Array of file paths to skip.
-  skip: ['docs/images', 'docs/contributing', 'docs/README.md', 'docs/decisions'],
+  skip: [
+    'docs/images',
+    'docs/contributing',
+    'docs/README.md',
+    'docs/decisions',
+  ],
   // require a path entry to be copied. If true files will still be copied by default
   // and appear in the same directory structure as their source file.
   enableDefaultPaths: true,


### PR DESCRIPTION
## This PR: 
- Skips the `/docs/decisions` directory, as we don't want this content being pulled in to Shopify.dev
- Relates to https://github.com/Shopify/hydrogen/pull/1734