### PR TITLE
Move Minimum Node Version to 18

### DIFF
--- a/.github/workflows/oxygen-deployment.yml
+++ b/.github/workflows/oxygen-deployment.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           cache: 'yarn'
 
       - name: Install the packages

--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
 
     name: OS ${{ matrix.os }} / NodeJS ${{ matrix.node-version }}
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Spin up a Hydrogen app in your browser with our [playground](https://hydrogen.ne
 **Requirements:**
 
 - `yarn` or `npm`
-- Node.js version 16.5.0 or higher
+- Node.js version 18.0.0 or higher [with globally available browser-compatible
+  APIs](https://nodejs.org/ko/blog/announcements/v18-release-announce/#new-globally-available-browser-compatible-apis)
 
 **Installation:**
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "hydrogen-monorepo",
   "private": true,
   "packageManager": "yarn@1.22.17",
-  "workspaces": ["templates/*", "packages/*", "packages/playground/*"],
+  "workspaces": [
+    "templates/*",
+    "packages/*",
+    "packages/playground/*"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -70,10 +74,19 @@
     "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,jsx}": ["prettier --write"],
-    "*.{ts,tsx}": ["eslint", "prettier --parser=typescript --write"],
-    "*.html": ["prettier --write"],
-    "*.md": ["prettier --write"]
+    "*.{js,jsx}": [
+      "prettier --write"
+    ],
+    "*.{ts,tsx}": [
+      "eslint",
+      "prettier --parser=typescript --write"
+    ],
+    "*.html": [
+      "prettier --write"
+    ],
+    "*.md": [
+      "prettier --write"
+    ]
   },
   "resolutions": {
     "unified": "9.2.2"

--- a/package.json
+++ b/package.json
@@ -2,13 +2,9 @@
   "name": "hydrogen-monorepo",
   "private": true,
   "packageManager": "yarn@1.22.17",
-  "workspaces": [
-    "templates/*",
-    "packages/*",
-    "packages/playground/*"
-  ],
+  "workspaces": ["templates/*", "packages/*", "packages/playground/*"],
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "scripts": {
     "dev": "yarn turbo run dev --parallel --filter=@shopify/hydrogen-ui --filter=@shopify/hydrogen",
@@ -74,19 +70,10 @@
     "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,jsx}": [
-      "prettier --write"
-    ],
-    "*.{ts,tsx}": [
-      "eslint",
-      "prettier --parser=typescript --write"
-    ],
-    "*.html": [
-      "prettier --write"
-    ],
-    "*.md": [
-      "prettier --write"
-    ]
+    "*.{js,jsx}": ["prettier --write"],
+    "*.{ts,tsx}": ["eslint", "prettier --parser=typescript --write"],
+    "*.html": ["prettier --write"],
+    "*.md": ["prettier --write"]
   },
   "resolutions": {
     "unified": "9.2.2"

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -16,7 +16,7 @@
   } from '@shopify/hydrogen/platforms';
 
   // Platform entry handler
-  export default function(request) {
+  export default function (request) {
     if (isAsset(new URL(request.url).pathname)) {
       return platformAssetHandler(request);
     }

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "shopify hydrogen dev",
     "build": "shopify hydrogen build",

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "shopify hydrogen dev",
     "build": "shopify hydrogen build",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Ensure that the minimum Node version is 18. This ensures that globals like `fetch`, `formData`, etc. are always available.

[Node 18 - New globally available browser-compatible APIs](https://nodejs.org/ko/blog/announcements/v18-release-announce/#new-globally-available-browser-compatible-apis)

### Additional context

Also updated starter templates