### PR TITLE
Fix HMR in client components

### DIFF
--- a/.changeset/violet-mice-sing.md
+++ b/.changeset/violet-mice-sing.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix HMR in client components. It should now update only the modified client component in the browser instead of refreshing the entire page.

--- a/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/cjs/react-server-dom-vite-plugin.js
@@ -297,6 +297,19 @@ function ReactFlightVitePlugin() {
 
         return findClientBoundariesForClientBuild(serverBuildEntries, optimizeBoundaries !== false).then(injectGlobs);
       }
+    },
+    handleHotUpdate: function (_ref2) {
+      var modules = _ref2.modules;
+
+      if (modules.some(function (mod) {
+        return mod.meta && mod.meta.isClientComponent;
+      })) {
+        return modules.filter(function (mod) {
+          return !mod.meta || !mod.meta.ssr;
+        });
+      }
+
+      return modules;
     }
   };
 }
@@ -466,9 +479,9 @@ function isDirectImportInServer(originalMod, currentMod, accModInfo) {
         exports: []
       };
       lastModImports.forEach(function (mod) {
-        mod.variables.forEach(function (_ref2) {
-          var name = _ref2[0],
-              alias = _ref2[1];
+        mod.variables.forEach(function (_ref3) {
+          var name = _ref3[0],
+              alias = _ref3[1];
 
           if (name === '*' && !alias) {
             var _accModInfo$exports;
@@ -501,8 +514,8 @@ function isDirectImportInServer(originalMod, currentMod, accModInfo) {
   // the original module before marking it as client boundary.
 
   return currentMod.meta.imports.some(function (imp) {
-    return imp.from === accModInfo.file && (imp.variables || []).some(function (_ref3) {
-      var name = _ref3[0];
+    return imp.from === accModInfo.file && (imp.variables || []).some(function (_ref4) {
+      var name = _ref4[0];
       return accModInfo.exports.includes(name);
     });
   });
@@ -540,12 +553,12 @@ function augmentModuleGraph(moduleGraph, id, code, root, resolveAlias) {
 
 
   var imports = [];
-  rawImports.forEach(function (_ref4) {
-    var startMod = _ref4.s,
-        endMod = _ref4.e,
-        dynamicImportIndex = _ref4.d,
-        startStatement = _ref4.ss,
-        endStatement = _ref4.se;
+  rawImports.forEach(function (_ref5) {
+    var startMod = _ref5.s,
+        endMod = _ref5.e,
+        dynamicImportIndex = _ref5.d,
+        startStatement = _ref5.ss,
+        endStatement = _ref5.se;
     if (dynamicImportIndex !== -1) return; // Skip dynamic imports for now
 
     var rawModPath = code.slice(startMod, endMod);
@@ -593,7 +606,8 @@ function augmentModuleGraph(moduleGraph, id, code, root, resolveAlias) {
   assign(currentModule.meta, {
     isFacade: isFacade,
     namedExports: namedExports,
-    imports: imports
+    imports: imports,
+    ssr: true
   });
 }
 

--- a/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
+++ b/packages/hydrogen/vendor/react-server-dom-vite/esm/react-server-dom-vite-plugin.js
@@ -293,6 +293,19 @@ function ReactFlightVitePlugin() {
 
         return findClientBoundariesForClientBuild(serverBuildEntries, optimizeBoundaries !== false).then(injectGlobs);
       }
+    },
+    handleHotUpdate: function (_ref2) {
+      var modules = _ref2.modules;
+
+      if (modules.some(function (mod) {
+        return mod.meta && mod.meta.isClientComponent;
+      })) {
+        return modules.filter(function (mod) {
+          return !mod.meta || !mod.meta.ssr;
+        });
+      }
+
+      return modules;
     }
   };
 }
@@ -462,9 +475,9 @@ function isDirectImportInServer(originalMod, currentMod, accModInfo) {
         exports: []
       };
       lastModImports.forEach(function (mod) {
-        mod.variables.forEach(function (_ref2) {
-          var name = _ref2[0],
-              alias = _ref2[1];
+        mod.variables.forEach(function (_ref3) {
+          var name = _ref3[0],
+              alias = _ref3[1];
 
           if (name === '*' && !alias) {
             var _accModInfo$exports;
@@ -497,8 +510,8 @@ function isDirectImportInServer(originalMod, currentMod, accModInfo) {
   // the original module before marking it as client boundary.
 
   return currentMod.meta.imports.some(function (imp) {
-    return imp.from === accModInfo.file && (imp.variables || []).some(function (_ref3) {
-      var name = _ref3[0];
+    return imp.from === accModInfo.file && (imp.variables || []).some(function (_ref4) {
+      var name = _ref4[0];
       return accModInfo.exports.includes(name);
     });
   });
@@ -536,12 +549,12 @@ function augmentModuleGraph(moduleGraph, id, code, root, resolveAlias) {
 
 
   var imports = [];
-  rawImports.forEach(function (_ref4) {
-    var startMod = _ref4.s,
-        endMod = _ref4.e,
-        dynamicImportIndex = _ref4.d,
-        startStatement = _ref4.ss,
-        endStatement = _ref4.se;
+  rawImports.forEach(function (_ref5) {
+    var startMod = _ref5.s,
+        endMod = _ref5.e,
+        dynamicImportIndex = _ref5.d,
+        startStatement = _ref5.ss,
+        endStatement = _ref5.se;
     if (dynamicImportIndex !== -1) return; // Skip dynamic imports for now
 
     var rawModPath = code.slice(startMod, endMod);
@@ -589,7 +602,8 @@ function augmentModuleGraph(moduleGraph, id, code, root, resolveAlias) {
   assign(currentModule.meta, {
     isFacade: isFacade,
     namedExports: namedExports,
-    imports: imports
+    imports: imports,
+    ssr: true
   });
 }
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -327,6 +327,10 @@ export default async function testCases({
       const newButtonText = 'add';
 
       await page.goto(getServerUrl() + '/about');
+      expect(await page.textContent('h1')).toContain('About');
+
+      await page.click('.increase');
+      expect(await page.textContent('.count')).toBe('Count is 1');
 
       await edit(
         fullPath,
@@ -334,6 +338,9 @@ export default async function testCases({
         () => untilUpdated(() => page.textContent('button'), 'increase count'),
         () => untilUpdated(() => page.textContent('button'), newButtonText)
       );
+
+      // Only refreshes the client component without changing input state
+      expect(await page.textContent('.count')).toBe('Count is 1');
     });
 
     it('updates the contents when a server component file changes', async () => {
@@ -341,6 +348,10 @@ export default async function testCases({
       const newheading = 'Snow Devil';
 
       await page.goto(getServerUrl() + '/about');
+      expect(await page.textContent('h1')).toContain('About');
+
+      await page.click('.increase');
+      expect(await page.textContent('.count')).toBe('Count is 1');
 
       await edit(
         fullPath,
@@ -348,6 +359,9 @@ export default async function testCases({
         () => untilUpdated(() => page.textContent('h1'), 'About'),
         () => untilUpdated(() => page.textContent('h1'), newheading)
       );
+
+      // Full page refresh
+      expect(await page.textContent('.count')).toBe('Count is 0');
     });
   });
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #39
Closes #1793

Modifying client components was triggering a full page refresh because Vite was invalidating modules used in the server during SSR. This PR filters the modules Vite invalidates to only include browser files.

cc @await-ovo Thanks for all the research!

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
