### PR TITLE
New locale logic

### DIFF
--- a/.changeset/funny-items-travel.md
+++ b/.changeset/funny-items-travel.md
@@ -6,4 +6,4 @@
 
 The following is how we calculate `locale`:
 If the Shopify `language` includes a region, then this value is used to calculate the `locale` and `countryCode` is disregarded. For example, if `language` is `PT_BR` (Brazilian Portuguese), then `locale` is calculated as `PT-BR`.
-If the `language` does not contain a region, for example `EN` (English) and a `countryCode` like `US` (United States), the calculated `locale` will merge both into `EN-US`.
+If the Shopify `language` doesn't include a region, then this value is merged with the `countryCode` to calculate the `locale`. For example, if `language` is `EN` (English) and `countryCode` is `US` (United States), then `locale` is calculated as `EN-US`.

--- a/.changeset/funny-items-travel.md
+++ b/.changeset/funny-items-travel.md
@@ -1,0 +1,9 @@
+---
+'@shopify/hydrogen': patch
+---
+
+`locale` calculation logic and docs have been updated to support Shopify languages with extended language subtags.
+
+`locale` is now calculated like this:
+Given a Shopify `language` that includes a region, for example `PT_BR` (Portuguese from Brazil), the calculated `locale` will be `PT-BR` disregarding `countryCode`.
+If the `language` does not contain a region, for example `EN` (English) and a `countryCode` like `US` (United States), the calculated `locale` will merge both into `EN-US`.

--- a/.changeset/funny-items-travel.md
+++ b/.changeset/funny-items-travel.md
@@ -4,6 +4,6 @@
 
 `locale` calculation logic and docs have been updated to support Shopify languages with extended language subtags.
 
-`locale` is now calculated like this:
+The following is how we calculate `locale`:
 If the Shopify `language` includes a region, then this value is used to calculate the `locale` and `countryCode` is disregarded. For example, if `language` is `PT_BR` (Brazilian Portuguese), then `locale` is calculated as `PT-BR`.
 If the `language` does not contain a region, for example `EN` (English) and a `countryCode` like `US` (United States), the calculated `locale` will merge both into `EN-US`.

--- a/.changeset/funny-items-travel.md
+++ b/.changeset/funny-items-travel.md
@@ -5,5 +5,5 @@
 `locale` calculation logic and docs have been updated to support Shopify languages with extended language subtags.
 
 `locale` is now calculated like this:
-Given a Shopify `language` that includes a region, for example `PT_BR` (Portuguese from Brazil), the calculated `locale` will be `PT-BR` disregarding `countryCode`.
+If the Shopify `language` includes a region, then this value is used to calculate the `locale` and `countryCode` is disregarded. For example, if `language` is `PT_BR` (Brazilian Portuguese), then `locale` is calculated as `PT-BR`.
 If the `language` does not contain a region, for example `EN` (English) and a `countryCode` like `US` (United States), the calculated `locale` will merge both into `EN-US`.

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -48,8 +48,16 @@ This hook returns an object with the following properties:
 | ---------- | ---------------------------------------------------------------------------------------- |
 | `country`  | An object with the country's `isoCode`.                                       |
 | `language` | An object with the language's `isoCode`.                                                 |
-| `locale`   | A locale string, which includes the `isoCode` of both the `language` and `country`. For example, `en-US`. |
+| `locale`   | The locale string based on `country` and `language`. See [how we determine locale](#calculating-the-locale-for-i18n).  |
 
+## Determine the locale for i18n
+
+We use both the assigned `language` and `countryCode` in the `ShopifyProvider` to determine the `locale`.
+
+If the `language` does not contain language tag extensions, then we try to merge `language` and `countryCode`. For example, given `language` is `EN` (english) and `countryCode` is `US` (United States), the resulting `locale` is `EN-US`.
+
+Alternatively if the `language` contains a language tag extension we use it directly as `locale`. For example, given
+`language` is `PT_BR` (Brazilian Portuguese) and `countryCode` is `US` (United States), the resulting `locale` is `PT_BR`
 ## Related components
 
 - [`ShopifyProvider`](https://shopify.dev/api/hydrogen/components/global/shopifyprovider)

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -57,7 +57,7 @@ We use the assigned `language` and `countryCode` in the `ShopifyProvider` to det
 If the `language` doesn't contain language tag extensions, then we try to merge `language` and `countryCode`. For example, if `language` is `EN` (English) and `countryCode` is `US` (United States), then `locale` is `EN-US`.
 
 Alternatively if the `language` contains a language tag extension, then we use it directly as `locale`. For example, if
-`language` is `PT_BR` (Brazilian Portuguese) and `countryCode` is `US` (United States), the resulting `locale` is `PT_BR`
+`language` is `PT_BR` (Brazilian Portuguese) and `countryCode` is `US` (United States), then `locale` is `PT_BR`
 ## Related components
 
 - [`ShopifyProvider`](https://shopify.dev/api/hydrogen/components/global/shopifyprovider)

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -48,7 +48,7 @@ This hook returns an object with the following properties:
 | ---------- | ---------------------------------------------------------------------------------------- |
 | `country`  | An object with the country's `isoCode`.                                       |
 | `language` | An object with the language's `isoCode`.                                                 |
-| `locale`   | The locale string based on `country` and `language`. See [how we determine locale](#calculating-the-locale-for-i18n).  |
+| `locale`   | The locale string based on `country` and `language`. See [how we determine locale](#determine-the-locale-for-i18n).  |
 
 ## Determine the locale for i18n
 

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -56,7 +56,7 @@ We use the assigned `language` and `countryCode` in the `ShopifyProvider` to det
 
 If the `language` doesn't contain language tag extensions, then we try to merge `language` and `countryCode`. For example, if `language` is `EN` (English) and `countryCode` is `US` (United States), then `locale` is `EN-US`.
 
-Alternatively if the `language` contains a language tag extension we use it directly as `locale`. For example, given
+Alternatively if the `language` contains a language tag extension, then we use it directly as `locale`. For example, if
 `language` is `PT_BR` (Brazilian Portuguese) and `countryCode` is `US` (United States), the resulting `locale` is `PT_BR`
 ## Related components
 

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -52,7 +52,7 @@ This hook returns an object with the following properties:
 
 ## Determine the locale for i18n
 
-We use both the assigned `language` and `countryCode` in the `ShopifyProvider` to determine the `locale`.
+We use the assigned `language` and `countryCode` in the `ShopifyProvider` to determine the `locale`.
 
 If the `language` does not contain language tag extensions, then we try to merge `language` and `countryCode`. For example, given `language` is `EN` (english) and `countryCode` is `US` (United States), the resulting `locale` is `EN-US`.
 

--- a/docs/hooks/localization/uselocalization.md
+++ b/docs/hooks/localization/uselocalization.md
@@ -54,7 +54,7 @@ This hook returns an object with the following properties:
 
 We use the assigned `language` and `countryCode` in the `ShopifyProvider` to determine the `locale`.
 
-If the `language` does not contain language tag extensions, then we try to merge `language` and `countryCode`. For example, given `language` is `EN` (english) and `countryCode` is `US` (United States), the resulting `locale` is `EN-US`.
+If the `language` doesn't contain language tag extensions, then we try to merge `language` and `countryCode`. For example, if `language` is `EN` (English) and `countryCode` is `US` (United States), then `locale` is `EN-US`.
 
 Alternatively if the `language` contains a language tag extension we use it directly as `locale`. For example, given
 `language` is `PT_BR` (Brazilian Portuguese) and `countryCode` is `US` (United States), the resulting `locale` is `PT_BR`

--- a/packages/hydrogen/src/foundation/DevTools/DevTools.server.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/DevTools.server.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {DevTools as DevToolsClient} from './DevTools.client';
 import {useServerRequest} from '../ServerRequestProvider';
+import {getLocale} from '../../utilities/locale';
 
 export function DevTools() {
   const serverRequest = useServerRequest();
@@ -12,7 +13,10 @@ export function DevTools() {
     storefrontApiVersion,
   } = shopifyConfig || {};
   const settings = {
-    locale: `${languageCode}-${countryCode}`,
+    locale:
+      languageCode && countryCode
+        ? getLocale(languageCode, countryCode)
+        : `${languageCode}-${countryCode}`,
     storeDomain,
     storefrontApiVersion,
   };

--- a/packages/hydrogen/src/foundation/DevTools/DevTools.server.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/DevTools.server.tsx
@@ -13,10 +13,7 @@ export function DevTools() {
     storefrontApiVersion,
   } = shopifyConfig || {};
   const settings = {
-    locale:
-      languageCode && countryCode
-        ? getLocale(languageCode, countryCode)
-        : `${languageCode}-${countryCode}`,
+    locale: getLocale(languageCode, countryCode),
     storeDomain,
     storefrontApiVersion,
   };

--- a/packages/hydrogen/src/foundation/DevTools/components/Settings.client.tsx
+++ b/packages/hydrogen/src/foundation/DevTools/components/Settings.client.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import {Locale} from '../../ShopifyProvider/types';
 import {Table} from './Table';
 
 interface Props {
-  locale: string;
+  locale: Locale;
   storeDomain: string;
   storefrontApiVersion: string;
 }

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.server.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.server.tsx
@@ -9,6 +9,7 @@ import type {ShopifyConfig, ShopifyConfigFetcher} from '../../types';
 import {useRequestCacheData, useServerRequest} from '../ServerRequestProvider';
 import {getOxygenVariable} from '../../utilities/storefrontApi';
 import {SHOPIFY_STOREFRONT_ID_VARIABLE} from '../../constants';
+import {getLocale} from '../../utilities/locale';
 
 function makeShopifyContext(shopifyConfig: ShopifyConfig): ShopifyContextValue {
   const countryCode = shopifyConfig.defaultCountryCode ?? DEFAULT_COUNTRY;
@@ -128,7 +129,7 @@ export function getLocalizationContextValue(
       language: {
         isoCode: runtimeLanguageCode,
       },
-      locale: `${runtimeLanguageCode}-${runtimeCountryCode}`,
+      locale: getLocale(runtimeLanguageCode, runtimeCountryCode),
     };
   }, [defaultLanguageCode, defaultCountryCode, countryCode, languageCode]);
 }

--- a/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
@@ -9,6 +9,9 @@ export interface ShopifyContextValue
   storefrontId: string | null;
 }
 
+// TODO: improve types with intrinsic string manipulation
+export type Locale = string;
+
 export interface LocalizationContextValue {
   country: {
     isoCode: `${CountryCode}`;
@@ -16,7 +19,7 @@ export interface LocalizationContextValue {
   language: {
     isoCode: `${LanguageCode}`;
   };
-  locale: `${LanguageCode}-${CountryCode}`;
+  locale: Locale;
 }
 
 export type ShopifyProviderProps = {

--- a/packages/hydrogen/src/hooks/useLocalization/useLocalization.tsx
+++ b/packages/hydrogen/src/hooks/useLocalization/useLocalization.tsx
@@ -1,10 +1,12 @@
 import {LocalizationContext} from '../../foundation/ShopifyProvider/ShopifyProvider.client';
-import type {LocalizationContextValue} from '../../foundation/ShopifyProvider/types';
+import type {
+  Locale,
+  LocalizationContextValue,
+} from '../../foundation/ShopifyProvider/types';
 import {useEnvContext} from '../../foundation/ssr-interop';
-import {CountryCode, LanguageCode} from '../../storefront-api-types';
 
 export function useLocalization(): LocalizationContextValue & {
-  locale: `${LanguageCode}-${CountryCode}`;
+  locale: Locale;
 } {
   const localization = useEnvContext(
     (req) => req.ctx.localization,

--- a/packages/hydrogen/src/utilities/locale.ts
+++ b/packages/hydrogen/src/utilities/locale.ts
@@ -1,0 +1,25 @@
+import {CountryCode, LanguageCode} from '../storefront-api-types';
+
+/**
+ * Calculates locale based on provided language and countryCode
+ * 1. If language is extended with region, hyphenate and use as locale
+ * 2. Else merge language and countryCode
+ */
+export function getLocale(
+  language: `${LanguageCode}`,
+  countryCode: `${CountryCode}`
+) {
+  if (isLanguageExtended(language)) {
+    return hyphenateLanguage(language);
+  }
+  return `${language}-${countryCode}`;
+}
+
+function hyphenateLanguage(str: `${LanguageCode}`) {
+  return str.replace('_', '-');
+}
+
+function isLanguageExtended(str?: `${LanguageCode}`) {
+  if (!str) return false;
+  return /-|_/.test(str);
+}

--- a/packages/hydrogen/src/utilities/locale/index.ts
+++ b/packages/hydrogen/src/utilities/locale/index.ts
@@ -1,0 +1,1 @@
+export {getLocale} from './locale';

--- a/packages/hydrogen/src/utilities/locale/locale.ts
+++ b/packages/hydrogen/src/utilities/locale/locale.ts
@@ -2,7 +2,7 @@ import {CountryCode, LanguageCode} from '../../storefront-api-types';
 
 /**
  * Calculates locale based on provided language and countryCode
- * 1. If language is extended with region, hyphenate and use as locale
+ * 1. If language is extended with region, then hyphenate and use as locale
  * 2. Else merge language and countryCode
  */
 export function getLocale(

--- a/packages/hydrogen/src/utilities/locale/locale.ts
+++ b/packages/hydrogen/src/utilities/locale/locale.ts
@@ -1,4 +1,4 @@
-import {CountryCode, LanguageCode} from '../storefront-api-types';
+import {CountryCode, LanguageCode} from '../../storefront-api-types';
 
 /**
  * Calculates locale based on provided language and countryCode
@@ -6,9 +6,13 @@ import {CountryCode, LanguageCode} from '../storefront-api-types';
  * 2. Else merge language and countryCode
  */
 export function getLocale(
-  language: `${LanguageCode}`,
-  countryCode: `${CountryCode}`
+  language?: `${LanguageCode}`,
+  countryCode?: `${CountryCode}`
 ) {
+  if (!language || !countryCode) {
+    return '';
+  }
+
   if (isLanguageExtended(language)) {
     return hyphenateLanguage(language);
   }
@@ -21,5 +25,5 @@ function hyphenateLanguage(str: `${LanguageCode}`) {
 
 function isLanguageExtended(str?: `${LanguageCode}`) {
   if (!str) return false;
-  return /-|_/.test(str);
+  return str.includes('_') || str.includes('-');
 }

--- a/packages/hydrogen/src/utilities/locale/tests/locale.test.ts
+++ b/packages/hydrogen/src/utilities/locale/tests/locale.test.ts
@@ -1,0 +1,31 @@
+import {getLocale} from '../locale';
+
+describe('locale', () => {
+  describe('getLocale', () => {
+    it('returns `language` as `locale` given a language with a subtag extensions', () => {
+      const countryCode = 'US';
+      const language = 'PT_BR';
+
+      const result = getLocale(language, countryCode);
+
+      expect(result).toBe('PT-BR');
+    });
+
+    it('returns `locale` as the merge of the `language` and `countryCode`', () => {
+      const countryCode = 'US';
+      const language = 'PT';
+
+      const result = getLocale(language, countryCode);
+
+      expect(result).toBe('PT-US');
+    });
+
+    it('returns empty string when `language` or `countryCode` as missing', () => {
+      const countryCode = 'US';
+
+      const result = getLocale(undefined, countryCode);
+
+      expect(result).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
https://github.com/Shopify/hydrogen/issues/1835

### Description
Locale will now work with languages with regions
`PT_PT`, `PT_BR`, etc.

### Additional context
Consulted with `i18n` team about this. Only concern could be that this might be confusing how locale gets calculated. 
My conclusion is that locale's and validity have a funny history.
