### PR TITLE
Fix snapshot release

### DIFF
--- a/.changeset/empty-humans-wink.md
+++ b/.changeset/empty-humans-wink.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-- Log detailed error message for Storefront API root errors
+Log detailed error message for Storefront API root errors

--- a/.github/releasing.md
+++ b/.github/releasing.md
@@ -21,6 +21,8 @@ To release an unstable version:
 1. Merge your changes into the `unstable` branch.
 1. Visit the [Changesets Snapshot](https://github.com/Shopify/hydrogen/actions/workflows/changesets_snapshot.yml) GitHub Action workflow.
 1. Click "Run Workflow." Be sure to select `unstable` as the branch name.
+1. A new branch and pull request into the `unstable` branch will be created. If that unstable release branch looks good, merge it.
+1. Manually release the unstable version on NPM by repeating steps 2 and 3.
 
 A new snapshot release will be created with your changes and tagged on NPM with `unstable`. You can install the unstable version of Hydrogen using this tag:
 

--- a/.github/workflows/changesets_snapshot.yml
+++ b/.github/workflows/changesets_snapshot.yml
@@ -32,9 +32,10 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: yarn run version --snapshot ${{ github.ref_name }}
+          version: yarn run version:snapshot --snapshot ${{ github.ref_name }}
           publish: yarn changeset publish --no-git-tag --tag ${{ github.ref_name }}
           commit: '[ci] release ${{ github.ref_name }}'
+          title: '${{ github.ref_name }} release'
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:vite-ci": "cross-env FORCE_COLOR=true jest && jest --config jest-e2e.config.ts",
     "test:hydrogen:vite": "yarn workspace @shopify/hydrogen test:vitest:ci",
     "test:hydrogen-ui": "yarn workspace @shopify/hydrogen-ui test:ci",
+    "version:snapshot": "changeset version",
     "version": "changeset version && node -p \"'export const LIB_VERSION = \\'' + require('./packages/hydrogen/package.json').version + '\\';'\" > packages/hydrogen/src/version.ts",
     "generate-docs": "node ./scripts/generate-docs.mjs",
     "graphql-types": "run-s graphql-types:hydrogen lint:schema",


### PR DESCRIPTION
### Description

`--snapshot` doesn't get properly passed to the `changeset version` command with the `&&` with the second node command. I'm not sure how to best pass the `snapshot` variable while preserving the second command. For now, I don't think the `LIB_VERSION` is that important, it is only used as a header in our underlying fetch implementation. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
