### PR TITLE
Fix add-to-cart button in Firefox

### DIFF
--- a/templates/demo-store/src/components/product/ProductForm.client.tsx
+++ b/templates/demo-store/src/components/product/ProductForm.client.tsx
@@ -106,6 +106,7 @@ export function ProductForm() {
           quantity={1}
           accessibleAddingToCartLabel="Adding item to your cart"
           disabled={isOutOfStock}
+          type="button"
         >
           <Button
             width="full"


### PR DESCRIPTION
This button is inside of a `<form>` element, which causes the form to submit and Post in Firefox. 

Existing behavior can be seen here (while in Firefox) when you click "Add To Bag" 

https://www.hydrogen.shop/products/snowboard

The options were to either add 

```tsx
<form onSubmit={evt => evt.preventDefault()}>
```

or this change. I'm open to either if someone has preferences. 