### PR TITLE
Fixes viewport height on mobile

### DIFF
--- a/templates/demo-store/src/styles/index.css
+++ b/templates/demo-store/src/styles/index.css
@@ -25,8 +25,8 @@
     --font-size-heading: 2.25rem; /* text-4xl */
     --font-size-display: 3.75rem; /* text-6xl */
   }
-  @supports (height: 100lvh) {
-    --screen-height: 100lvh;
+  @supports (height: 100svh) {
+    --screen-height: 100svh;
   }
 }
 


### PR DESCRIPTION
A _very_ small tweak to have the Hero sections use the correct viewport height unit (`svh`).