### PR TITLE
Do not cache 500 responses

### DIFF
--- a/.changeset/thirty-lies-fail.md
+++ b/.changeset/thirty-lies-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix: Hydrogen no longer caches 500 responses. Any 500 response will not have a cache control-header, nor will Hydrogen cache it internally.

--- a/.changeset/thirty-lies-fail.md
+++ b/.changeset/thirty-lies-fail.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix: Hydrogen no longer caches 500 responses. Any 500 response will not have a cache control-header, nor will Hydrogen cache it internally.
+Fix: Hydrogen no longer caches error responses. Any 400 or 500 level response will not have a cache control-header, nor will Hydrogen cache it internally.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -436,7 +436,9 @@ async function runSSR({
     const prepareForStreaming = () => {
       Object.assign(responseOptions, getResponseOptions(response, didError()));
 
-      if (responseOptions.status === 200) {
+      if (responseOptions.status >= 400) {
+        responseOptions.headers.set('cache-control', 'no-store');
+      } else {
         /**
          * TODO: This assumes `response.cache()` has been called _before_ any
          * queries which might be caught behind Suspense. Clarify this or add
@@ -450,8 +452,6 @@ async function runSSR({
           'cache-control',
           response.cacheControlHeader
         );
-      } else {
-        responseOptions.headers.set('cache-control', 'no-store');
       }
 
       if (isRedirect(responseOptions)) {
@@ -747,7 +747,9 @@ function writeHeadToNodeResponse(
     error
   );
 
-  if (status === 200) {
+  if (status >= 400) {
+    nodeResponse.setHeader('cache-control', 'no-store');
+  } else {
     /**
      * TODO: Also add `Vary` headers for `accept-language` and any other keys
      * we want to shard our full-page cache for all Hydrogen storefronts.
@@ -756,8 +758,6 @@ function writeHeadToNodeResponse(
       'cache-control',
       componentResponse.cacheControlHeader
     );
-  } else {
-    nodeResponse.setHeader('cache-control', 'no-store');
   }
 
   nodeResponse.statusCode = status;

--- a/packages/playground/server-components/src/routes/error-async.server.jsx
+++ b/packages/playground/server-components/src/routes/error-async.server.jsx
@@ -3,7 +3,7 @@ import {useQuery} from '@shopify/hydrogen';
 export default function Error() {
   useQuery(
     'async-error',
-    () => new Promise((resolve) => setTimeout(resolve, 1000))
+    () => new Promise((resolve) => setTimeout(resolve, 20))
   );
   // eslint-disable-next-line no-undef
   itBroke();

--- a/packages/playground/server-components/src/routes/error-async.server.jsx
+++ b/packages/playground/server-components/src/routes/error-async.server.jsx
@@ -1,0 +1,11 @@
+import {useQuery} from '@shopify/hydrogen';
+
+export default function Error() {
+  useQuery(
+    'async-error',
+    () => new Promise((resolve) => setTimeout(resolve, 1000))
+  );
+  // eslint-disable-next-line no-undef
+  itBroke();
+  return <div>Hi</div>;
+}

--- a/packages/playground/server-components/src/routes/error.server.jsx
+++ b/packages/playground/server-components/src/routes/error.server.jsx
@@ -1,0 +1,5 @@
+export default function Error() {
+  // eslint-disable-next-line no-undef
+  itBroke();
+  return <div>Hi</div>;
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -881,5 +881,11 @@ export default async function testCases({
       expect(response.status).toBe(500);
       expect(response.headers.get('cache-control')).toBe('no-store');
     });
+
+    it('responds with a 500 and no cache headers for bots', async () => {
+      const response = await fetch(getServerUrl() + '/async-error?_bot');
+      expect(response.status).toBe(500);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    });
   });
 }

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -860,4 +860,26 @@ export default async function testCases({
       ).toBeTruthy();
     });
   });
+
+  describe('Custom error apge', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('responds with a 500 and no cache headers', async () => {
+      const response = await fetch(getServerUrl() + '/error');
+      expect(response.status).toBe(500);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('responds with a 500 and no cache headers for bots', async () => {
+      const response = await fetch(getServerUrl() + '/error?_bot');
+      expect(response.status).toBe(500);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    });
+  });
 }

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -883,7 +883,7 @@ export default async function testCases({
     });
 
     it('responds with a 500 and no cache headers for bots', async () => {
-      const response = await fetch(getServerUrl() + '/async-error?_bot');
+      const response = await fetch(getServerUrl() + '/error-async?_bot');
       expect(response.status).toBe(500);
       expect(response.headers.get('cache-control')).toBe('no-store');
     });

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -882,7 +882,7 @@ export default async function testCases({
       expect(response.headers.get('cache-control')).toBe('no-store');
     });
 
-    it('responds with a 500 and no cache headers for bots', async () => {
+    it('responds with a 500 and no cache headers for bots on async pages', async () => {
       const response = await fetch(getServerUrl() + '/error-async?_bot');
       expect(response.status).toBe(500);
       expect(response.headers.get('cache-control')).toBe('no-store');

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -38,6 +38,7 @@ export default function Homepage() {
 }
 
 function HomepageContent() {
+  itBroke();
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},

--- a/templates/demo-store/src/routes/index.server.tsx
+++ b/templates/demo-store/src/routes/index.server.tsx
@@ -38,7 +38,6 @@ export default function Homepage() {
 }
 
 function HomepageContent() {
-  itBroke();
   const {
     language: {isoCode: languageCode},
     country: {isoCode: countryCode},


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix: Hydrogen no longer caches 500 responses. Any 500 response will not have a cache control-header, nor will Hydrogen cache it internally.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
