### PR TITLE
Add assets proxy in Oxygen

### DIFF
--- a/.changeset/clever-clocks-stare.md
+++ b/.changeset/clever-clocks-stare.md
@@ -1,0 +1,9 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Serve assets in `public` directory from the same origin when deploying to Oxygen.
+
+Normally, public assets are served from a CDN domain that is different from the storefront URL. This creates issues in some situations where the assets need to be served from the same origin, such as when using service workers in PWA or tools like Partytown. This change adds a proxy so that the browser can download assets from the same origin.
+
+Note that, for performance reasons, it is still recommended placing assets in `/src/assets` instead of `/public` whenever possible.

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -1,4 +1,4 @@
-import {handleRequest, indexTemplate} from './virtual';
+import {handleRequest, indexTemplate, isAsset, assetBasePath} from './virtual';
 
 declare global {
   // eslint-disable-next-line no-var
@@ -14,6 +14,13 @@ export default {
     env: unknown,
     context: {waitUntil: (promise: Promise<any>) => void}
   ) {
+    // Proxy assets to the CDN. This should be removed
+    // once the proxy is implemented in Oxygen itself.
+    const url = new URL(request.url);
+    if (assetBasePath && isAsset(url.pathname)) {
+      return fetch(request.url.replace(url.origin, assetBasePath), request);
+    }
+
     if (!globalThis.Oxygen) {
       globalThis.Oxygen = {env};
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Public assets are served from a CDN when deploying to Oxygen. This creates issues with service workers because they need to be served from the same origin instead of an external CDN.

This PR builds on top of recent changes and adds a proxy to forward the asset request to the CDN from the worker.

Related: https://github.com/Shopify/hydrogen/discussions/1730

cc @maxshirshin @graygilmore -- Let me know when this is available in Oxygen and we can remove it from here 👍 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
