### PR TITLE
Add `merchandise.product.id` to cart line query

### DIFF
--- a/.changeset/slow-camels-watch.md
+++ b/.changeset/slow-camels-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Adds `merchandise.product.id` to cart line items query

--- a/packages/hydrogen/src/components/CartProvider/cart-queries.ts
+++ b/packages/hydrogen/src/components/CartProvider/cart-queries.ts
@@ -163,6 +163,7 @@ fragment CartFragment on Cart {
             product {
               handle
               title
+              id
             }
             selectedOptions {
               name


### PR DESCRIPTION
<img width="811" alt="Screen Shot 2022-08-16 at 7 22 05 AM" src="https://user-images.githubusercontent.com/12080141/184905165-bf9f51a4-e82f-4ad8-8e16-bd19d3bc0d24.png">

### Description
Adds `merchandise.product.id` to the cart line query

### Additional context

Fixes issue https://github.com/Shopify/hydrogen/issues/1952

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
