### PR TITLE
Decode non UTF-8 chars in server props

### DIFF
--- a/.changeset/tender-adults-fry.md
+++ b/.changeset/tender-adults-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix server props when using non UTF-8 characters in URL.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -242,8 +242,11 @@ async function processRequest(
   }
 
   const state: Record<string, any> = isRSCRequest
-    ? parseJSON(url.searchParams.get('state') || '{}')
-    : {pathname: url.pathname, search: url.search};
+    ? parseJSON(decodeURIComponent(url.searchParams.get('state') || '{}'))
+    : {
+        pathname: decodeURIComponent(url.pathname),
+        search: decodeURIComponent(url.search),
+      };
 
   const rsc = runRSC({App, state, log, request, response});
 

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -94,9 +94,9 @@ export class HydrogenRequest extends Request {
 
     this.time = getTime();
     this.id = generateId();
-    this.normalizedUrl = this.isRscRequest()
-      ? normalizeUrl(this.url)
-      : this.url;
+    this.normalizedUrl = decodeURIComponent(
+      this.isRscRequest() ? normalizeUrl(this.url) : this.url
+    );
 
     this.ctx = {
       cache: new Map(),

--- a/packages/playground/server-components/src/routes/encode-uri/[handle].server.jsx
+++ b/packages/playground/server-components/src/routes/encode-uri/[handle].server.jsx
@@ -1,0 +1,9 @@
+export default function EncodeURI({params}) {
+  return (
+    <>
+      <h1>Encode URI</h1>
+
+      <div id="encode-uri-content">{params.handle}</div>
+    </>
+  );
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -52,6 +52,15 @@ export default async function testCases({
     expect(await page.textContent('.count')).toBe('Count is 1');
   });
 
+  it('decodes non UTF-8 parameters', async () => {
+    await page.goto(getServerUrl() + '/encode-uri/送料無料対象商品');
+
+    expect(await page.textContent('h1')).toContain('Encode URI');
+    expect(await page.textContent('#encode-uri-content')).toMatch(
+      '送料無料対象商品'
+    );
+  });
+
   it('renders `<ShopifyProvider>` dynamically in RSC and on the client', async () => {
     // "someDynamicValue should get injected into the response config paylout"
     await page.goto(getServerUrl() + '/config/someDynamicValue');


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1775 

URLs are encoded in UTF-8 so we need to decode them when creating the state. This also decodes `normalizedUrl`, I think it makes sense to have a proper URL there.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
