### PR TITLE
[Hydrogen docs]: Update descriptions and code examples, and add links

### DIFF
--- a/docs/components/global/shopifyprovider.md
+++ b/docs/components/global/shopifyprovider.md
@@ -4,7 +4,7 @@ title: ShopifyProvider
 description: The ShopifyProvider component wraps your entire app and provides support for hooks.
 ---
 
-The `ShopifyProvider` component wraps your entire app and provides functionality for many components, hooks, and utilities. You should place it in your app's entry point component. If you're using the Hydrogen framework, then it should be within `App.server.jsx`. 
+The `ShopifyProvider` component wraps your entire app and provides functionality for many components, hooks, and utilities. You should place it in your app's entry point component. If you're using the Hydrogen framework, then it should be within `App.server.jsx`.
 
 The `ShopifyProvider` component also provides localization data for the app. The default localization data is defined within your [Hydrogen configuration file](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config). You can change the active country and language at runtime by passing in the `countryCode` and `languageCode` props.
 
@@ -34,6 +34,7 @@ The `ShopifyProvider` component is a server component that renders inside `App.s
 ## Related framework topics
 
 - [Hydrogen configuration](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config)
+- [Internationalization](https://shopify.dev/custom-storefronts/hydrogen/framework/internationalization)
 
 ## Considerations
 

--- a/docs/components/primitive/image.md
+++ b/docs/components/primitive/image.md
@@ -109,8 +109,8 @@ You can change the size and format of the image returned by the Shopify CDN.
 
 | Key      | Description                                                                                             |
 | -------- | ------------------------------------------------------------------------------------------------------- |
-| `width`  | A string of the pixel width (for example, `100px`) or `original` for the original width of the image.   |
-| `height` | A string of the pixel height (for example, `100px`) or `original` for the original height of the image. |
+| `width`  | The integer or string value for the pixel width of the image. For example, `100px`. This is a required prop when `src` is present.  |
+| `height` | The integer or string value for the pixel height of the image. For example, `100px`. This is a required prop when `src` is present. |
 | `crop`   | Valid values: `top`, `bottom`, `left`, `right`, or `center`.                                            |
 | `scale`  | Valid values: 2 or 3.                                                                                   |
 

--- a/docs/framework/analytics.md
+++ b/docs/framework/analytics.md
@@ -152,7 +152,7 @@ Aside from the [default events](#default-events) that Hydrogen supports, you can
 ```
 {% endcodeblock %}
 
-> Note: 
+> Note:
 > You can test the custom event subscription by clicking the button with the analytics event attached. The  custom fields `creative_name` and `creative_slot` are added to the payload.
 
 ### Retrieving data from other parts of your Hydrogen storefront
@@ -419,6 +419,10 @@ export function GoogleAnalytics() {
       // Load the gtag script
       loadScript(URL).catch(() => {});
 
+      function trackPageView(payload) {
+        gtag('event', 'page_view');
+      }
+
       // gtag initialization code
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -434,10 +438,11 @@ export function GoogleAnalytics() {
       // Listen for events from Hydrogen
       ClientAnalytics.subscribe(
         ClientAnalytics.eventNames.PAGE_VIEW,
-        (payload) => {
-          gtag('event', 'page_view');
-        }
+        trackPageView
       );
+
+      ClientAnalytics.hasSentFirstPageView() &&
+        trackPageView(ClientAnalytics.getPageAnalyticsData());
     }
   });
 

--- a/docs/framework/internationalization.md
+++ b/docs/framework/internationalization.md
@@ -129,8 +129,8 @@ import {
 
 function App({routes, request}) {
   const pathname = new URL(request.normalizedUrl).pathname;
-  const acceptLanguage = request.headers.get(‘accept-language’);
-  const countryCode = acceptLanguage?.replace(/-.*/, '') || undefined; // Or set a default country code. For example, 'en'.
+  const localeMatch = /^\/([a-z]{2})(\/|$)/i.exec(pathname);
+  const countryCode = localeMatch ? localeMatch[1] : null;
 
   return (
     <Suspense fallback={<LoadingFallback />}>

--- a/docs/framework/internationalization.md
+++ b/docs/framework/internationalization.md
@@ -129,8 +129,8 @@ import {
 
 function App({routes, request}) {
   const pathname = new URL(request.normalizedUrl).pathname;
-  const localeMatch = /^\/([a-z]{2})(\/|$)/i.exec(pathname);
-  const countryCode = localeMatch ? localeMatch[1] : null;
+  const acceptLanguage = request.headers.get(‘accept-language’);
+  const countryCode = acceptLanguage?.replace(/-.*/, '') || undefined; // Or set a default country code. For example, 'en'.
 
   return (
     <Suspense fallback={<LoadingFallback />}>
@@ -178,8 +178,7 @@ If you're hosting your Hydrogen storefront on a platform that isn't Oxygen, then
 
 ```tsx
 const acceptLanguage = request.headers.get(‘accept-language’);
-const localeMatch = /^\/([a-z]{2})(\/|$)/i.exec(acceptLanguage);
-const countryCode = localeMatch ? localeMatch[1] : undefined;
+const countryCode = acceptLanguage?.replace(/-.*/, '') || undefined; // Or set a default country code. For example, 'en'.
 ```
 
 {% endcodeblock %}

--- a/docs/hooks/cart/usecartline.md
+++ b/docs/hooks/cart/usecartline.md
@@ -44,8 +44,8 @@ The `useCartLine` hook returns an object with the following keys:
 | ------------- | --------------------------------------- |
 | `id`          | The cart line's ID.                     |
 | `quantity`    | The cart line's quantity.               |
-| `attributes`  | The cart line's attributes.             |
-| `merchandise` | The cart line's associated merchandise. |
+| `attributes`  | The cart line's [attributes](https://shopify.dev/api/examples/cart#how-a-cart-works).             |
+| `merchandise` | The cart line's associated [merchandise](https://shopify.dev/api/examples/cart#how-a-cart-works). |
 
 ## Related components
 

--- a/docs/hooks/cart/usecartline.md
+++ b/docs/hooks/cart/usecartline.md
@@ -44,8 +44,8 @@ The `useCartLine` hook returns an object with the following keys:
 | ------------- | --------------------------------------- |
 | `id`          | The cart line's ID.                     |
 | `quantity`    | The cart line's quantity.               |
-| `attributes`  | The cart line's [attributes](https://shopify.dev/api/examples/cart#how-a-cart-works).             |
-| `merchandise` | The cart line's associated [merchandise](https://shopify.dev/api/examples/cart#how-a-cart-works). |
+| `attributes`  | The cart line's [attributes](https://shopify.dev/api/storefront/latest/objects/cartline).             |
+| `merchandise` | The cart line's associated [merchandise](https://shopify.dev/api/storefront/latest/objects/cartline). |
 
 ## Related components
 

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -53,3 +53,8 @@ This hook returns an object with the following properties:
 ## Related components
 
 - [`ShopifyProvider`](https://shopify.dev/api/hydrogen/components/global/shopifyprovider)
+
+## Related framework topics
+
+- [Hydrogen configuration](https://shopify.dev/custom-storefronts/hydrogen/framework/hydrogen-config)
+- [Internationalization](https://shopify.dev/custom-storefronts/hydrogen/framework/internationalization)


### PR DESCRIPTION
## This PR: 
- Updates the descriptions for the `width` and `height` props in the `Image` component reference
- Adds links to the "Internationalization" framework topic from the `ShopifyProvider` and `useLocalization` references
- Adds links to the Storefront API reference, which explains concepts such as `attributes` and `merchandise` on a cart
- Updates some incorrect regex code
- Updates some code in the Analytics topic
- Fixes https://github.com/Shopify/shopify-dev/issues/22917
- Fixes https://github.com/Shopify/shopify-dev/issues/22771
- Fixes https://github.com/Shopify/shopify-dev/issues/22593
- Fixes https://github.com/Shopify/shopify-dev/issues/22657
- Relates to https://github.com/Shopify/hydrogen/pull/1797 and https://github.com/Shopify/hydrogen/pull/1795