### PR TITLE
Doc edits for shopify-dev

### DIFF
--- a/docs/components/framework/form.md
+++ b/docs/components/framework/form.md
@@ -64,4 +64,4 @@ The `Form` component is a client component, so it renders on the client. For mor
 
 ## Related framework topics
 
-- [Forms and API Routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#concatenating-requests)
+- [Forms and API routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#concatenating-requests)

--- a/docs/components/framework/form.md
+++ b/docs/components/framework/form.md
@@ -1,7 +1,7 @@
 ---
 gid: 9120943b-00c9-4da3-a201-5a54cab6ca2a
 title: Form
-description: The Form provides a declarative way to perform mutations for creating, updating, and deleting data
+description: The Form provides a declarative way to perform mutations for creating, updating, and deleting data.
 ---
 
 <aside class="note beta">

--- a/docs/framework/css-support.md
+++ b/docs/framework/css-support.md
@@ -190,7 +190,7 @@ When the CSS mode is `modules-only`, styles are inlined in a `<style>` tag befor
 
 ### CSS-in-JS libraries
 
-Hydrogen supports CSS-in-JS libraries that emit `.css` files at build time via third-party Vite plugins. Please reach out to the library maintainers to ask for React Server Components support and feel free to tag the Hydrogen team.
+Hydrogen supports CSS-in-JS libraries that emit `.css` files at build time via third-party Vite plugins. Please reach out to the library maintainers to ask for React Server Components support, and feel free to tag the Hydrogen team (`@shopify/hydrogen`).
 
 However, CSS-in-JS libraries that collect styles at runtime aren't currently supported due to limitation integrating these libraries with React Server Components.
 

--- a/docs/framework/css-support.md
+++ b/docs/framework/css-support.md
@@ -190,7 +190,7 @@ When the CSS mode is `modules-only`, styles are inlined in a `<style>` tag befor
 
 ### CSS-in-JS libraries
 
-Hydrogen supports CSS-in-JS libraries that emit `.css` files at build time via third-party Vite plugins. Please, reach out to the library maintainers to ask for React Server Components support and feel free to tag the Hydrogen team.
+Hydrogen supports CSS-in-JS libraries that emit `.css` files at build time via third-party Vite plugins. Please reach out to the library maintainers to ask for React Server Components support and feel free to tag the Hydrogen team.
 
 However, CSS-in-JS libraries that collect styles at runtime aren't currently supported due to limitation integrating these libraries with React Server Components.
 

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -1,7 +1,7 @@
 ---
 gid: 9120943b-01c9-4da3-a201-5a54cab6ca2a
 title: Forms
-description: Learn how to run declarative mutations with the `Form` component and API routes
+description: Learn how to run declarative mutations with the Form component and API routes.
 ---
 
 <aside class="note beta">

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -11,7 +11,7 @@ description: Learn how to run declarative mutations with the Form component and 
 
 </aside>
 
-Within a Hydrogen app, [server components](https://shopify.dev/custom-storefronts/hydrogen/framework/work-with-rsc#fetching-data-on-the-server) fetch data and [API routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#api-routes) mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components. Hydrogen's `Form` component mimics the functionality of a native `<form>` element, while providing an enhanced experience with client-side JavaScript.
+Within a Hydrogen app, [server components](https://shopify.dev/custom-storefronts/hydrogen/framework/work-with-rsc#fetching-data-on-the-server) fetch data and [API routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#api-routes) mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components.
 
 ## HTML `form` element
 
@@ -235,6 +235,10 @@ export default function Product({product}) {
 
 The hidden input field for the `productId` is sent to the server when the **Add to cart** button is clicked. The API route at `/addToCart` can contain all the logic to add the product to the cart and re-render the page. The button is actionable before the page fully loads and the JavaScript is hydrated.
 
+## Related components
+
+- [`Form`](https://shopify.dev/api/hydrogen/components/framework/form).
+
 ## Next steps
 
-- Read the full API reference for the [`Form` component](https://shopify.dev/api/hydrogen/components/framework/form).
+- Learn more about [forms and API routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#concatenating-requests).

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -237,7 +237,11 @@ The hidden input field for the `productId` is sent to the server when the **Add 
 
 ## Related components
 
-- [`Form`](https://shopify.dev/api/hydrogen/components/framework/form).
+- [Form](https://shopify.dev/api/hydrogen/components/framework/form)
+
+## Related framework topics
+
+- [Routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes)
 
 ## Next steps
 

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -1,7 +1,7 @@
 ---
 gid: 9120943b-01c9-4da3-a201-5a54cab6ca2a
 title: Forms
-description: Declarative mutations with `Form` and API Routes
+description: Learn how to run declarative mutations with the `Form` component and API routes
 ---
 
 <aside class="note beta">
@@ -11,11 +11,11 @@ description: Declarative mutations with `Form` and API Routes
 
 </aside>
 
-Within a Hydrogen App, [Server components](https://shopify.dev/custom-storefronts/hydrogen/framework/work-with-rsc#fetching-data-on-the-server) are used to fetch data and [API Routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#api-routes) to mutate data. The `Form` component provides a declarative way to send data to API Routes, and re-render server components.
+Within a Hydrogen app, [server components](https://shopify.dev/custom-storefronts/hydrogen/framework/work-with-rsc#fetching-data-on-the-server) fetch data and [API routes](https://shopify.dev/custom-storefronts/hydrogen/framework/routes#api-routes) mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components. Hydrogen's `Form` component mimics the functionality of a native `<form>` element, while providing an enhanced experience with client-side JavaScript.
 
-## HTML `<form>`
+## HTML `form` element
 
-The `Form` builds upon native `<form>` elements:
+The `Form` component builds on the native HTML `<form>` element. The following is an example:
 
 {% codeblock file, filename: 'index.html' %}
 
@@ -29,18 +29,18 @@ The `Form` builds upon native `<form>` elements:
 
 {% endcodeblock %}
 
-This example HTML doesn't run any JavaScript. When **Submit** is clicked, the browser sends a `POST` request to `/login` with each form field encoded. The browser also reloads the entire page to display the server's response. Read more about [native HTML forms](https://developer.mozilla.org/en-US/docs/Learn/Forms).
+This example HTML doesn't run any JavaScript. When **Submit** is clicked, the browser sends a `POST` request to `/login` with each form field encoded. The browser also reloads the entire page to display the server's response. Learn more about [native HTML forms](https://developer.mozilla.org/en-US/docs/Learn/Forms).
 
-## Hydrogen `Form`
+## Hydrogen `Form` component
 
-Native HTML forms work without JavaScript. However, Javascript can provide the following improvements:
+Hydrogen's `Form` component mimics the functionality of a native `<form>` element, while providing an enhanced experience with client-side JavaScript.
+
+Native HTML forms work without JavaScript. However, JavaScript can provide the following improvements:
 
 - **Performance**: JavaScript prevents the entire page from reloading to display responses from the server.
 - **UX**: JavaScript provides client-side validation and feedback. Client-side validation is quicker than making a round trip to the server, and feedback helps the user know when the form is in the process of submitting.
 
-Hydrogen's `Form` component mimics the functionality of a native `<form>` element, while providing an enhanced user experience with client-side JavaScript.
-
-The following example rewrites the [example form element](#html-form) by substituting the native HTML with a `Form` component that's imported from Hydrogen:
+The following example rewrites the [example form element](#html-form-element) by substituting the native HTML with a `Form` component that's imported from Hydrogen:
 
 {% codeblock file, filename: 'login.server.jsx' %}
 
@@ -96,7 +96,7 @@ export async function api(request, {session}) {
 
 {% endcodeblock %}
 
-Read data in the API route from the `Form` by using the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API. The API Route must respond with a `new Request()`. This renders the server components for the given page. You can re-render the current page, or render an entirely different page in the app.
+Read data in the API route from the `Form` by using the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API. The API route must respond with a `new Request()`. This renders the server components for the given page. You can re-render the current page, or render an entirely different page in the app.
 
 In the previous example, when the user is not found, the current page is re-rendered with a search parameter. The following code updates the server component to render the login error:
 
@@ -237,4 +237,4 @@ The hidden input field for the `productId` is sent to the server when the **Add 
 
 ## Next steps
 
-Read the full API reference for the [`Form` component](https://shopify.dev/api/hydrogen/components/framework/form).
+- Read the full API reference for the [`Form` component](https://shopify.dev/api/hydrogen/components/framework/form).

--- a/docs/framework/routes.md
+++ b/docs/framework/routes.md
@@ -458,3 +458,4 @@ export async function api(
 - Learn how to manage [cache options](https://shopify.dev/custom-storefronts/hydrogen/framework/cache) for Hydrogen storefronts.
 - Improve your app's loading performance with [streaming SSR and Suspense](https://shopify.dev/custom-storefronts/hydrogen/framework/streaming-ssr).
 - Learn how to [manage your server props](https://shopify.dev/custom-storefronts/hydrogen/framework/server-props) during your development process.
+- Learn more about [forms](https://shopify.dev/custom-storefronts/hydrogen/framework/forms).

--- a/docs/framework/routes.md
+++ b/docs/framework/routes.md
@@ -450,6 +450,7 @@ export async function api(
 - [`useQuery`](https://shopify.dev/api/hydrogen/hooks/global/usequery)
 - [`useShopQuery`](https://shopify.dev/api/hydrogen/hooks/global/useshopquery)
 - [`fetchSync`](https://shopify.dev/api/hydrogen/hooks/global/fetchsync)
+- [`Form`](https://shopify.dev/api/hydrogen/components/framework/form)
 
 ## Next steps
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

## This PR:

- Addresses PR comments made in https://github.com/Shopify/shopify-dev/pull/23656/files, which regenerates the Hydrogen docs for 1.2.
- Fixes the broken anchor link (see PR ^)
- Applies some nitty style and copy edits



### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)

## 🎩 

[Staging site](https://shopify-dev-staging2.shopifycloud.com/custom-storefronts/hydrogen)