### PR TITLE
Add flash session data

### DIFF
--- a/.changeset/sweet-pugs-enjoy.md
+++ b/.changeset/sweet-pugs-enjoy.md
@@ -20,7 +20,7 @@ export default function Login() {
   );
 }
 
-export async function api(request) {
+export async function api(request, {session}) {
   const data = await request.formData();
   const username = data.get('username');
   const password = data.get('password');

--- a/.changeset/sweet-pugs-enjoy.md
+++ b/.changeset/sweet-pugs-enjoy.md
@@ -1,0 +1,40 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add the experimental `useFlashSession` hook. This hook reads and clears a session value. It is useful for request validation within the experimental `<Form>` component:
+
+```ts
+import {Form, useFlashSession} from '@shopify/hydrogen/experimental';
+
+export default function Login() {
+  const loginError = useFlashSession('loginError');
+
+  return (
+    <Form action="/login">
+      {loginError ? <div>Invalid user!</div> : null}
+      <input type="text" name="username" />
+      <input type="password" name="password" />
+      <button type="submit">Login</button>
+    </Form>
+  );
+}
+
+export async function api(request) {
+  const data = await request.formData();
+  const username = data.get('username');
+  const password = data.get('password');
+
+  const userId = await getUser(username, password);
+
+  if (!userId) {
+    await session.set('loginError', 'INVALID_USER');
+    return new Request('/login');
+  } else {
+    await session.set('userId', userId);
+    return new Request('/account');
+  }
+}
+```
+
+Note, `useFlashSession` is experimental, and subject to change at any time.

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -107,8 +107,8 @@ In the previous example, when the user is not found, the current page is re-rend
 import {Form, useFlashSession} from '@shopify/hydrogen/experimental';
 
 export default function Login() {
-  // `useFlashSession` also clears the value after reading it. This makes it
-  // so that if the user refreshes the page, the validation error goes away.
+  // `useFlashSession` also clears the value after reading it. This way,
+  // if the user refreshes the page, the validation error goes away.
   const loginError = useFlashSession('loginError');
 
   return (
@@ -130,7 +130,7 @@ export default function Login() {
 
 {% endcodeblock %}
 
-The page initially loads without a session loginError value. If the login mutation fails, then the server components re-render with the `loginError` session value and display a message to the user. Because it uses `useFlashSession`, instead of `useSession`, the value is subsequently cleared. If the user refreshes the page, the validation error goes away.
+The page initially loads without a session `loginError` value. If the login mutation fails, then the server components re-render with the `loginError` session value and display a message to the user. Because it uses `useFlashSession` instead of `useSession`, the value is subsequently cleared. If the user refreshes the page, then the validation error goes away.
 
 ## Client validation and feedback
 

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -130,7 +130,7 @@ export default function Login() {
 
 {% endcodeblock %}
 
-The page initially loads without a session `loginError` value. If the login mutation fails, then the server components re-render with the `loginError` session value and display a message to the user. Because it uses `useFlashSession` instead of `useSession`, the value is subsequently cleared. If the user refreshes the page, then the validation error goes away.
+The page initially loads without a session `loginError` value. If the login mutation fails, then the server components re-render with the `loginError` session value and display a message to the user. Because the component uses `useFlashSession` instead of `useSession`, the value is subsequently cleared. If the user refreshes the page, then the validation error goes away.
 
 ## Client validation and feedback
 

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -83,6 +83,7 @@ export async function api(request, {session}) {
   if (!userId) {
     // We couldn't find the user.
     // Re-render the login page with a login error displayed
+    await session.set('loginError', true);
     return new Request('/login?error');
   }
 
@@ -98,15 +99,18 @@ export async function api(request, {session}) {
 
 Read data in the API route from the `Form` by using the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API. The API route must respond with a `new Request()`. This renders the server components for the given page. You can re-render the current page, or render an entirely different page in the app.
 
-In the previous example, when the user is not found, the current page is re-rendered with a search parameter. The following code updates the server component to render the login error:
+In the previous example, when the user is not found, the current page is re-rendered with an error set on the session. The following code updates the server component to render the login error:
 
 {% codeblock file, filename: 'login.server.jsx' %}
 
 ```tsx
-import {Form} from '@shopify/hydrogen/experimental';
+import {Form, useFlashSession} from '@shopify/hydrogen/experimental';
 
 export default function Login() {
-  const url = useUrl();
+  // `useFlashSession` also clears the value after reading it. This makes it
+  // so that if the user refreshes the page, the validation error goes away.
+  const loginError = useFlashSession('loginError');
+
   return (
     <Form action="/login" method="post">
       <label>
@@ -115,7 +119,7 @@ export default function Login() {
       <label>
         Password <input type="password" name="password" />
       </label>
-      {url.searchParams.get('error') ? (
+      {loginError ? (
         <h2 className="text-red-700">Invalid username or password</h2>
       ) : null}
       <button type="submit">Submit</button>
@@ -126,9 +130,7 @@ export default function Login() {
 
 {% endcodeblock %}
 
-The page initially loads without a search parameter. If the login mutation fails, then the server components re-render with the `error` search parameter and display a message to the user.
-
-The downside to this approach is that the error state is within the URL, which means the error message persists if the page is refreshed. This won't be a problem with flashed session data.
+The page initially loads without a session loginError value. If the login mutation fails, then the server components re-render with the `loginError` session value and display a message to the user. Because it uses `useFlashSession`, instead of `useSession`, the value is subsequently cleared. If the user refreshes the page, the validation error goes away.
 
 ## Client validation and feedback
 

--- a/docs/framework/forms.md
+++ b/docs/framework/forms.md
@@ -84,7 +84,7 @@ export async function api(request, {session}) {
     // We couldn't find the user.
     // Re-render the login page with a login error displayed
     await session.set('loginError', true);
-    return new Request('/login?error');
+    return new Request('/login');
   }
 
   // Save the user to the session

--- a/docs/hooks/framework/useflashsession.md
+++ b/docs/hooks/framework/useflashsession.md
@@ -15,7 +15,7 @@ The `useFlashSession` hook reads session data and subsequently clears it in serv
 
 ## Example code
 
-{% codeblock file, filename: 'component.server.jsx' %}
+{% codeblock file, filename: 'src/component.server.jsx' %}
 
 ```jsx
 import {Form, useFlashSession} from '@shopify/hydrogen/experimental';
@@ -54,7 +54,7 @@ export async function api(request) {
 
 ## Return value
 
-The `useFlashSession` hook returns data from the session. It also clears that data so that it will be gone the next time it is read.
+The `useFlashSession` hook returns data from the session. It also clears that data so that it will be gone the next time that it's read.
 
 ## Considerations
 

--- a/docs/hooks/framework/useflashsession.md
+++ b/docs/hooks/framework/useflashsession.md
@@ -33,7 +33,7 @@ export default function Login() {
   );
 }
 
-export async function api(request) {
+export async function api(request, {session}) {
   const data = await request.formData();
   const username = data.get('username');
   const password = data.get('password');

--- a/docs/hooks/framework/useflashsession.md
+++ b/docs/hooks/framework/useflashsession.md
@@ -1,0 +1,70 @@
+---
+gid: 17707d5c-4c7c-49f0-8cff-e29d15dfa2f9
+title: useFlashSession
+description: The useFlashSession hook reads session data and subsequently clears it in server components.
+---
+
+<aside class="note beta">
+<h4>Experimental feature</h4>
+
+<p><code>useFlashSession</code> is an experimental feature. As a result, functionality is subject to change. You can provide feedback on this feature by <a href="https://github.com/Shopify/hydrogen/issues">submitting an issue in GitHub</a>.</p>
+
+</aside>
+
+The `useFlashSession` hook reads session data and subsequently clears it in server components.
+
+## Example code
+
+{% codeblock file, filename: 'component.server.jsx' %}
+
+```jsx
+import {Form, useFlashSession} from '@shopify/hydrogen/experimental';
+
+export default function Login() {
+  const loginError = useFlashSession('loginError');
+
+  return (
+    <Form action="/login">
+      {loginError ? <div>Invalid user!</div> : null}
+      <input type="text" name="username" />
+      <input type="password" name="password" />
+      <button type="submit">Login</button>
+    </Form>
+  );
+}
+
+export async function api(request) {
+  const data = await request.formData();
+  const username = data.get('username');
+  const password = data.get('password');
+
+  const userId = await getUser(username, password);
+
+  if (!userId) {
+    await session.set('loginError', 'INVALID_USER');
+    return new Request('/login');
+  } else {
+    await session.set('userId', userId);
+    return new Request('/account');
+  }
+}
+```
+
+{% endcodeblock %}
+
+## Return value
+
+The `useFlashSession` hook returns data from the session. It also clears that data so that it will be gone the next time it is read.
+
+## Considerations
+
+The `useFlashSession` hook is best used for form validation in the [`Form`](https://shopify.dev/api/hydrogen/components/framework/form) component.
+
+## Related components
+
+- [`Form`](https://shopify.dev/api/hydrogen/components/framework/form)
+
+## Related framework topics
+
+- [Forms](https://shopify.dev/api/hydrogen/components/framework/forms)
+- [Session management](https://shopify.dev/custom-storefronts/hydrogen/framework/sessions)

--- a/packages/hydrogen/src/constants.ts
+++ b/packages/hydrogen/src/constants.ts
@@ -7,6 +7,7 @@ export const STOREFRONT_API_SECRET_TOKEN_HEADER =
   'Shopify-Storefront-Private-Token';
 export const STOREFRONT_API_PUBLIC_TOKEN_HEADER =
   'X-Shopify-Storefront-Access-Token';
+export const FORM_REDIRECT_COOKIE = 'Hydrogen-Redirect';
 export const STOREFRONT_API_BUYER_IP_HEADER = 'Shopify-Storefront-Buyer-IP';
 export const SHOPIFY_STOREFRONT_ID_VARIABLE = 'SHOPIFY_STOREFRONT_ID';
 export const SHOPIFY_STOREFRONT_ID_HEADER = 'Shopify-Storefront-Id';

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -106,6 +106,7 @@ export const renderHydrogen = (App: any) => {
 
     if (request.cookies.get(FORM_REDIRECT_COOKIE)) {
       response.headers.set('SET-COOKIE', `${FORM_REDIRECT_COOKIE}=`);
+      response.doNotStream();
     }
 
     if (hydrogenConfig.poweredByHeader ?? true) {
@@ -363,7 +364,7 @@ async function runSSR({
 
   const AppSSR = (
     <Html
-      template={shouldStream(request, response) ? noScriptTemplate : template}
+      template={response.canStream() ? noScriptTemplate : template}
       hydrogenConfig={request.ctx.hydrogenConfig!}
     >
       <ServerRequestProvider request={request}>
@@ -382,7 +383,7 @@ async function runSSR({
 
   log.trace('start ssr');
 
-  const rscReadable = shouldStream(request, response)
+  const rscReadable = response.canStream()
     ? new ReadableStream({
         start(controller) {
           log.trace('rsc start chunks');
@@ -434,7 +435,7 @@ async function runSSR({
       );
     }
 
-    if (shouldStream(request, response)) log.trace('worker ready to stream');
+    if (response.canStream()) log.trace('worker ready to stream');
     ssrReadable.allReady.then(() => log.trace('worker complete ssr'));
 
     const prepareForStreaming = () => {
@@ -474,7 +475,7 @@ async function runSSR({
       return true;
     };
 
-    const shouldFlushBody = shouldStream(request, response)
+    const shouldFlushBody = response.canStream()
       ? prepareForStreaming()
       : await ssrReadable.allReady.then(prepareForStreaming);
 
@@ -484,7 +485,7 @@ async function runSSR({
 
       const writingSSR = bufferReadableStream(
         ssrReadable.getReader(),
-        shouldStream(request, response)
+        response.canStream()
           ? (chunk) => {
               bufferedSsr += chunk;
 
@@ -507,13 +508,13 @@ async function runSSR({
 
       const writingRSC = bufferReadableStream(
         rscReadable.getReader(),
-        shouldStream(request, response)
+        response.canStream()
           ? (scriptTag) => writable.write(encoder.encode(scriptTag))
           : undefined
       );
 
       Promise.all([writingSSR, writingRSC]).then(([ssrHtml, rscPayload]) => {
-        if (!shouldStream(request, response)) {
+        if (!response.canStream()) {
           const html = assembleHtml({ssrHtml, rscPayload, request, template});
           writable.write(encoder.encode(html));
         }
@@ -532,7 +533,7 @@ async function runSSR({
       postRequestTasks('str', responseOptions.status, request, response);
     }
 
-    if (shouldStream(request, response)) {
+    if (response.canStream()) {
       return new Response(transform.readable, responseOptions);
     }
 
@@ -568,7 +569,7 @@ async function runSSR({
           return nodeResponse.end();
         }
 
-        if (!shouldStream(request, response)) return;
+        if (!response.canStream()) return;
 
         startWritingToNodeResponse(nodeResponse, dev ? didError() : undefined);
 
@@ -587,7 +588,7 @@ async function runSSR({
 
         if (
           !revalidate &&
-          (shouldStream(request, response) || nodeResponse.writableEnded)
+          (response.canStream() || nodeResponse.writableEnded)
         ) {
           postRequestTasks('str', nodeResponse.statusCode, request, response);
           return;
@@ -949,11 +950,4 @@ async function saveCacheResponse(
     );
     deleteItemFromCache(request.cacheKey(true));
   }
-}
-
-function shouldStream(
-  request: HydrogenRequest,
-  response: HydrogenResponse
-): boolean {
-  return !request.cookies.get(FORM_REDIRECT_COOKIE) && response.canStream();
 }

--- a/packages/hydrogen/src/experimental.ts
+++ b/packages/hydrogen/src/experimental.ts
@@ -1,1 +1,2 @@
 export {Form} from './foundation/Form/Form.client.js';
+export {useFlashSession} from './foundation/useSession/useSession.js';

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -77,6 +77,7 @@ export class HydrogenRequest extends Request {
     router: RouterContextData;
     buyerIpHeader?: string;
     session?: SessionSyncApi;
+    flashSession: Record<string, any>;
     runtime?: RuntimeContext;
     scopes: Map<string, Record<string, any>>;
     localization?: LocalizationContextValue;
@@ -114,6 +115,7 @@ export class HydrogenRequest extends Request {
       },
       preloadQueries: new Map(),
       scopes: new Map(),
+      flashSession: {},
     };
     this.cookies = this.parseCookies();
   }

--- a/packages/hydrogen/src/foundation/session/session-types.ts
+++ b/packages/hydrogen/src/foundation/session/session-types.ts
@@ -1,11 +1,13 @@
 export type SessionSyncApi = {
   get: () => Record<string, string>;
+  set: (data: Record<string, any>) => any;
 };
 
 export type SessionApi = {
   get: () => Promise<Record<string, string>>;
   set: (key: string, value: string) => Promise<void>;
   destroy: () => Promise<void>;
+  getFlash: (key: string) => any;
 };
 
 export type SessionStorageAdapter = {

--- a/packages/hydrogen/src/foundation/session/session.ts
+++ b/packages/hydrogen/src/foundation/session/session.ts
@@ -24,12 +24,26 @@ export function getSyncSessionApi(
           }
           return sessionPromises.getPromise.read();
         },
+        set(data: Record<string, any>) {
+          if (!sessionPromises.setPromise) {
+            sessionPromises.setPromise = wrapPromise(
+              session.set(request, data)
+            );
+          }
+          const cookie = sessionPromises.setPromise.read();
+          componentResponse.headers.set('Set-Cookie', cookie);
+          return cookie;
+        },
       }
     : emptySyncSessionImplementation(log);
 }
 
 export const emptySessionImplementation = function (log: Logger) {
   return {
+    async getFlash(key: string) {
+      log.warn('No session adapter has been configured!');
+      return null;
+    },
     async get() {
       log.warn('No session adapter has been configured!');
       return {};
@@ -49,6 +63,10 @@ export const emptySyncSessionImplementation = function (log: Logger) {
     get() {
       log.warn('No session adapter has been configured!');
       return {};
+    },
+    set(data: Record<string, any>) {
+      log.warn('No session adapter has been configured!');
+      return null;
     },
   };
 };

--- a/packages/hydrogen/src/foundation/useSession/useSession.ts
+++ b/packages/hydrogen/src/foundation/useSession/useSession.ts
@@ -6,3 +6,20 @@ export const useSession = function () {
   const session = request.ctx.session?.get() || {};
   return session;
 };
+
+export const useFlashSession = function (key: string) {
+  const request = useServerRequest();
+  const data = request.ctx.session?.get() || {};
+  let value = data[key];
+
+  if (value) {
+    delete data[key];
+    request.ctx.flashSession[key] = value;
+  }
+  request.ctx.session?.set(data);
+
+  value = request.ctx.flashSession[key];
+  delete request.ctx.flashSession[key];
+
+  return value;
+};

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -1,6 +1,5 @@
 /**
- * Export all client components from here to ensure they're available in both import
- * paths. This is because we transform `@shopify/hydrogen` to `@shopify/hydrogen/client`
+ * Export all client components from here to ensure they're available in both import * paths. This is because we transform `@shopify/hydrogen` to `@shopify/hydrogen/client`
  * inside client components during the client build only, but when the same components
  * run during SSR, they reference this path.
  */
@@ -44,7 +43,10 @@ export {useRequestContext} from './foundation/useRequestContext/index.js';
 export {useServerAnalytics} from './foundation/Analytics/hook.js';
 export {ShopifyAnalytics} from './foundation/Analytics/connectors/Shopify/ShopifyAnalytics.server.js';
 export {ShopifyAnalyticsConstants} from './foundation/Analytics/connectors/Shopify/const.js';
-export {useSession} from './foundation/useSession/useSession.js';
+export {
+  useSession,
+  useFlashSession,
+} from './foundation/useSession/useSession.js';
 export {Cookie} from './foundation/Cookie/Cookie.js';
 
 /**

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -1,5 +1,6 @@
 /**
- * Export all client components from here to ensure they're available in both import * paths. This is because we transform `@shopify/hydrogen` to `@shopify/hydrogen/client`
+ * Export all client components from here to ensure they're available in both import
+ * paths. This is because we transform `@shopify/hydrogen` to `@shopify/hydrogen/client`
  * inside client components during the client build only, but when the same components
  * run during SSR, they reference this path.
  */

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -43,10 +43,7 @@ export {useRequestContext} from './foundation/useRequestContext/index.js';
 export {useServerAnalytics} from './foundation/Analytics/hook.js';
 export {ShopifyAnalytics} from './foundation/Analytics/connectors/Shopify/ShopifyAnalytics.server.js';
 export {ShopifyAnalyticsConstants} from './foundation/Analytics/connectors/Shopify/const.js';
-export {
-  useSession,
-  useFlashSession,
-} from './foundation/useSession/useSession.js';
+export {useSession} from './foundation/useSession/useSession.js';
 export {Cookie} from './foundation/Cookie/Cookie.js';
 
 /**

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -17,7 +17,7 @@ import type {
 } from '../foundation/session/session-types.js';
 import {emptySessionImplementation} from '../foundation/session/session.js';
 import {UseShopQueryResponse} from '../hooks/useShopQuery/hooks.js';
-import {RSC_PATHNAME} from '../constants.js';
+import {FORM_REDIRECT_COOKIE, RSC_PATHNAME} from '../constants.js';
 
 let memoizedApiRoutes: Array<HydrogenApiRoute> = [];
 let memoizedRawRoutes: ImportGlobEagerOutput = {};
@@ -293,6 +293,7 @@ export async function renderApiRoute(
       // Doing so prevents odd refresh / back behavior. The redirect response also should *never* be cached.
       response.headers.set('Location', newUrl.href);
       response.headers.set('Cache-Control', 'no-store');
+      response.headers.append('Set-Cookie', `${FORM_REDIRECT_COOKIE}=1`);
 
       return new Response(null, {
         status: 303,

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -217,6 +217,15 @@ export async function renderApiRoute(
       hydrogenConfig,
       session: session
         ? {
+            async getFlash(key: string) {
+              const data = await session.get(request);
+              const value = data[key];
+              if (value) {
+                delete data[key];
+                await session.set(request, data);
+              }
+              return value;
+            },
             async get() {
               return session.get(request);
             },

--- a/packages/playground/server-components/src/routes/account.server.jsx
+++ b/packages/playground/server-components/src/routes/account.server.jsx
@@ -1,4 +1,5 @@
-import {useSession, useFlashSession} from '@shopify/hydrogen';
+import {useSession} from '@shopify/hydrogen';
+import {useFlashSession} from '@shopify/hydrogen/experimental';
 import {Form} from '@shopify/hydrogen/experimental';
 import {
   LoginForm,

--- a/packages/playground/server-components/src/routes/account.server.jsx
+++ b/packages/playground/server-components/src/routes/account.server.jsx
@@ -1,4 +1,4 @@
-import {useSession, useUrl} from '@shopify/hydrogen';
+import {useSession, useFlashSession} from '@shopify/hydrogen';
 import {Form} from '@shopify/hydrogen/experimental';
 import {
   LoginForm,
@@ -18,8 +18,7 @@ const users = [
 
 export default function Account() {
   const {user} = useSession();
-  const url = useUrl();
-  const loginError = url.searchParams.get(LOGIN_ERROR);
+  const loginError = useFlashSession(LOGIN_ERROR);
 
   if (user)
     return (
@@ -54,10 +53,12 @@ export async function api(request, {session}) {
   const password = data.get('password');
 
   if (!username) {
-    return new Request(`/account?${LOGIN_ERROR}=${INVALID_USERNAME}`);
+    await session.set(LOGIN_ERROR, INVALID_USERNAME);
+    return new Request(`/account`);
   }
   if (!password) {
-    return new Request(`/account?${LOGIN_ERROR}=${INVALID_PASSWORD}`);
+    await session.set(LOGIN_ERROR, INVALID_PASSWORD);
+    return new Request(`/account`);
   }
 
   const user = users.find(
@@ -65,7 +66,8 @@ export async function api(request, {session}) {
   );
 
   if (!user) {
-    return new Request(`/account?${LOGIN_ERROR}=${INVALID_USER}`);
+    await session.set(LOGIN_ERROR, INVALID_USER);
+    return new Request(`/account`);
   }
 
   await session.set('user', user.username);

--- a/packages/playground/server-components/src/routes/sessions/flash.server.jsx
+++ b/packages/playground/server-components/src/routes/sessions/flash.server.jsx
@@ -1,0 +1,6 @@
+import {useFlashSession} from '@shopify/hydrogen';
+
+export default function Flash() {
+  const someData = useFlashSession('someData');
+  return <h1>Session Data: {someData}</h1>;
+}

--- a/packages/playground/server-components/src/routes/sessions/flash.server.jsx
+++ b/packages/playground/server-components/src/routes/sessions/flash.server.jsx
@@ -1,4 +1,4 @@
-import {useFlashSession} from '@shopify/hydrogen';
+import {useFlashSession} from '@shopify/hydrogen/experimental';
 
 export default function Flash() {
   const someData = useFlashSession('someData');

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -724,6 +724,22 @@ export default async function testCases({
       expect(response.status).toBe(200);
       expect(text).toContain(`some value`);
     });
+
+    it('clears flash session data after read', async () => {
+      const response = await fetch(getServerUrl() + '/sessions/flash', {
+        headers: {
+          cookie: '__session=%7B%22someData%22%3A%22some%20value%22%7D',
+        },
+      });
+
+      const text = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Set-Cookie')).toBe(
+        '__session=%7B%7D; Expires=Sun, 08 Jun 2025 00:39:38 GMT'
+      );
+      expect(text).toContain(`some value`);
+    });
   });
 
   describe('Shopify analytics', () => {

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -728,7 +728,9 @@ export default async function testCases({
     it('clears flash session data after read', async () => {
       const response = await fetch(getServerUrl() + '/sessions/flash', {
         headers: {
-          cookie: '__session=%7B%22someData%22%3A%22some%20value%22%7D',
+          cookie:
+            '__session=%7B%22someData%22%3A%22some%20value%22%7D' +
+            ';Hydrogen-Redirect=1',
         },
       });
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add the experimental `useFlashSession` hook. This hook reads and clears a session value. It is useful for request validation within the experimental `<Form>` component:

```ts
import {Form, useFlashSession} from '@shopify/hydrogen/experimental';

export default function Login() {
  const loginError = useFlashSession('loginError');

  return (
    <Form action="/login">
      {loginError ? <div>Invalid user!</div> : null}
      <input type="text" name="username" />
      <input type="password" name="password" />
      <button type="submit">Login</button>
    </Form>
  );
}

export async function api(request) {
  const data = await request.formData();
  const username = data.get('username');
  const password = data.get('password');

  const userId = await getUser(username, password);

  if (!userId) {
    await session.set('loginError', 'INVALID_USER');
    return new Request('/login');
  } else {
    await session.set('userId', userId);
    return new Request('/account');
  }
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
