### PR TITLE
[Docs] Add inline comments about Demo Store homepage hero metafield definitions

### DIFF
--- a/.changeset/sour-turtles-prove.md
+++ b/.changeset/sour-turtles-prove.md
@@ -1,0 +1,5 @@
+---
+'demo-store': patch
+---
+
+Add code comments about setting custom metafield values

--- a/.changeset/sour-turtles-prove.md
+++ b/.changeset/sour-turtles-prove.md
@@ -1,5 +1,0 @@
----
-'demo-store': patch
----
-
-Add code comments about setting custom metafield values

--- a/templates/demo-store/src/lib/placeholders.ts
+++ b/templates/demo-store/src/lib/placeholders.ts
@@ -174,12 +174,12 @@ const PLACEHOLDERS = {
 
 /**
  * getHeroPlaceholder() returns placeholder content when the expected metafields
- * don't exist. Define these 5 custom metafields on your Shopify store to override placeholders:
+ * don't exist. Define the following five custom metafields on your Shopify store to override placeholders:
  * - hero.title             Single line text
  * - hero.byline            Single line text
  * - hero.cta               Single line text
  * - hero.spread            File
- * - hero.spread_seconary   File
+ * - hero.spread_secondary   File
  *
  * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
  * @see https://github.com/Shopify/hydrogen/discussions/1790

--- a/templates/demo-store/src/lib/placeholders.ts
+++ b/templates/demo-store/src/lib/placeholders.ts
@@ -179,7 +179,7 @@ const PLACEHOLDERS = {
  * - hero.byline            Single line text
  * - hero.cta               Single line text
  * - hero.spread            File
- * - hero.spread_secondary  File
+ * - hero.spread_secondary   File
  *
  * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
  * @see https://github.com/Shopify/hydrogen/discussions/1790

--- a/templates/demo-store/src/lib/placeholders.ts
+++ b/templates/demo-store/src/lib/placeholders.ts
@@ -172,7 +172,19 @@ const PLACEHOLDERS = {
   },
 };
 
-// Return placeholders for collection Heros when metafields are not set
+/**
+ * getHeroPlaceholder() returns placeholder content when the expected metafields
+ * don't exist. Define these 5 custom metafields on your Shopify store to override placeholders:
+ * - hero.title             Single line text
+ * - hero.byline            Single line text
+ * - hero.cta               Single line text
+ * - hero.spread            File
+ * - hero.spread_seconary   File
+ *
+ * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
+ * @see https://github.com/Shopify/hydrogen/discussions/1790
+ */
+
 export function getHeroPlaceholder(heros: any[]) {
   if (!heros?.length) return [];
 

--- a/templates/demo-store/src/lib/placeholders.ts
+++ b/templates/demo-store/src/lib/placeholders.ts
@@ -179,7 +179,7 @@ const PLACEHOLDERS = {
  * - hero.byline            Single line text
  * - hero.cta               Single line text
  * - hero.spread            File
- * - hero.spread_secondary   File
+ * - hero.spread_secondary  File
  *
  * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
  * @see https://github.com/Shopify/hydrogen/discussions/1790

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -114,7 +114,7 @@ function SeoForHomepage() {
  * - hero.byline            Single line text
  * - hero.cta               Single line text
  * - hero.spread            File
- * - hero.spread_secondary  File
+ * - hero.spread_seconary   File
  *
  * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
  * @see https://github.com/Shopify/hydrogen/discussions/1790

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -114,7 +114,7 @@ function SeoForHomepage() {
  * - hero.byline            Single line text
  * - hero.cta               Single line text
  * - hero.spread            File
- * - hero.spread_seconary   File
+ * - hero.spread_secondary  File
  *
  * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
  * @see https://github.com/Shopify/hydrogen/discussions/1790

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -108,8 +108,8 @@ function SeoForHomepage() {
 
 /**
  * The homepage content query includes a request for custom metafields inside the alias
- * `heroBanners`. The template will load placeholder content if these metafields don't
- * exist. Define these 5 custom metafields on your Shopify store to override placeholders:
+ * `heroBanners`. The template loads placeholder content if these metafields don't
+ * exist. Define the following five custom metafields on your Shopify store to override placeholders:
  * - hero.title             Single line text
  * - hero.byline            Single line text
  * - hero.cta               Single line text

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -106,6 +106,20 @@ function SeoForHomepage() {
   );
 }
 
+/**
+ * The homepage content query includes a request for custom metafields inside the alias
+ * `heroBanners`. The template will load placeholder content if these metafields don't
+ * exist. Define these 5 custom metafields on your Shopify store to override placeholders:
+ * - hero.title             Single line text
+ * - hero.byline            Single line text
+ * - hero.cta               Single line text
+ * - hero.spread            File
+ * - hero.spread_seconary   File
+ *
+ * @see https://help.shopify.com/manual/metafields/metafield-definitions/creating-custom-metafield-definitions
+ * @see https://github.com/Shopify/hydrogen/discussions/1790
+ */
+
 const HOMEPAGE_CONTENT_QUERY = gql`
   ${MEDIA_FRAGMENT}
   ${PRODUCT_CARD_FRAGMENT}


### PR DESCRIPTION
### Description
This PR adds inline comments to better document how people can customize hero content on the homepage of the Demo Store template by defining the expected custom metafields on their Shopify store.

There are two contextual places that might make sense to add this information, but I'm not convinced we need both; I'd lean toward `index.server.ts`.

Also curious to gather opinions on adding links to the original GitHub discussion. Personally I think it could be useful context down the road but not essential IMO.

Finally, since this commentary is more verbose I'm using the JSDoc comment block style. Open to alternatives!

### Additional context
Original discussion here:
https://github.com/Shopify/hydrogen/discussions/1790

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] ~Update docs in this repository according to your change~
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
