### PR TITLE
Simplify integration with other deployment platforms

### DIFF
--- a/.changeset/late-moons-hide.md
+++ b/.changeset/late-moons-hide.md
@@ -1,0 +1,24 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Expose utilities for integrating Hydrogen with 3rd party platforms in `@shopify/hydrogen/platforms`. These utilities can resolve the project build path automatically and also find the client build assets.
+
+```js
+import {
+  handleRequest, // Instead of './src/App.server'
+  indexTemplate, // Instead of './dist/client/index.html?raw'
+  isAsset, // Access a list of files in './dist/client/**/*'
+} from '@shopify/hydrogen/platforms';
+
+// Platform entry handler
+export default function (request) {
+  if (isAsset(new URL(request.url).pathname)) {
+    return platformAssetHandler(request);
+  }
+
+  return handleRequest(request, {indexTemplate});
+}
+```
+
+Note that user apps don't need to be changed.

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -35,6 +35,11 @@
       "import": "./dist/esnext/framework/cache/*.js",
       "require": "./dist/node/framework/cache/*.js"
     },
+    "./platforms": {
+      "types": "./dist/esnext/platforms/virtual.d.ts",
+      "import": "./dist/esnext/platforms/virtual.js",
+      "require": "./dist/node/platforms/virtual.js"
+    },
     "./package.json": "./package.json",
     "./*": "./dist/esnext/*.js"
   },

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -3,6 +3,7 @@ import {HYDROGEN_DEFAULT_SERVER_ENTRY} from './vite-plugin-hydrogen-middleware';
 import MagicString from 'magic-string';
 import path from 'path';
 import fs from 'fs';
+import FastGlob from 'fast-glob';
 
 const SSR_BUNDLE_NAME = 'index.js';
 
@@ -85,12 +86,16 @@ export default () => {
         );
 
         const files = clientBuildPath
-          ? fs
-              .readdirSync(clientBuildPath)
-              .filter((file) => file !== 'index.html')
+          ? FastGlob.sync(clientBuildPath + '/**/*', {
+              ignore: ['**/index.html', `**/${config.build.assetsDir}/**`],
+            }).map(
+              (file) =>
+                '/' + normalizePath(path.relative(clientBuildPath, file))
+            )
           : [];
+
         ms.replace("\\['__HYDROGEN_ASSETS__'\\]", JSON.stringify(files));
-        ms.replace('__HYDROGEN_ASSET_DIR__', config.build.assetsDir);
+        ms.replace('__HYDROGEN_ASSETS_DIR__', config.build.assetsDir);
 
         // Remove the poison pill
         ms.replace('throw', '//');

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -85,16 +85,18 @@ export default () => {
         );
 
         const files = clientBuildPath
-          ? FastGlob.sync(clientBuildPath + '/**/*', {
+          ? FastGlob.sync('**/*', {
+              cwd: clientBuildPath,
               ignore: ['**/index.html', `**/${config.build.assetsDir}/**`],
-            }).map(
-              (file) =>
-                '/' + normalizePath(path.relative(clientBuildPath, file))
-            )
+            }).map((file) => '/' + file)
           : [];
 
         ms.replace("\\['__HYDROGEN_ASSETS__'\\]", JSON.stringify(files));
         ms.replace('__HYDROGEN_ASSETS_DIR__', config.build.assetsDir);
+        ms.replace(
+          '__HYDROGEN_ASSETS_BASE_URL__',
+          (process.env.HYDROGEN_ASSET_BASE_URL || '').replace(/\/$/, '')
+        );
 
         // Remove the poison pill
         ms.replace('throw', '//');

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -64,11 +64,8 @@ export default () => {
 
         if (!clientBuildPath) {
           // Default value
-          clientBuildPath = path.resolve(
-            config.root,
-            config.build.outDir,
-            '..',
-            'client'
+          clientBuildPath = normalizePath(
+            path.resolve(config.root, config.build.outDir, '..', 'client')
           );
         }
 
@@ -79,9 +76,11 @@ export default () => {
 
         ms.replace(
           '__HYDROGEN_RELATIVE_CLIENT_BUILD__',
-          path.relative(
-            path.resolve(config.root, config.build.outDir),
-            clientBuildPath
+          normalizePath(
+            path.relative(
+              normalizePath(path.resolve(config.root, config.build.outDir)),
+              clientBuildPath
+            )
           )
         );
 
@@ -111,7 +110,9 @@ export default () => {
         // Save outDir from client build in the outer scope in order
         // to read it during the server build. The CLI runs Vite in
         // the same process so the scope is shared across builds.
-        clientBuildPath = path.resolve(config.root, config.build.outDir);
+        clientBuildPath = normalizePath(
+          path.resolve(config.root, config.build.outDir)
+        );
       }
     },
     generateBundle(options, bundle) {

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -54,9 +54,7 @@ export default () => {
       if (
         config.command === 'build' &&
         options?.ssr &&
-        normalizePath(id)
-          .split('@shopify/hydrogen/')[1]
-          ?.includes('platforms/virtual')
+        /@shopify\/hydrogen\/.+platforms\/virtual\./.test(normalizePath(id))
       ) {
         const ms = new MagicString(code);
 

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -3,7 +3,7 @@ import {HYDROGEN_DEFAULT_SERVER_ENTRY} from './vite-plugin-hydrogen-middleware';
 import MagicString from 'magic-string';
 import path from 'path';
 import fs from 'fs';
-import FastGlob from 'fast-glob';
+import fastGlob from 'fast-glob';
 
 const SSR_BUNDLE_NAME = 'index.js';
 
@@ -50,7 +50,7 @@ export default () => {
 
       return null;
     },
-    transform(code, id, options) {
+    async transform(code, id, options) {
       if (
         config.command === 'build' &&
         options?.ssr &&
@@ -85,10 +85,12 @@ export default () => {
         );
 
         const files = clientBuildPath
-          ? FastGlob.sync('**/*', {
-              cwd: clientBuildPath,
-              ignore: ['**/index.html', `**/${config.build.assetsDir}/**`],
-            }).map((file) => '/' + file)
+          ? (
+              await fastGlob('**/*', {
+                cwd: clientBuildPath,
+                ignore: ['**/index.html', `**/${config.build.assetsDir}/**`],
+              })
+            ).map((file) => '/' + file)
           : [];
 
         ms.replace("\\['__HYDROGEN_ASSETS__'\\]", JSON.stringify(files));

--- a/packages/hydrogen/src/platforms/index.ts
+++ b/packages/hydrogen/src/platforms/index.ts
@@ -1,0 +1,1 @@
+export * from './virtual';

--- a/packages/hydrogen/src/platforms/node.ts
+++ b/packages/hydrogen/src/platforms/node.ts
@@ -1,12 +1,6 @@
 import '../utilities/web-api-polyfill';
-import type {RequestHandler} from '../types';
 import path from 'path';
-// @ts-ignore
-// eslint-disable-next-line node/no-missing-import
-import entrypoint from '__HYDROGEN_ENTRY__';
-// @ts-ignore
-// eslint-disable-next-line node/no-missing-import
-import indexTemplate from '__HYDROGEN_HTML_TEMPLATE__';
+import {handleRequest, indexTemplate, relativeClientBuildPath} from './virtual';
 import {hydrogenMiddleware} from '../framework/middleware';
 
 // @ts-ignore
@@ -16,8 +10,6 @@ import compression from 'compression';
 import bodyParser from 'body-parser';
 import connect, {NextHandleFunction} from 'connect';
 import {InMemoryCache} from '../framework/cache/in-memory';
-
-const handleRequest = entrypoint as RequestHandler;
 
 type CreateServerOptions = {
   cache?: Cache;
@@ -34,7 +26,7 @@ export async function createServer({
   app.use(compression() as NextHandleFunction);
 
   app.use(
-    serveStatic(path.resolve(__dirname, '__HYDROGEN_RELATIVE_CLIENT_BUILD__'), {
+    serveStatic(path.resolve(__dirname, relativeClientBuildPath), {
       index: false,
     }) as NextHandleFunction
   );

--- a/packages/hydrogen/src/platforms/node.ts
+++ b/packages/hydrogen/src/platforms/node.ts
@@ -3,10 +3,10 @@ import type {RequestHandler} from '../types';
 import path from 'path';
 // @ts-ignore
 // eslint-disable-next-line node/no-missing-import
-import entrypoint from '__SERVER_ENTRY__';
+import entrypoint from '__HYDROGEN_ENTRY__';
 // @ts-ignore
 // eslint-disable-next-line node/no-missing-import
-import indexTemplate from '__INDEX_TEMPLATE__?raw';
+import indexTemplate from '__HYDROGEN_HTML_TEMPLATE__';
 import {hydrogenMiddleware} from '../framework/middleware';
 
 // @ts-ignore
@@ -34,7 +34,7 @@ export async function createServer({
   app.use(compression() as NextHandleFunction);
 
   app.use(
-    serveStatic(path.resolve(__dirname, '../client'), {
+    serveStatic(path.resolve(__dirname, '__HYDROGEN_RELATIVE_CLIENT_BUILD__'), {
       index: false,
     }) as NextHandleFunction
   );

--- a/packages/hydrogen/src/platforms/virtual.ts
+++ b/packages/hydrogen/src/platforms/virtual.ts
@@ -12,7 +12,7 @@ export const handleRequest = appEntry as RequestHandler;
 export {default as indexTemplate} from '__HYDROGEN_HTML_TEMPLATE__?raw';
 
 export const assets = ['__HYDROGEN_ASSETS__'] as string[];
-export const assetPrefix = '/__HYDROGEN_ASSET_DIR__/' as string;
+export const assetPrefix = '/__HYDROGEN_ASSETS_DIR__/' as string;
 
 export const isAsset = (pathname = '') =>
   pathname.startsWith(assetPrefix) || assets.includes(pathname);

--- a/packages/hydrogen/src/platforms/virtual.ts
+++ b/packages/hydrogen/src/platforms/virtual.ts
@@ -11,13 +11,15 @@ export const handleRequest = appEntry as RequestHandler;
 // eslint-disable-next-line node/no-missing-import
 export {default as indexTemplate} from '__HYDROGEN_HTML_TEMPLATE__?raw';
 
-export const assets = ['__HYDROGEN_ASSETS__'] as string[];
+export const assets = new Set(['__HYDROGEN_ASSETS__']) as Set<string>;
 export const assetPrefix = '/__HYDROGEN_ASSETS_DIR__/' as string;
 
 export const isAsset = (pathname = '') =>
-  pathname.startsWith(assetPrefix) || assets.includes(pathname);
+  pathname.startsWith(assetPrefix) || assets.has(pathname);
 
 export const relativeClientBuildPath =
   '__HYDROGEN_RELATIVE_CLIENT_BUILD__' as string;
+
+export const assetBasePath = '__HYDROGEN_ASSETS_BASE_URL__' as string;
 
 throw new Error('This file must be overwritten in a Vite plugin');

--- a/packages/hydrogen/src/platforms/virtual.ts
+++ b/packages/hydrogen/src/platforms/virtual.ts
@@ -1,0 +1,23 @@
+// This file is modified by Vite at build time
+// with user project information and re-exports it.
+
+// @ts-ignore
+// eslint-disable-next-line node/no-missing-import
+import appEntry from '__HYDROGEN_ENTRY__';
+import type {RequestHandler} from '../shared-types';
+
+export const handleRequest = appEntry as RequestHandler;
+
+// eslint-disable-next-line node/no-missing-import
+export {default as indexTemplate} from '__HYDROGEN_HTML_TEMPLATE__?raw';
+
+export const assets = ['__HYDROGEN_ASSETS__'] as string[];
+export const assetPrefix = '/__HYDROGEN_ASSET_DIR__/' as string;
+
+export const isAsset = (pathname = '') =>
+  pathname.startsWith(assetPrefix) || assets.includes(pathname);
+
+export const relativeClientBuildPath =
+  '__HYDROGEN_RELATIVE_CLIENT_BUILD__' as string;
+
+throw new Error('This file must be overwritten in a Vite plugin');

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -1,12 +1,4 @@
-import type {RequestHandler} from '../types';
-// @ts-ignore
-// eslint-disable-next-line node/no-missing-import
-import entrypoint from '__HYDROGEN_ENTRY__';
-// @ts-ignore
-// eslint-disable-next-line node/no-missing-import
-import indexTemplate from '__HYDROGEN_HTML_TEMPLATE__';
-
-const handleRequest = entrypoint as RequestHandler;
+import {handleRequest, indexTemplate} from './virtual';
 
 declare global {
   // eslint-disable-next-line no-var

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -1,10 +1,10 @@
 import type {RequestHandler} from '../types';
 // @ts-ignore
 // eslint-disable-next-line node/no-missing-import
-import entrypoint from '__SERVER_ENTRY__';
+import entrypoint from '__HYDROGEN_ENTRY__';
 // @ts-ignore
 // eslint-disable-next-line node/no-missing-import
-import indexTemplate from '__INDEX_TEMPLATE__?raw';
+import indexTemplate from '__HYDROGEN_HTML_TEMPLATE__';
 
 const handleRequest = entrypoint as RequestHandler;
 

--- a/packages/playground/async-config/package.json
+++ b/packages/playground/async-config/package.json
@@ -4,7 +4,7 @@
   "version": "0.11.0",
   "scripts": {
     "dev": "shopify hydrogen dev",
-    "build": "shopify hydrogen build --entry worker",
+    "build": "shopify hydrogen build --entry ../test-utils/worker-entry",
     "build:server": "shopify hydrogen build --target node",
     "start:node": "node ../test-utils/start-node",
     "start:worker": "node ../test-utils/start-worker"

--- a/packages/playground/async-config/worker.js
+++ b/packages/playground/async-config/worker.js
@@ -1,7 +1,0 @@
-import handleRequest from './src/App.server';
-// eslint-disable-next-line node/no-missing-import
-import indexTemplate from './dist/client/index.html?raw';
-
-import setup from '../test-utils/worker-entry';
-
-setup({handleRequest, indexTemplate});

--- a/packages/playground/server-components/package.json
+++ b/packages/playground/server-components/package.json
@@ -4,7 +4,7 @@
   "version": "0.11.0",
   "scripts": {
     "dev": "shopify hydrogen dev",
-    "build": "shopify hydrogen build --entry worker",
+    "build": "shopify hydrogen build --entry  ../test-utils/worker-entry",
     "build:server": "shopify hydrogen build --target node",
     "start:node": "node ../test-utils/start-node",
     "start:worker": "node ../test-utils/start-worker"

--- a/packages/playground/server-components/worker.js
+++ b/packages/playground/server-components/worker.js
@@ -1,7 +1,0 @@
-import handleRequest from './src/App.server';
-// eslint-disable-next-line node/no-missing-import
-import indexTemplate from './dist/client/index.html?raw';
-
-import setup from '../test-utils/worker-entry';
-
-setup({handleRequest, indexTemplate});

--- a/packages/playground/test-utils/worker-entry.js
+++ b/packages/playground/test-utils/worker-entry.js
@@ -3,7 +3,7 @@ import {
   isAsset,
   handleRequest,
   indexTemplate,
-} from '@shopify/hydrogen/platforms/virtual';
+} from '@shopify/hydrogen/platforms';
 
 // Mock Oxygen global
 globalThis.Oxygen = {env: globalThis};

--- a/packages/playground/test-utils/worker-entry.js
+++ b/packages/playground/test-utils/worker-entry.js
@@ -1,12 +1,9 @@
 import {getAssetFromKV} from '@cloudflare/kv-asset-handler';
+import {isAsset} from '@shopify/hydrogen/virtual/assets';
 
 export default function setup({handleRequest, indexTemplate}) {
   // Mock Oxygen global
   globalThis.Oxygen = {env: globalThis};
-
-  function isAsset(url) {
-    return /\.(png|jpe?g|gif|css|js|svg|ico|map)$/i.test(url.pathname);
-  }
 
   async function handleAsset(url, event) {
     const response = await getAssetFromKV(event, {});
@@ -29,7 +26,7 @@ export default function setup({handleRequest, indexTemplate}) {
     try {
       const url = new URL(event.request.url);
 
-      if (isAsset(url)) {
+      if (isAsset(url.pathname)) {
         return await handleAsset(url, event);
       }
 

--- a/packages/playground/test-utils/worker-entry.js
+++ b/packages/playground/test-utils/worker-entry.js
@@ -1,43 +1,46 @@
 import {getAssetFromKV} from '@cloudflare/kv-asset-handler';
-import {isAsset} from '@shopify/hydrogen/virtual/assets';
+import {
+  isAsset,
+  handleRequest,
+  indexTemplate,
+} from '@shopify/hydrogen/platforms/virtual';
 
-export default function setup({handleRequest, indexTemplate}) {
-  // Mock Oxygen global
-  globalThis.Oxygen = {env: globalThis};
+// Mock Oxygen global
+globalThis.Oxygen = {env: globalThis};
 
-  async function handleAsset(url, event) {
-    const response = await getAssetFromKV(event, {});
+async function handleAsset(url, event) {
+  const response = await getAssetFromKV(event, {});
 
-    if (response.status < 400) {
-      const filename = url.pathname.split('/').pop();
+  if (response.status < 400) {
+    const filename = url.pathname.split('/').pop();
 
-      const maxAge =
-        filename.split('.').length > 2
-          ? 31536000 // hashed asset, will never be updated
-          : 86400; // favicon and other public assets
+    const maxAge =
+      filename.split('.').length > 2
+        ? 31536000 // hashed asset, will never be updated
+        : 86400; // favicon and other public assets
 
-      response.headers.append('cache-control', `public, max-age=${maxAge}`);
-    }
-
-    return response;
+    response.headers.append('cache-control', `public, max-age=${maxAge}`);
   }
 
-  async function handleEvent(event) {
-    try {
-      const url = new URL(event.request.url);
-
-      if (isAsset(url.pathname)) {
-        return await handleAsset(url, event);
-      }
-
-      return await handleRequest(event.request, {
-        indexTemplate,
-        cache: caches.default,
-        context: event,
-      });
-    } catch (error) {
-      return new Response(error.message || error.toString(), {status: 500});
-    }
-  }
-  addEventListener('fetch', (event) => event.respondWith(handleEvent(event)));
+  return response;
 }
+
+async function handleEvent(event) {
+  try {
+    const url = new URL(event.request.url);
+
+    if (isAsset(url.pathname)) {
+      return await handleAsset(url, event);
+    }
+
+    return await handleRequest(event.request, {
+      indexTemplate,
+      cache: caches.default,
+      context: event,
+    });
+  } catch (error) {
+    return new Response(error.message || error.toString(), {status: 500});
+  }
+}
+
+addEventListener('fetch', (event) => event.respondWith(handleEvent(event)));


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The challenge we have is that each platform needs to output the build code in different directories and handle assets in different ways. Plus, the user could have moved the entry `App.server.jsx` file to a different path, making it hard for integrations to find it.

To work around this, right now we use placeholders like `__SERVER_ENTRY__` that is resolved by Hydrogen and replaced at build time. However, this needs to be handled by every integration separately (see [Netlify plugin](https://github.com/netlify/hydrogen-platform/blob/21d8a49cf9e8b7795b0c5d5bf82b37f7e1b9f4ed/src/plugin.ts#L39) for an example, which basically copies what we do internally).

This PR aims to provide a simplified way to write 3p integrations. It basically builds on top of what we were using internally but provides a public `@shopify/hydrogen/platforms` entry point (name/path can be changed, feedback welcome) with utilities.

```js
// Handler before: paths needed to be hardcoded, which makes it hard to extract a generic plugin.
// Otherwise, the plugin itself need to implement a generic resolution logic.
import handleRequest from '../arbitrary/path/to/user/src/App.server';
import indexTemplate from '../arbitrary/path/to/user/dist/client/index.html?raw';

const isAsset = (urlPath) => /png|jpg|etc/.test(urlPath);

export default function (request) {
    if (isAsset(new URL(request.url).pathname)) return platformHandleAsset(request);
    return handleRequest(request, {indexTemplate});
}
```

```js
// Handler after: Hydrogen resolves all the paths and provides them as utilities (with types).
import {handleRequest, indexTemplate, isAsset} from '@shopify/hydrogen/platforms';

export default function (request) {
    if (isAsset(new URL(request.url).pathname)) return platformHandleAsset(request);
    return handleRequest(request, {indexTemplate});
}
```

### Additional context

A 3p integration would still consist of a Vite plugin that adds its own entry file for the SSR build, and a custom output directory. The key is that the custom entry file and the Vite plugin they make can now be simplified:

```js
// Plugin
{
  name: 'my-3p-platform',
  config(config) {
    return {
      build: config.build?.ssr
        ? {outDir: 'dist/worker', ssr: './handler'}
        : {outDir: 'dist/client'},
    };
  },
},
```

It would also be possible to skip the Vite plugin and use CLI flags directly for simple integrations (e.g. `shopify hydrogen build --entry 3p-provider/entry --outDir ....` (but I think we are missing some of these flags in the CLI).

We could add more abstractions on top of this at some point after we get more feedback.

cc @ascorbic Do you think this would be enough for now to simplify your plugin? Any other thing you are missing?

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
