### PR TITLE
Fix `fetchSync` payload and cache

### DIFF
--- a/.changeset/hot-drinks-juggle.md
+++ b/.changeset/hot-drinks-juggle.md
@@ -1,0 +1,14 @@
+---
+'@shopify/hydrogen': patch
+---
+
+The payload returned by `fetchSync` was supposed to mimic `react-fetch` but it wrongly moved the Response data to a sub-property `response`. This has been fixed to have the Response at the top level. Also, cached responses are now correctly serialized and retrieved to avoid issues on cache hit.
+
+```diff
+const response = fetchSync('...');
+-response.response.headers.get('...');
++response.headers.get('...');
+const jsonData = response.json();
+```
+
+Note that the sub-property `response` is still available but marked as deprecated.

--- a/docs/hooks/global/fetchsync.md
+++ b/docs/hooks/global/fetchsync.md
@@ -78,13 +78,12 @@ The `requestInit` object augments the [`init` properties available in the Web Fe
 
 ### Return value
 
-The `fetchSync` function returns an object with the following keys:
+The `fetchSync` function returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object with the usual properties (`status`, `headers`, etc.). However, the following properties are adapted to work with React Suspense:
 
 | Key        | Description                                                                               |
 | ---------- | ----------------------------------------------------------------------------------------- |
-| `response` | The response returned by the fetch call. Useful for checking the status code and headers. |
-| `json()`   | A function to return a JavaScript object based on the JSON response body.                 |
-| `text()`   | A function to return a string version of the response body.                               |
+| `json()`   | A function to synchronously return a JavaScript object based on the JSON response body.   |
+| `text()`   | A function to synchronously return a string version of the response body.                 |
 
 ## `fetchSync` in client components
 
@@ -123,13 +122,12 @@ The `requestInit` object mirrors the [`init` properties available in the Web Fet
 
 ### Return value
 
-The `fetchSync` function returns an object with the following keys:
+The `fetchSync` function returns a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object with the usual properties (`status`, `headers`, etc.). However, the following properties are adapted to work with React Suspense:
 
 | Key        | Description                                                                             |
 | ---------- | --------------------------------------------------------------------------------------- |
-| `response` | The Response returned by the fetch call. Useful for checking status code, headers, etc. |
-| `json()`   | A function to return a JavaScript object based on the JSON response body.               |
-| `text()`   | A function to return a string version of the response body.                             |
+| `json()`   | A function to synchronously return a JavaScript object based on the JSON response body. |
+| `text()`   | A function to synchronously return a string version of the response body.               |
 
 ## Considerations
 

--- a/examples/meta-pixel/package.json
+++ b/examples/meta-pixel/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-google-analytics",
+  "name": "example-meta-pixel",
   "description": "An example using Meta Pixel in Hydrogen",
   "license": "MIT",
   "private": true,

--- a/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
@@ -4,8 +4,9 @@ import {log} from '../../utilities/log';
 type ResponseSyncInit = [string, ResponseInit];
 
 export class ResponseSync extends Response {
-  #text: string;
   bodyUsed = true;
+  #text: string;
+  #json: any;
 
   constructor(init: ResponseSyncInit) {
     super(...init);
@@ -18,7 +19,7 @@ export class ResponseSync extends Response {
   }
 
   json() {
-    return parseJSON(this.#text);
+    return (this.#json ??= parseJSON(this.#text));
   }
 
   /**

--- a/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
@@ -28,7 +28,8 @@ export class ResponseSync extends Response {
   get response() {
     if (__HYDROGEN_DEV__) {
       log.warn(
-        `Property 'response' is deprecated from the result of 'fetchSync'.`
+        `Property 'response' is deprecated from the result of 'fetchSync'.` +
+          ` Access response properties at the top level instead.`
       );
     }
 

--- a/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
@@ -1,0 +1,47 @@
+import {parseJSON} from '../../utilities/parse';
+import {log} from '../../utilities/log';
+
+type ResponseSyncInit = [string, ResponseInit];
+
+export class ResponseSync extends Response {
+  #text: string;
+  bodyUsed = true;
+
+  constructor(init: ResponseSyncInit) {
+    super(...init);
+    this.#text = init[0];
+  }
+
+  // @ts-expect-error Changing inherited types
+  text() {
+    return this.#text;
+  }
+
+  json() {
+    return parseJSON(this.#text);
+  }
+
+  /**
+   * @deprecated Access response properties at the top level instead.
+   */
+  get response() {
+    if (__HYDROGEN_DEV__) {
+      log.warn(
+        `Property 'response' is deprecated from the result of 'fetchSync'.`
+      );
+    }
+
+    return this;
+  }
+
+  static async toSerializable(response: Response) {
+    return [
+      await response.text(),
+      {
+        status: response.status,
+        statusText: response.statusText,
+        headers: Array.from(response.headers.entries()),
+      },
+    ] as ResponseSyncInit;
+  }
+}

--- a/packages/hydrogen/src/foundation/fetchSync/client/fetchSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/client/fetchSync.ts
@@ -1,27 +1,20 @@
-import {parseJSON} from '../../../utilities/parse';
 import {suspendFunction, preloadFunction} from '../../../utilities/suspense';
-import type {FetchResponse} from '../types';
+import {ResponseSync} from '../ResponseSync';
 
 /**
  * Fetch a URL for use in a client component Suspense boundary.
  */
-export function fetchSync(url: string, options?: RequestInit): FetchResponse {
-  const [text, response] = suspendFunction([url, options], async () => {
+export function fetchSync(url: string, options?: RequestInit) {
+  const responseSyncInit = suspendFunction([url, options], async () => {
     const response = await globalThis.fetch(
       new URL(url, window.location.origin),
       options
     );
 
-    const text = await response.text();
-
-    return [text, response] as [string, Response];
+    return ResponseSync.toSerializable(response);
   });
 
-  return {
-    response,
-    json: () => parseJSON(text),
-    text: () => text,
-  };
+  return new ResponseSync(responseSyncInit);
 }
 
 /**

--- a/packages/hydrogen/src/foundation/fetchSync/types.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/types.ts
@@ -1,5 +1,0 @@
-export interface FetchResponse {
-  response: Response;
-  json: () => any;
-  text: () => any;
-}

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -79,15 +79,17 @@ export function useShopQuery<T>({
   let useQueryError: any;
 
   try {
-    text = fetchSync(url, {
+    const response = fetchSync(url, {
       ...requestInit,
       cache,
       preload,
       shouldCacheResponse,
-    }).text();
+    });
+
+    text = response.text();
 
     try {
-      data = JSON.parse(text);
+      data = response.json();
     } catch (error: any) {
       useQueryError = new Error('Unable to parse response:\n' + text);
     }

--- a/packages/playground/async-config/tests/e2e-test-cases.ts
+++ b/packages/playground/async-config/tests/e2e-test-cases.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch';
-import type {Page} from 'playwright';
 
 type TestOptions = {
   getServerUrl: () => string;
@@ -12,12 +11,6 @@ export default async function testCases({
   isBuild,
   isWorker,
 }: TestOptions) {
-  let page: Page;
-  beforeEach(async () => {
-    page && (await page.close());
-    page = await browser.newPage();
-  });
-
   it('shows the homepage with the correct locale', async () => {
     await page.goto(getServerUrl());
 

--- a/packages/playground/async-config/tests/e2e-test-cases.ts
+++ b/packages/playground/async-config/tests/e2e-test-cases.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import type {Page} from 'playwright';
 
 type TestOptions = {
   getServerUrl: () => string;
@@ -11,6 +12,12 @@ export default async function testCases({
   isBuild,
   isWorker,
 }: TestOptions) {
+  let page: Page;
+  beforeEach(async () => {
+    page && (await page.close());
+    page = await browser.newPage();
+  });
+
   it('shows the homepage with the correct locale', async () => {
     await page.goto(getServerUrl());
 

--- a/packages/playground/server-components/src/routes/about.server.jsx
+++ b/packages/playground/server-components/src/routes/about.server.jsx
@@ -1,6 +1,9 @@
+import {CacheNone} from '@shopify/hydrogen';
 import {ClientCounter as Counter} from '../components/index3';
 
-export default function About() {
+export default function About({response}) {
+  response.cache(CacheNone());
+
   return (
     <div>
       <h1>About</h1>

--- a/packages/playground/server-components/src/routes/response-sync.server.jsx
+++ b/packages/playground/server-components/src/routes/response-sync.server.jsx
@@ -1,0 +1,30 @@
+import {CacheNone, CacheLong, fetchSync} from '@shopify/hydrogen';
+
+export function api() {
+  return new Response(JSON.stringify({bodyContent: 'OK'}), {
+    status: 201,
+    headers: {test: '42'},
+  });
+}
+
+export default function ResponseSync({response}) {
+  response.cache(CacheNone());
+
+  const fetchResponse = fetchSync('/response-sync', {
+    method: 'POST',
+    cache: CacheLong(),
+    preload: false,
+  });
+
+  return (
+    <>
+      <h1>Request Sync</h1>
+
+      <div>
+        <div id="response-body">{fetchResponse.json().bodyContent}</div>
+        <div id="response-status">{fetchResponse.status}</div>
+        <div id="response-header-test">{fetchResponse.headers.get('test')}</div>
+      </div>
+    </>
+  );
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -296,12 +296,12 @@ export default async function testCases({
       expect(await page.textContent('#response-header-test')).toMatch('42');
     };
 
-    // Make fetchSync request and store in cache
+    // Make fetchSync request and store response data in cache
     await page.goto(getServerUrl() + '/response-sync');
     await test();
 
-    // Reuse cached response dataReuses cache properly.
-    // This requires `devCache: true` in
+    // Check that cached response data is reused properly.
+    // This requires `devCache: true` in `vite.config.js`.
     await page.reload();
     await test();
   });

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -283,6 +283,24 @@ export default async function testCases({
     expect(serverRenderedId).toEqual(clientRenderedId);
   });
 
+  it('can cache fetchSync responses', async () => {
+    const test = async () => {
+      expect(await page.textContent('h1')).toContain('Request Sync');
+      expect(await page.textContent('#response-body')).toMatch('OK');
+      expect(await page.textContent('#response-status')).toMatch('201');
+      expect(await page.textContent('#response-header-test')).toMatch('42');
+    };
+
+    // Make fetchSync request and store in cache
+    await page.goto(getServerUrl() + '/response-sync');
+    await test();
+
+    // Reuse cached response dataReuses cache properly.
+    // This requires `devCache: true` in
+    await page.reload();
+    await test();
+  });
+
   describe('HMR', () => {
     if (isBuild) return;
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -2,6 +2,11 @@ import {RSC_PATHNAME} from '../../../hydrogen/src/constants';
 import {htmlEncode} from '../../../hydrogen/src/utilities';
 import fetch from 'node-fetch';
 import {resolve} from 'path';
+import type {Browser, Page} from 'playwright';
+
+declare global {
+  const browser: Browser;
+}
 
 import {edit, untilUpdated} from '../../utilities';
 
@@ -21,10 +26,10 @@ export default async function testCases({
   isBuild,
   isWorker,
 }: TestOptions) {
-  let page;
+  let page: Page;
   beforeEach(async () => {
     page && (await page.close());
-    page = await global.browser.newPage();
+    page = await browser.newPage();
   });
 
   it('shows the homepage, navigates to about, and increases the count', async () => {

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -305,15 +305,15 @@ export default async function testCases({
     });
 
     it('updates the contents when a server component file changes', async () => {
-      const fullPath = resolve(__dirname, '../', 'src/routes/index.server.jsx');
+      const fullPath = resolve(__dirname, '../', 'src/routes/about.server.jsx');
       const newheading = 'Snow Devil';
 
-      await page.goto(getServerUrl());
+      await page.goto(getServerUrl() + '/about');
 
       await edit(
         fullPath,
-        (code) => code.replace('<h1>Home', `<h1>${newheading}`),
-        () => untilUpdated(() => page.textContent('h1'), 'Home'),
+        (code) => code.replace('<h1>About', `<h1>${newheading}`),
+        () => untilUpdated(() => page.textContent('h1'), 'About'),
         () => untilUpdated(() => page.textContent('h1'), newheading)
       );
     });

--- a/packages/playground/server-components/vite.config.js
+++ b/packages/playground/server-components/vite.config.js
@@ -5,7 +5,10 @@ const path = require('path');
  * @type {import('vite').UserConfig}
  */
 module.exports = {
-  plugins: [hydrogen({})],
+  plugins: [
+    // devCache is used in /request-sync test
+    hydrogen({devCache: true}),
+  ],
   resolve: {
     alias: [
       {find: /^~\/(.*)/, replacement: '/src/$1'},

--- a/templates/demo-store/tests/utils.ts
+++ b/templates/demo-store/tests/utils.ts
@@ -3,6 +3,7 @@ import {
   type Page,
   type Response as PlaywrightResponse,
 } from 'playwright';
+import '@shopify/hydrogen/web-polyfills';
 import type {Server} from 'http';
 import {createServer as createViteDevServer} from 'vite';
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1743

The payload returned by `fetchSync` was incorrectly moving the Response data to a property. After this PR, things like `status` or `headers` will be available at the top level. The property `response` is still available but marked as deprecated to avoid breaking changes.

Apart from that, the other issue mentioned in #1743 related to cache is also fixed. Instead of serializing `Response` (resulting in a dummy JSON object), it now serializes `ResponseInit` which can be used later to create a new `Response` object.

### Additional context

If you want to make the e2e test fail, make this change in `server/fetchSync` (what we had before):

```diff
-return ResponseSync.toSerializable(response);
+return [await response.text(), response];
```

That would pass again if you disable in-memory cache in `vite.config.js` (the problem appears when storing `response` in the cache because it's not serializable).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
