### PR TITLE
Fix `Oxygen.env` access in Hydrogen config file

### DIFF
--- a/.changeset/cuddly-dryers-relate.md
+++ b/.changeset/cuddly-dryers-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix accessing `Oxygen.env` in `hydrogen.config.js` file in production.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -79,10 +79,13 @@ export const renderHydrogen = (App: any) => {
 
     let sessionApi = options.sessionApi;
 
-    const {default: inlineHydrogenConfig} = await import(
+    const {default: importedConfig} = await import(
       // @ts-ignore
       'virtual__hydrogen.config.ts'
     );
+
+    const inlineHydrogenConfig =
+      typeof importedConfig === 'function' ? importedConfig() : importedConfig;
 
     const {default: hydrogenRoutes} = await import(
       // @ts-ignore

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
@@ -44,7 +44,7 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
           config.root,
           pluginOptions.configPath
         ).then((hcPath: string) => {
-          resolvedConfigPath = hcPath;
+          resolvedConfigPath = normalizePath(hcPath);
           // This direct dependency on a real file
           // makes HMR work for the virtual module.
           return this.resolve(hcPath, importer, {skipSelf: true});

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import {promises as fs} from 'fs';
 import type {HydrogenVitePluginOptions} from '../types.js';
 import {viteception} from '../viteception.js';
+import MagicString from 'magic-string';
 
 export const HYDROGEN_DEFAULT_SERVER_ENTRY =
   process.env.HYDROGEN_SERVER_ENTRY || '/src/App.server';
@@ -27,6 +28,7 @@ export const VIRTUAL_PROXY_HYDROGEN_ROUTES_ID =
 export default (pluginOptions: HydrogenVitePluginOptions) => {
   let config: ResolvedConfig;
   let server: ViteDevServer;
+  let resolvedConfigPath: string;
 
   return {
     name: 'hydrogen:virtual-files',
@@ -41,11 +43,12 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
         return findHydrogenConfigPath(
           config.root,
           pluginOptions.configPath
-        ).then((hcPath: string) =>
+        ).then((hcPath: string) => {
+          resolvedConfigPath = hcPath;
           // This direct dependency on a real file
           // makes HMR work for the virtual module.
-          this.resolve(hcPath, importer, {skipSelf: true})
-        );
+          return this.resolve(hcPath, importer, {skipSelf: true});
+        });
       }
 
       if (
@@ -66,7 +69,7 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
       // Likely due to a bug in Vite, but virtual modules cannot be loaded
       // directly using ssrLoadModule from a Vite plugin. It needs to be proxied as follows:
       if (id === '\0' + VIRTUAL_PROXY_HYDROGEN_CONFIG_ID) {
-        return `import hc from '${VIRTUAL_HYDROGEN_CONFIG_ID}'; export default hc;`;
+        return `import hc from '${VIRTUAL_HYDROGEN_CONFIG_ID}'; export default typeof hc === 'function' ? hc() : hc;`;
       }
       if (id === '\0' + VIRTUAL_PROXY_HYDROGEN_ROUTES_ID) {
         return `import hr from '${VIRTUAL_HYDROGEN_ROUTES_ID}'; export default hr;`;
@@ -111,6 +114,21 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
           const code = `const errorPage = import.meta.glob("${errorPath}");\n export default Object.values(errorPage)[0];`;
           return {code};
         });
+      }
+    },
+    transform(code, id) {
+      if (id === resolvedConfigPath) {
+        const s = new MagicString(code);
+        // Wrap in function to avoid evaluating `Oxygen.env`
+        // in the config until we have polyfilled it properly.
+        s.replace(/export\s+default\s+(\w+)\s*\(/g, (all, m1) =>
+          all.replace(m1, `() => ${m1}`)
+        );
+
+        return {
+          code: s.toString(),
+          map: s.generateMap({file: id, source: id}),
+        };
       }
     },
   } as Plugin;

--- a/packages/playground/server-components/hydrogen.config.js
+++ b/packages/playground/server-components/hydrogen.config.js
@@ -6,7 +6,9 @@ export default defineConfig({
     defaultCountryCode: 'us',
     storeDomain: 'hydrogen-preview.myshopify.com',
     storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
-    storefrontApiVersion: '2022-07',
+    // This should not throw with undefined Oxygen
+    // eslint-disable-next-line no-undef
+    storefrontApiVersion: Oxygen.env.FAKE_VAR || '2022-07',
   },
   session: CookieSessionStorage('__session', {
     expires: new Date(1749343178614),

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig, CookieSessionStorage} from '@shopify/hydrogen/config';
 
 export default defineConfig({
-  shopify: () => ({
+  shopify: {
     defaultCountryCode: 'US',
     defaultLanguageCode: 'EN',
     storeDomain:
@@ -12,7 +12,7 @@ export default defineConfig({
       Oxygen?.env?.SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN ||
       '3b580e70970c4528da70c98e097c2fa0',
     storefrontApiVersion: '2022-07',
-  }),
+  },
   session: CookieSessionStorage('__session', {
     path: '/',
     httpOnly: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In production build, Vite/Rollup are hoisting the Hydrogen config declaration object to the top level of the bundle. This code runs before we can polyfill the global `Oxygen.env`. As a result, accessing `Oxygen.env.VARIABLE` in `hydrogen.config.js` file throws with `Oxygen is undefined`.

What we've done so far is wrapping our config's `shopify` key in a function to delay accessing `Oxygen.env`:

```js
export default defineConfig({
  shopify: () => ({
    something: Oxygen.env.VARIABLE,
  }),
})
```

That works, but requires work from the user and it's unclear why it's needed. Plus, it only allows variables in `shopify` object (future plugins might also need env variables).

This PR wraps the whole config in a function to delay running the code in the same way, but at the Vite level. The previous code is transformed to:

```js
export default () => defineConfig({ ... });
```

Hydrogen understands this and calls the function after `Oxygen.env` is polyfilled. Therefore, using the function in `shopify` is not needed anymore for just accessing environment variables.

Cons:
- It currently only works when using `defineConfig` inlined in the `export default`. I think this is the most common use so perhaps we don't need to worry about other situations (e.g. `const config = {}; export default config;`.);

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
