### PR TITLE
Update `ClientAnalytics.publish` so that the object is the third argument passed

### DIFF
--- a/docs/framework/analytics.md
+++ b/docs/framework/analytics.md
@@ -108,7 +108,7 @@ Aside from the [default events](#default-events) that Hydrogen supports, you can
 
     ```jsx
     <Banner onClick={(event) => {
-      ClientAnalytics.publish('select_promotion', {
+      ClientAnalytics.publish('select_promotion', true, {
         creative_name: "Summer Banner",
         creative_slot: "featured_app_1",
         ...


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Partially closes https://github.com/Shopify/shopify-dev/issues/24779

### Additional context

That there's no need to pass a `true`/`false` second argument if there's no object being passed in.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
