### PR TITLE
Fix app crash on prod

### DIFF
--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -162,7 +162,6 @@ function cachedQueryFnBuilder<T>(
      * Important: Do this async
      */
     if (shouldCacheResponse(newOutput)) {
-      console.log('Caching new output:', newOutput);
       const setItemInCachePromise = setItemInCache(
         key,
         newOutput,

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -162,6 +162,7 @@ function cachedQueryFnBuilder<T>(
      * Important: Do this async
      */
     if (shouldCacheResponse(newOutput)) {
+      console.log('Caching new output:', newOutput);
       const setItemInCachePromise = setItemInCache(
         key,
         newOutput,

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -9,6 +9,7 @@ import {fetchSync} from '../../foundation/fetchSync/server/fetchSync';
 import {META_ENV_SSR} from '../../foundation/ssr-interop';
 import {getStorefrontApiRequestHeaders} from '../../utilities/storefrontApi';
 import {parseJSON} from '../../utilities/parse';
+import {findQueryName} from '../../utilities/log/utils';
 
 export interface UseShopQueryResponse<T> {
   /** The data returned by the query. */
@@ -89,8 +90,12 @@ export function useShopQuery<T>({
     text = response.text();
 
     // @ts-ignore
-    console.log('Worker location:', serverRequest.cf?.colo);
-
+    console.log(
+      'Buyer region:',
+      serverRequest.headers.get('oxygen-buyer-region-code')
+    );
+    const queryname = findQueryName(body);
+    console.log('Query name', queryname);
     try {
       data = response.json();
     } catch (error: any) {

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -88,7 +88,8 @@ export function useShopQuery<T>({
 
     text = response.text();
 
-    console.log(serverRequest.headers);
+    // @ts-ignore
+    console.log('Worker location:', serverRequest.cf?.colo);
 
     try {
       data = response.json();

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -91,7 +91,19 @@ export function useShopQuery<T>({
     try {
       data = response.json();
     } catch (error: any) {
-      console.log('useShopQuery error');
+      console.log(
+        // @ts-ignore
+        `Public api token: ${requestInit.headers[
+          'X-Shopify-Storefront-Access-Token'
+        ]?.substr(0, 12)}`
+      );
+      console.log(
+        // @ts-ignore
+        `Public api token: ${requestInit.headers[
+          'Shopify-Storefront-Private-Token'
+        ]?.substr(0, 12)}`
+      );
+
       useQueryError = new Error(
         `Unable to parse response (x-request-id: ${response.headers.get(
           'x-request-id'

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -88,6 +88,8 @@ export function useShopQuery<T>({
 
     text = response.text();
 
+    console.log(serverRequest.headers);
+
     try {
       data = response.json();
     } catch (error: any) {
@@ -99,7 +101,7 @@ export function useShopQuery<T>({
       );
       console.log(
         // @ts-ignore
-        `Public api token: ${requestInit.headers[
+        `S2S token: ${requestInit.headers[
           'Shopify-Storefront-Private-Token'
         ]?.substr(0, 12)}`
       );

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -89,14 +89,7 @@ export function useShopQuery<T>({
 
     text = response.text();
 
-    // @ts-ignore
-    console.log(
-      'Buyer region:',
-      serverRequest.headers.get('oxygen-buyer-city'),
-      ', ',
-      serverRequest.headers.get('oxygen-buyer-region-code')
-    );
-    const queryname = findQueryName(body);
+    const queryname = findQueryName(query);
     console.log('Query name', queryname);
     try {
       data = response.json();

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -91,6 +91,7 @@ export function useShopQuery<T>({
     try {
       data = response.json();
     } catch (error: any) {
+      console.log('useShopQuery error');
       useQueryError = new Error(
         `Unable to parse response (x-request-id: ${response.headers.get(
           'x-request-id'

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -91,7 +91,11 @@ export function useShopQuery<T>({
     try {
       data = response.json();
     } catch (error: any) {
-      useQueryError = new Error('Unable to parse response:\n' + text);
+      useQueryError = new Error(
+        `Unable to parse response (x-request-id: ${response.headers.get(
+          'x-request-id'
+        )}):\n${text}`
+      );
     }
   } catch (error: any) {
     // Pass-through thrown promise for Suspense functionality

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -92,6 +92,8 @@ export function useShopQuery<T>({
     // @ts-ignore
     console.log(
       'Buyer region:',
+      serverRequest.headers.get('oxygen-buyer-city'),
+      ', ',
       serverRequest.headers.get('oxygen-buyer-region-code')
     );
     const queryname = findQueryName(body);
@@ -113,7 +115,7 @@ export function useShopQuery<T>({
       );
 
       useQueryError = new Error(
-        `Unable to parse response (x-request-id: ${response.headers.get(
+        `Unable to parse ${queryname} response (x-request-id: ${response.headers.get(
           'x-request-id'
         )}):\n${text}`
       );

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -89,26 +89,13 @@ export function useShopQuery<T>({
 
     text = response.text();
 
-    const queryname = findQueryName(query);
-    console.log('Query name', queryname);
     try {
       data = response.json();
     } catch (error: any) {
-      console.log(
-        // @ts-ignore
-        `Public api token: ${requestInit.headers[
-          'X-Shopify-Storefront-Access-Token'
-        ]?.substr(0, 12)}`
-      );
-      console.log(
-        // @ts-ignore
-        `S2S token: ${requestInit.headers[
-          'Shopify-Storefront-Private-Token'
-        ]?.substr(0, 12)}`
-      );
-
       useQueryError = new Error(
-        `Unable to parse ${queryname} response (x-request-id: ${response.headers.get(
+        `Unable to parse ${findQueryName(
+          query
+        )} response (x-request-id: ${response.headers.get(
           'x-request-id'
         )}):\n${text}`
       );

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     defaultCountryCode: 'US',
     defaultLanguageCode: 'EN',
     storeDomain: 'hydrogen-preview.myshopify.com',
-    storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
+    storefrontToken: '174af69ea23ab0c1d7191f13fd82ea3c',
     storefrontApiVersion: '2022-07',
   },
   session: CookieSessionStorage('__session', {

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -27,7 +27,7 @@ export default function Homepage() {
 
   return (
     <Layout>
-      <Suspense>
+      <Suspense fallback="">
         <SeoForHomepage />
       </Suspense>
       <Suspense>

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -86,7 +86,7 @@ function HomepageContent() {
 function SeoForHomepage() {
   const {
     data: {
-      shop: {title, description},
+      shop: {name: title, description},
     },
   } = useShopQuery({
     query: HOMEPAGE_SEO_QUERY,
@@ -168,9 +168,9 @@ const HOMEPAGE_CONTENT_QUERY = gql`
 `;
 
 const HOMEPAGE_SEO_QUERY = gql`
-  query homeShopInfo {
+  query shopInfo {
     shop {
-      title: name
+      name
       description
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

So far, the most consistent way to reproduce this bug is to:
1. Open a tab to hydrogen.shop
2. Leave it alone for 10 mins (and no one in the world is requesting for the site - ~might be easier to use a development oxygen instance to reproduce~)

**Edit:** Tried to reproduce this error in preview but was not able to. Gonna make a custom prod environment in admin to see if we can reproduce the error that way

Error we are seeing:

1. `"Field 'cart' doesn't exist on type 'QueryRoot'"` - This is happening on the `CartQuery($id: ID!...` query. - Suspecting this might be caused by an expired cart id. However, this should be a client-side network request and shouldn't make the app crash

2. From server log `ERROR: Failed to connect to the Storefront API: Unable to parse response: ` and `ERROR: {}` were observed. It seems that we got no response from SFAPI for some reason.

Error seems to be happening on the SFAPI. In order to get more information, we need to place some logging to help us track down this bug:

* Surface `x-request-id` in server log for `useShopQuery` requests

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
