### PR TITLE
Adding time-slicing with `startTransition` to prevent hydration from blocking the main thread for too long for those users who immediately scroll.

### DIFF
--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -5,8 +5,8 @@ import {
   addImageSizeParametersToUrl,
   IMG_SRC_SET_SIZES,
 } from '../../utilities/index.js';
-import type { Image as ImageType } from '../../storefront-api-types.js';
-import type { PartialDeep, Simplify, SetRequired } from 'type-fest';
+import type {Image as ImageType} from '../../storefront-api-types.js';
+import type {PartialDeep, Simplify, SetRequired} from 'type-fest';
 
 type HtmlImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
 
@@ -94,7 +94,6 @@ function ShopifyImage({
   loader = shopifyImageLoader,
   loaderOptions,
   widths,
-  decoding = "async",
   ...rest
 }: ShopifyImageProps) {
   if (!data.url) {
@@ -103,12 +102,13 @@ function ShopifyImage({
 
   if (__HYDROGEN_DEV__ && !data.altText && !rest.alt) {
     console.warn(
-      `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. ${`Image: ${data.id ?? data.url
+      `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. ${`Image: ${
+        data.id ?? data.url
       }`}`
     );
   }
 
-  const { width: imgElementWidth, height: imgElementHeight } =
+  const {width: imgElementWidth, height: imgElementHeight} =
     getShopifyImageDimensions({
       data,
       loaderOptions,
@@ -120,7 +120,8 @@ function ShopifyImage({
 
   if (__HYDROGEN_DEV__ && (!imgElementWidth || !imgElementHeight)) {
     console.warn(
-      `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. ${`Image: ${data.id ?? data.url
+      `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. ${`Image: ${
+        data.id ?? data.url
       }`}`
     );
   }
@@ -136,7 +137,8 @@ function ShopifyImage({
     });
     if (typeof finalSrc !== 'string' || !finalSrc) {
       throw new Error(
-        `<Image/>: 'loader' did not return a valid string. ${`Image: ${data.id ?? data.url
+        `<Image/>: 'loader' did not return a valid string. ${`Image: ${
+          data.id ?? data.url
         }`}`
       );
     }
@@ -170,7 +172,6 @@ function ShopifyImage({
       width={imgElementWidth ?? undefined}
       height={imgElementHeight ?? undefined}
       srcSet={finalSrcset}
-      decoding={decoding}
     />
   );
   /* eslint-enable hydrogen/prefer-image-component */
@@ -262,7 +263,7 @@ function ExternalImage<GenericLoaderOpts>({
   let finalSrc = src;
 
   if (loader) {
-    finalSrc = loader({ src, width, height, ...loaderOptions });
+    finalSrc = loader({src, width, height, ...loaderOptions});
     if (typeof finalSrc !== 'string' || !finalSrc) {
       throw new Error(`<Image/>: 'loader' did not return a valid string`);
     }

--- a/packages/hydrogen/src/components/Image/Image.tsx
+++ b/packages/hydrogen/src/components/Image/Image.tsx
@@ -5,8 +5,8 @@ import {
   addImageSizeParametersToUrl,
   IMG_SRC_SET_SIZES,
 } from '../../utilities/index.js';
-import type {Image as ImageType} from '../../storefront-api-types.js';
-import type {PartialDeep, Simplify, SetRequired} from 'type-fest';
+import type { Image as ImageType } from '../../storefront-api-types.js';
+import type { PartialDeep, Simplify, SetRequired } from 'type-fest';
 
 type HtmlImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
 
@@ -94,6 +94,7 @@ function ShopifyImage({
   loader = shopifyImageLoader,
   loaderOptions,
   widths,
+  decoding = "async",
   ...rest
 }: ShopifyImageProps) {
   if (!data.url) {
@@ -102,13 +103,12 @@ function ShopifyImage({
 
   if (__HYDROGEN_DEV__ && !data.altText && !rest.alt) {
     console.warn(
-      `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. ${`Image: ${
-        data.id ?? data.url
+      `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. ${`Image: ${data.id ?? data.url
       }`}`
     );
   }
 
-  const {width: imgElementWidth, height: imgElementHeight} =
+  const { width: imgElementWidth, height: imgElementHeight } =
     getShopifyImageDimensions({
       data,
       loaderOptions,
@@ -120,8 +120,7 @@ function ShopifyImage({
 
   if (__HYDROGEN_DEV__ && (!imgElementWidth || !imgElementHeight)) {
     console.warn(
-      `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. ${`Image: ${
-        data.id ?? data.url
+      `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. ${`Image: ${data.id ?? data.url
       }`}`
     );
   }
@@ -137,8 +136,7 @@ function ShopifyImage({
     });
     if (typeof finalSrc !== 'string' || !finalSrc) {
       throw new Error(
-        `<Image/>: 'loader' did not return a valid string. ${`Image: ${
-          data.id ?? data.url
+        `<Image/>: 'loader' did not return a valid string. ${`Image: ${data.id ?? data.url
         }`}`
       );
     }
@@ -172,6 +170,7 @@ function ShopifyImage({
       width={imgElementWidth ?? undefined}
       height={imgElementHeight ?? undefined}
       srcSet={finalSrcset}
+      decoding={decoding}
     />
   );
   /* eslint-enable hydrogen/prefer-image-component */
@@ -263,7 +262,7 @@ function ExternalImage<GenericLoaderOpts>({
   let finalSrc = src;
 
   if (loader) {
-    finalSrc = loader({src, width, height, ...loaderOptions});
+    finalSrc = loader({ src, width, height, ...loaderOptions });
     if (typeof finalSrc !== 'string' || !finalSrc) {
       throw new Error(`<Image/>: 'loader' did not return a valid string`);
     }

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -7,19 +7,19 @@ import React, {
   useEffect,
   ComponentType,
 } from 'react';
-import { hydrateRoot } from 'react-dom/client';
-import type { ClientConfig, ClientHandler } from './types.js';
-import { ErrorBoundary } from 'react-error-boundary';
+import {hydrateRoot} from 'react-dom/client';
+import type {ClientConfig, ClientHandler} from './types.js';
+import {ErrorBoundary} from 'react-error-boundary';
 import {
   createFromFetch,
   createFromReadableStream,
   // @ts-ignore
 } from '@shopify/hydrogen/vendor/react-server-dom-vite';
-import { RSC_PATHNAME } from './constants.js';
-import { ServerPropsProvider } from './foundation/ServerPropsProvider/index.js';
-import type { DevServerMessage } from './utilities/devtools.js';
-import type { LocationServerProps } from './foundation/ServerPropsProvider/ServerPropsProvider.js';
-import { ClientAnalytics } from './foundation/Analytics/index.js';
+import {RSC_PATHNAME} from './constants.js';
+import {ServerPropsProvider} from './foundation/ServerPropsProvider/index.js';
+import type {DevServerMessage} from './utilities/devtools.js';
+import type {LocationServerProps} from './foundation/ServerPropsProvider/ServerPropsProvider.js';
+import {ClientAnalytics} from './foundation/Analytics/index.js';
 // @ts-expect-error
 import CustomErrorPage from 'virtual__error.jsx';
 
@@ -106,7 +106,7 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
   if (import.meta.hot) {
     import.meta.hot.on(
       'hydrogen-browser-console',
-      ({ type, data }: DevServerMessage) => {
+      ({type, data}: DevServerMessage) => {
         if (type === 'warn') {
           console.warn(data);
         }
@@ -133,29 +133,26 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
 
   // Fixes hydration in `useId`: https://github.com/Shopify/hydrogen/issues/1589
   const ServerRequestProviderMock = () => null;
-  requestIdleCallback?.(() => {
-    React.startTransition(() => {
-      hydrateRoot(
-        root,
-        <RootComponent>
-          <ServerRequestProviderMock />
-          <ErrorBoundary
-            FallbackComponent={
-              CustomErrorPage
-                ? ({ error }) => (
-                  <CustomErrorWrapper error={error} errorPage={CustomErrorPage} />
-                )
-                : DefaultError
-            }
-          >
-            <Suspense fallback={null}>
-              <Content clientWrapper={ClientWrapper} />
-            </Suspense>
-          </ErrorBoundary>
-        </RootComponent>
-      );
-    })
-  })
+
+  hydrateRoot(
+    root,
+    <RootComponent>
+      <ServerRequestProviderMock />
+      <ErrorBoundary
+        FallbackComponent={
+          CustomErrorPage
+            ? ({error}) => (
+                <CustomErrorWrapper error={error} errorPage={CustomErrorPage} />
+              )
+            : DefaultError
+        }
+      >
+        <Suspense fallback={null}>
+          <Content clientWrapper={ClientWrapper} />
+        </Suspense>
+      </ErrorBoundary>
+    </RootComponent>
+  );
 };
 
 export default renderHydrogen;
@@ -166,7 +163,7 @@ interface APIRouteRscResponse {
 }
 
 function Content({
-  clientWrapper: ClientWrapper = ({ children }: { children: JSX.Element }) =>
+  clientWrapper: ClientWrapper = ({children}: {children: JSX.Element}) =>
     children,
 }: {
   clientWrapper: ElementType;
@@ -202,12 +199,12 @@ function CustomErrorWrapper({
   errorPage,
 }: {
   error: Error;
-  errorPage: () => Promise<{ default: ComponentType<any> }>;
+  errorPage: () => Promise<{default: ComponentType<any>}>;
 }) {
   const Error = React.lazy(errorPage);
   return (
     <ErrorBoundary
-      FallbackComponent={({ error: errorRenderingCustomPage }) => {
+      FallbackComponent={({error: errorRenderingCustomPage}) => {
         if (import.meta.env.DEV) {
           console.error(
             'Error rendering custom error page:\n' + errorRenderingCustomPage
@@ -223,7 +220,7 @@ function CustomErrorWrapper({
   );
 }
 
-function DefaultError({ error }: { error: Error }) {
+function DefaultError({error}: {error: Error}) {
   return (
     <div
       style={{
@@ -231,15 +228,15 @@ function DefaultError({ error }: { error: Error }) {
         textAlign: 'center',
       }}
     >
-      <h1 style={{ fontSize: '2em', marginBottom: '1em', fontWeight: 'bold' }}>
+      <h1 style={{fontSize: '2em', marginBottom: '1em', fontWeight: 'bold'}}>
         Something&apos;s wrong here...
       </h1>
 
-      <div style={{ fontSize: '1.1em' }}>
+      <div style={{fontSize: '1.1em'}}>
         <p>We found an error while loading this page.</p>
         <p>
           Please, refresh or go back to the{' '}
-          <a href="/" style={{ textDecoration: 'underline' }}>
+          <a href="/" style={{textDecoration: 'underline'}}>
             home page
           </a>
           .

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -7,19 +7,19 @@ import React, {
   useEffect,
   ComponentType,
 } from 'react';
-import {hydrateRoot} from 'react-dom/client';
-import type {ClientConfig, ClientHandler} from './types.js';
-import {ErrorBoundary} from 'react-error-boundary';
+import { hydrateRoot } from 'react-dom/client';
+import type { ClientConfig, ClientHandler } from './types.js';
+import { ErrorBoundary } from 'react-error-boundary';
 import {
   createFromFetch,
   createFromReadableStream,
   // @ts-ignore
 } from '@shopify/hydrogen/vendor/react-server-dom-vite';
-import {RSC_PATHNAME} from './constants.js';
-import {ServerPropsProvider} from './foundation/ServerPropsProvider/index.js';
-import type {DevServerMessage} from './utilities/devtools.js';
-import type {LocationServerProps} from './foundation/ServerPropsProvider/ServerPropsProvider.js';
-import {ClientAnalytics} from './foundation/Analytics/index.js';
+import { RSC_PATHNAME } from './constants.js';
+import { ServerPropsProvider } from './foundation/ServerPropsProvider/index.js';
+import type { DevServerMessage } from './utilities/devtools.js';
+import type { LocationServerProps } from './foundation/ServerPropsProvider/ServerPropsProvider.js';
+import { ClientAnalytics } from './foundation/Analytics/index.js';
 // @ts-expect-error
 import CustomErrorPage from 'virtual__error.jsx';
 
@@ -106,7 +106,7 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
   if (import.meta.hot) {
     import.meta.hot.on(
       'hydrogen-browser-console',
-      ({type, data}: DevServerMessage) => {
+      ({ type, data }: DevServerMessage) => {
         if (type === 'warn') {
           console.warn(data);
         }
@@ -133,26 +133,29 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
 
   // Fixes hydration in `useId`: https://github.com/Shopify/hydrogen/issues/1589
   const ServerRequestProviderMock = () => null;
-
-  hydrateRoot(
-    root,
-    <RootComponent>
-      <ServerRequestProviderMock />
-      <ErrorBoundary
-        FallbackComponent={
-          CustomErrorPage
-            ? ({error}) => (
-                <CustomErrorWrapper error={error} errorPage={CustomErrorPage} />
-              )
-            : DefaultError
-        }
-      >
-        <Suspense fallback={null}>
-          <Content clientWrapper={ClientWrapper} />
-        </Suspense>
-      </ErrorBoundary>
-    </RootComponent>
-  );
+  requestIdleCallback?.(() => {
+    React.startTransition(() => {
+      hydrateRoot(
+        root,
+        <RootComponent>
+          <ServerRequestProviderMock />
+          <ErrorBoundary
+            FallbackComponent={
+              CustomErrorPage
+                ? ({ error }) => (
+                  <CustomErrorWrapper error={error} errorPage={CustomErrorPage} />
+                )
+                : DefaultError
+            }
+          >
+            <Suspense fallback={null}>
+              <Content clientWrapper={ClientWrapper} />
+            </Suspense>
+          </ErrorBoundary>
+        </RootComponent>
+      );
+    })
+  })
 };
 
 export default renderHydrogen;
@@ -163,7 +166,7 @@ interface APIRouteRscResponse {
 }
 
 function Content({
-  clientWrapper: ClientWrapper = ({children}: {children: JSX.Element}) =>
+  clientWrapper: ClientWrapper = ({ children }: { children: JSX.Element }) =>
     children,
 }: {
   clientWrapper: ElementType;
@@ -199,12 +202,12 @@ function CustomErrorWrapper({
   errorPage,
 }: {
   error: Error;
-  errorPage: () => Promise<{default: ComponentType<any>}>;
+  errorPage: () => Promise<{ default: ComponentType<any> }>;
 }) {
   const Error = React.lazy(errorPage);
   return (
     <ErrorBoundary
-      FallbackComponent={({error: errorRenderingCustomPage}) => {
+      FallbackComponent={({ error: errorRenderingCustomPage }) => {
         if (import.meta.env.DEV) {
           console.error(
             'Error rendering custom error page:\n' + errorRenderingCustomPage
@@ -220,7 +223,7 @@ function CustomErrorWrapper({
   );
 }
 
-function DefaultError({error}: {error: Error}) {
+function DefaultError({ error }: { error: Error }) {
   return (
     <div
       style={{
@@ -228,15 +231,15 @@ function DefaultError({error}: {error: Error}) {
         textAlign: 'center',
       }}
     >
-      <h1 style={{fontSize: '2em', marginBottom: '1em', fontWeight: 'bold'}}>
+      <h1 style={{ fontSize: '2em', marginBottom: '1em', fontWeight: 'bold' }}>
         Something&apos;s wrong here...
       </h1>
 
-      <div style={{fontSize: '1.1em'}}>
+      <div style={{ fontSize: '1.1em' }}>
         <p>We found an error while loading this page.</p>
         <p>
           Please, refresh or go back to the{' '}
-          <a href="/" style={{textDecoration: 'underline'}}>
+          <a href="/" style={{ textDecoration: 'underline' }}>
             home page
           </a>
           .

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -152,15 +152,15 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
   requestIdleCallbackHydrogen(() => {
     startTransition(() => {
         hydrateRoot(root, <RootComponent>
-        <ServerRequestProviderMock />
-        <ErrorBoundary FallbackComponent={CustomErrorPage
-                ? ({ error }) => (<CustomErrorWrapper error={error} errorPage={CustomErrorPage}/>)
-                : DefaultError}>
-          <Suspense fallback={null}>
-            <Content clientWrapper={ClientWrapper}/>
-          </Suspense>
-        </ErrorBoundary>
-      </RootComponent>);
+          <ServerRequestProviderMock />
+          <ErrorBoundary FallbackComponent={CustomErrorPage
+            ? ({ error }) => (<CustomErrorWrapper error={error} errorPage={CustomErrorPage} />)
+            : DefaultError}>
+            <Suspense fallback={null}>
+              <Content clientWrapper={ClientWrapper} />
+            </Suspense>
+          </ErrorBoundary>
+        </RootComponent>);
     });
 });
 };

--- a/packages/hydrogen/src/entry-client.tsx
+++ b/packages/hydrogen/src/entry-client.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   StrictMode,
   Fragment,
+  startTransition,
   type ElementType,
   useEffect,
   ComponentType,
@@ -30,6 +31,21 @@ const cache = new Map();
 // Hydrate an SSR response from <meta> tags placed in the DOM.
 const flightChunks: string[] = [];
 const FLIGHT_ATTRIBUTE = 'data-flight';
+
+const requestIdleCallbackHydrogen = (typeof self !== 'undefined' &&
+    self.requestIdleCallback &&
+    self.requestIdleCallback.bind(window)) ||
+    function (cb) {
+        let start = Date.now();
+        return setTimeout(function () {
+            cb({
+                didTimeout: false,
+                timeRemaining: function () {
+                    return Math.max(0, 50 - (Date.now() - start));
+                },
+            });
+        }, 1);
+    };
 
 function addElementToFlightChunks(el: Element) {
   // We don't need to decode, because `.getAttribute` already decodes
@@ -133,26 +149,20 @@ const renderHydrogen: ClientHandler = async (ClientWrapper) => {
 
   // Fixes hydration in `useId`: https://github.com/Shopify/hydrogen/issues/1589
   const ServerRequestProviderMock = () => null;
-
-  hydrateRoot(
-    root,
-    <RootComponent>
-      <ServerRequestProviderMock />
-      <ErrorBoundary
-        FallbackComponent={
-          CustomErrorPage
-            ? ({error}) => (
-                <CustomErrorWrapper error={error} errorPage={CustomErrorPage} />
-              )
-            : DefaultError
-        }
-      >
-        <Suspense fallback={null}>
-          <Content clientWrapper={ClientWrapper} />
-        </Suspense>
-      </ErrorBoundary>
-    </RootComponent>
-  );
+  requestIdleCallbackHydrogen(() => {
+    startTransition(() => {
+        hydrateRoot(root, <RootComponent>
+        <ServerRequestProviderMock />
+        <ErrorBoundary FallbackComponent={CustomErrorPage
+                ? ({ error }) => (<CustomErrorWrapper error={error} errorPage={CustomErrorPage}/>)
+                : DefaultError}>
+          <Suspense fallback={null}>
+            <Content clientWrapper={ClientWrapper}/>
+          </Suspense>
+        </ErrorBoundary>
+      </RootComponent>);
+    });
+});
 };
 
 export default renderHydrogen;


### PR DESCRIPTION
This PR is heavily inspired from  [tweet by Ryan Florence.](https://twitter.com/ryanflorence/status/1547959632663961602 )

Time slicing is the thing that keeps me firmly in the React camp. I've built so much UI in my career where user interactions can cause rapid UI updates.

Without time slicing, the main thread gets blocked and you get jank.

React 18 just solves--and hides--the problem completely.
https://twitter.com/ryanflorence/status/1547961298813497355?s=20&t=BxmSnZmZfN4nOyTVw5aOTQ

_I am extremely sorry if I made any mistakes :(_