### PR TITLE
Expose inner form ref in <Form>

### DIFF
--- a/.changeset/giant-crews-juggle.md
+++ b/.changeset/giant-crews-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': major
+---
+
+The `<Form>` ref is now forwarded to the native `<form>` element. This is useful to allow users to interact with the form programatically, for example, calling `form.submit()`.

--- a/packages/hydrogen/src/foundation/Form/Form.client.tsx
+++ b/packages/hydrogen/src/foundation/Form/Form.client.tsx
@@ -12,15 +12,18 @@ interface FormProps {
   noValidate?: boolean;
 }
 
-export function Form({
-  action,
-  method,
-  children,
-  onSubmit,
-  encType = 'application/x-www-form-urlencoded',
-  noValidate,
-  ...props
-}: FormProps) {
+export const Form = React.forwardRef<HTMLFormElement, FormProps>(function Form(
+  {
+    action,
+    method,
+    children,
+    onSubmit,
+    encType = 'application/x-www-form-urlencoded',
+    noValidate,
+    ...props
+  },
+  ref
+) {
   const {setRscResponseFromApiRoute} = useInternalServerProps();
   const [_, startTransition] = (React as any).useTransition();
   const [loading, setLoading] = useState(false);
@@ -80,6 +83,7 @@ export function Form({
 
   return (
     <form
+      ref={ref}
       action={action}
       method={method}
       onSubmit={submit}
@@ -90,4 +94,4 @@ export function Form({
       {children instanceof Function ? children({loading, error}) : children}
     </form>
   );
-}
+});

--- a/packages/hydrogen/src/foundation/Form/tests/Form.client.test.tsx
+++ b/packages/hydrogen/src/foundation/Form/tests/Form.client.test.tsx
@@ -44,6 +44,26 @@ describe('<Form>', () => {
     });
   });
 
+  it('forwards the ref', (done) => {
+    mountWithProviders(
+      <Form
+        action="/account"
+        method="POST"
+        ref={(ref) => {
+          try {
+            expect(ref).toBeInstanceOf(HTMLFormElement);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }}
+      >
+        <input type="text" name="username" defaultValue="test" />
+        <button type="submit">Submit</button>
+      </Form>
+    );
+  });
+
   it('submits the form with a fetch', () => {
     const component = mountWithProviders(
       <Form action="/account" method="POST">


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I have some forms that I need to auto submit (i.e. `onChange={() => formRef.current.submit()}`), but can't do it when using the `<Form>` component (which offers a nicer UX than regular `<form>`).

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
