### PR TITLE
[Hydrogen docs]: Storefront API scopes for `CartProvider`

### DIFF
--- a/docs/components/cart/cartprovider.md
+++ b/docs/components/cart/cartprovider.md
@@ -12,6 +12,13 @@ then the callback will be called when a new line item is successfully added to t
 The `CartProvider` component must be a descendent of the `ShopifyProvider` component.
 You must use this component if you want to use the `useCart` hook or related hooks, or if you would like to use the `AddToCartButton` component.
 
+## Required access scopes
+
+The `CartProvider` component requires the following [Storefront API access scopes](https://shopify.dev/api/usage/access-scopes#unauthenticated-access-scopes):
+
+- `unauthenticated_read_customers`
+- `unauthenticated_write_customers`
+
 ## Example code
 
 ```tsx


### PR DESCRIPTION
## This PR: 
- Adds a new "Required access scopes" section to the `CartProvider` component doc
- Relates to https://shopify.slack.com/archives/C02A5S8LNP9/p1656090135601719