### PR TITLE
Improve Cart event payloads

### DIFF
--- a/.changeset/twelve-lobsters-check.md
+++ b/.changeset/twelve-lobsters-check.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen': patch
+'demo-store': patch
+---
+
+Adds `prevCart` to cart event payloads

--- a/.changeset/twelve-lobsters-check.md
+++ b/.changeset/twelve-lobsters-check.md
@@ -1,6 +1,5 @@
 ---
 '@shopify/hydrogen': patch
-'demo-store': patch
 ---
 
 Adds `prevCart` to cart event payloads

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -358,6 +358,7 @@ export function CartProvider({
             {
               addedCartLines: cart.lines,
               cart: data.cartCreate.cart,
+              prevCart: null,
             }
           );
         }
@@ -414,6 +415,7 @@ export function CartProvider({
             {
               addedCartLines: lines,
               cart: data.cartLinesAdd.cart,
+              prevCart: state.cart,
             }
           );
           dispatch({
@@ -460,6 +462,7 @@ export function CartProvider({
             {
               removedCartLines: lines,
               cart: data.cartLinesRemove.cart,
+              prevCart: state.cart,
             }
           );
           dispatch({
@@ -505,6 +508,8 @@ export function CartProvider({
             {
               updatedCartLines: lines,
               oldCart: state.cart,
+              cart: data.cartLinesUpdate.cart,
+              prevCart: state.cart,
             }
           );
           dispatch({
@@ -668,6 +673,7 @@ export function CartProvider({
             {
               updatedDiscountCodes: discountCodes,
               cart: data.cartDiscountCodesUpdate.cart,
+              prevCart: state.cart,
             }
           );
           dispatch({

--- a/templates/demo-store/src/App.server.tsx
+++ b/templates/demo-store/src/App.server.tsx
@@ -11,8 +11,7 @@ import {
   ShopifyProvider,
   CartProvider,
 } from '@shopify/hydrogen';
-
-import {HeaderFallback} from '~/components';
+import {HeaderFallback, EventsListener} from '~/components';
 import type {CountryCode} from '@shopify/hydrogen/storefront-api-types';
 import {DefaultSeo, NotFound} from '~/components/index.server';
 
@@ -25,6 +24,7 @@ function App({request}: HydrogenRouteProps) {
 
   return (
     <Suspense fallback={<HeaderFallback isHome={isHome} />}>
+      <EventsListener />
       <ShopifyProvider countryCode={countryCode}>
         <CartProvider countryCode={countryCode}>
           <Suspense>

--- a/templates/demo-store/src/components/EventsListener.client.tsx
+++ b/templates/demo-store/src/components/EventsListener.client.tsx
@@ -1,0 +1,36 @@
+import {ClientAnalytics} from '@shopify/hydrogen';
+import {useEffect} from 'react';
+
+let init = false;
+
+// Example client-side event listener
+export function EventsListener() {
+  useEffect(() => {
+    if (init) return;
+    init = true;
+
+    // cart events
+    ClientAnalytics.subscribe(
+      ClientAnalytics.eventNames.ADD_TO_CART,
+      ({cart, prevCart}) => {
+        // emit ADD_TO_CART event to server
+      },
+    );
+    ClientAnalytics.subscribe(
+      ClientAnalytics.eventNames.REMOVE_FROM_CART,
+      ({cart, prevCart}) => {
+        // emit REMOVE_FROM_CART event to server
+      },
+    );
+    ClientAnalytics.subscribe(
+      ClientAnalytics.eventNames.UPDATE_CART,
+      ({cart, prevCart}) => {
+        // emit UPDATE_CART event to server
+      },
+    );
+
+    // other events...
+  }, []);
+
+  return null;
+}

--- a/templates/demo-store/src/components/index.ts
+++ b/templates/demo-store/src/components/index.ts
@@ -8,3 +8,4 @@ export * from './sections/index';
 export {CountrySelector} from './CountrySelector.client';
 export {CustomFont} from './CustomFont.client';
 export {HeaderFallback} from './HeaderFallback';
+export {EventsListener} from './EventsListener.client';


### PR DESCRIPTION
### Description

This PR solves #1981 by providing both `cart` (current) and `prevCart` to all event payloads

```jsx
// cart events
ClientAnalytics.subscribe(
  ClientAnalytics.eventNames.ADD_TO_CART,
  ({cart, prevCart}) => {
    // emit ADD_TO_CART event to server
  },
);
ClientAnalytics.subscribe(
  ClientAnalytics.eventNames.REMOVE_FROM_CART,
  ({cart, prevCart}) => {
    // emit REMOVE_FROM_CART event to server
  },
);
ClientAnalytics.subscribe(
  ClientAnalytics.eventNames.UPDATE_CART,
  ({cart, prevCart}) => {
    // emit UPDATE_CART event to server
  },
);

// other events....
```


### Additional context
In response to:

```
Strategic partner
----
Another Q specifically for the UPDATE_CART event

I've been having a hard time being able to tell at the event level if a user is removing or adding to an existing line item. I've noticed in the payload that an oldCart filed exists which is super helpful. But there is no currentCart to work off of.

I actually only see a cart field appear when I add to cart and then update the cart AFTER I have added to the cart.

Even at that point I'm seeing the quantity not correctly reflect the current state of the cart.

I also see an addedCartLines field, but that also only populates after I add a fresh item to the cart. Not when I just update a line item.  This field also doesnt reflect if the item was added or removed. Rather it always spits out a quantity of 1.

Have you guys seen any weird behavior with this event too?
```

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
