### PR TITLE
Add Subscription compatibility to AddToCartButton

### DIFF
--- a/.changeset/polite-goats-smile.md
+++ b/.changeset/polite-goats-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Added optional sellingPlanId prop to AddToCartButton.client.tsx

--- a/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
+++ b/packages/hydrogen/src/components/AddToCartButton/AddToCartButton.client.tsx
@@ -15,6 +15,8 @@ interface AddToCartButtonProps {
   quantity?: number;
   /** The text that is announced by the screen reader when the item is being added to the cart. Used for accessibility purposes only and not displayed on the page. */
   accessibleAddingToCartLabel?: string;
+  /** The selling plan ID of the subscription variant */
+  sellingPlanId?: string;
 }
 
 /**
@@ -27,6 +29,7 @@ export function AddToCartButton(props: AddToCartButtonProps & BaseButtonProps) {
     variantId: explicitVariantId,
     quantity = 1,
     attributes,
+    sellingPlanId,
     onClick,
     children,
     accessibleAddingToCartLabel,
@@ -55,9 +58,10 @@ export function AddToCartButton(props: AddToCartButtonProps & BaseButtonProps) {
         quantity,
         merchandiseId: variantId,
         attributes,
+        sellingPlanId,
       },
     ]);
-  }, [linesAdd, quantity, variantId, attributes]);
+  }, [linesAdd, quantity, variantId, attributes, sellingPlanId]);
 
   return (
     <>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Added the optional `sellingPlanId` prop to the `AddToCartButton.client.tsx` component

<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context
The current `AddToCartButton.client.tsx` does not allow the `sellingPlanId` prop to pass-through to the `useCart` hook. The types and the Storefront API are already compatible with this.

Without this prop, you cannot add items to a subscription.


<!-- e.g. is there anything you'd like reviewers to focus on? -->


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
