### PR TITLE
Add null check for `waitUntil`

### DIFF
--- a/.changeset/dull-mirrors-care.md
+++ b/.changeset/dull-mirrors-care.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add null check for `runtime.waitUntil`

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -184,7 +184,7 @@ export const renderHydrogen = (App: any) => {
           });
 
           // Asynchronously wait for it in workers
-          request.ctx.runtime?.waitUntil(staleWhileRevalidatePromise);
+          request.ctx.runtime?.waitUntil?.(staleWhileRevalidatePromise);
         }
 
         return cachedResponse;
@@ -900,7 +900,7 @@ async function cacheResponse(
       const cachePutPromise = Promise.resolve(true).then(() =>
         saveCacheResponse(response, request, chunks)
       );
-      request.ctx.runtime?.waitUntil(cachePutPromise);
+      request.ctx.runtime?.waitUntil?.(cachePutPromise);
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently requests fail if `ctx.runtime` exists but doesn't include `waitUntil` which is a Cloudflare-specific function. Netlify includes a runtime object but not `waitUntil`. This PR adds an optional chain for the `waitUntil` function.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
