### PR TITLE
Slightly improve messaging around SFAPI GraphQL errors

### DIFF
--- a/.changeset/large-hotels-shout.md
+++ b/.changeset/large-hotels-shout.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improve error messaging when there is an error in the Storefront API's GraphQL response.

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -77,9 +77,10 @@ export function useShopQuery<T>({
   let text: string;
   let data: any;
   let useQueryError: any;
+  let response: ReturnType<typeof fetchSync> | null = null;
 
   try {
-    const response = fetchSync(url, {
+    response = fetchSync(url, {
       ...requestInit,
       cache,
       preload,
@@ -127,12 +128,19 @@ export function useShopQuery<T>({
    */
   if (data?.errors) {
     const errors = Array.isArray(data.errors) ? data.errors : [data.errors];
-
+    const requestId = response?.headers?.get('x-request-id') ?? '';
     for (const error of errors) {
       if (__HYDROGEN_DEV__ && !__HYDROGEN_TEST__) {
-        throw new Error(`Storefront API GraphQL Error: ${error.message}`);
+        throw new Error(
+          `Storefront API GraphQL Error: ${error.message}.\nRequest id: ${requestId}`
+        );
       } else {
-        log.error('Storefront API GraphQL Error', error);
+        log.error(
+          'Storefront API GraphQL Error',
+          error,
+          'Storefront API GraphQL request id',
+          requestId
+        );
       }
     }
     log.error(`Storefront API GraphQL error count: ${errors.length}`);

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -130,12 +130,12 @@ export function useShopQuery<T>({
 
     for (const error of errors) {
       if (__HYDROGEN_DEV__ && !__HYDROGEN_TEST__) {
-        throw new Error(error.message);
+        throw new Error(`Storefront API GraphQL Error: ${error.message}`);
       } else {
-        log.error('GraphQL Error', error);
+        log.error('Storefront API GraphQL Error', error);
       }
     }
-    log.error(`GraphQL errors: ${errors.length}`);
+    log.error(`Storefront API GraphQL error count: ${errors.length}`);
   }
 
   if (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We want to make it clearer that errors came from the Storefront API GraphQL. 

### Additional context

- Would be cool to use Error [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) but I don't think we're quite there yet.  

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
