### PR TITLE
Expose the private token and storefrontId within Hydrogen config

### DIFF
--- a/.changeset/empty-rocks-lick.md
+++ b/.changeset/empty-rocks-lick.md
@@ -1,0 +1,17 @@
+---
+'@shopify/hydrogen': patch
+'create-hydrogen-app': patch
+---
+
+We've exposed the private server-to-server storefront API token in the hydrogen config. The private token is necessary when deploying to production, otherwise the requests to the storefront API will be rate limited. This should make it easier to properly configure hydrogen when deploying to non-Oxygen environments. We'll also warn when in production mode and the token is not defined.
+
+We've also added the `storefrontId` property to the config. It's necessary to add this as well, otherwise your analytics dashboard on the admin will be broken.
+
+Lastly we also updagted all Oxygen environment variable references to a more consistent naming convention. The previous variables will still remain, but are deprecated, and will be removed down the road. If you still reference them, a warning will be given:
+
+| **Current Oxygen Variable**              | **New Oxygen Variable**              |
+| ---------------------------------------- | ------------------------------------ |
+| SHOPIFY_STORE_DOMAIN                     | PUBLIC_SHOPIFY_STORE_DOMAIN          |
+| SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN      | PUBLIC_SHOPIFY_STOREFRONT_API_TOKEN  |
+| OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE | PRIVATE_SHOPIFY_STOREFRONT_API_TOKEN |
+| SHOPIFY_STOREFRONT_ID                    | PUBLIC_STOREFRONT_ID                 |

--- a/.changeset/empty-rocks-lick.md
+++ b/.changeset/empty-rocks-lick.md
@@ -7,11 +7,11 @@ We've exposed the private server-to-server storefront API token in the hydrogen 
 
 We've also added the `storefrontId` property to the config. It's necessary to add this as well, otherwise your analytics dashboard on the admin will be broken.
 
-Lastly we also updagted all Oxygen environment variable references to a more consistent naming convention. The previous variables will still remain, but are deprecated, and will be removed down the road. If you still reference them, a warning will be given:
+Lastly we also updagted all Oxygen environment variable references to a more consistent naming convention. The previous variables are still available, but are deprecated, and will be removed down the road. If you still reference them, a warning will be given:
 
 | **Current Oxygen Variable**              | **New Oxygen Variable**              |
 | ---------------------------------------- | ------------------------------------ |
 | SHOPIFY_STORE_DOMAIN                     | PUBLIC_SHOPIFY_STORE_DOMAIN          |
 | SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN      | PUBLIC_SHOPIFY_STOREFRONT_API_TOKEN  |
 | OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE | PRIVATE_SHOPIFY_STOREFRONT_API_TOKEN |
-| SHOPIFY_STOREFRONT_ID                    | PUBLIC_STOREFRONT_ID                 |
+| SHOPIFY_STOREFRONT_ID                    | PUBLIC_SHOPIFY_STOREFRONT_ID         |

--- a/.changeset/empty-rocks-lick.md
+++ b/.changeset/empty-rocks-lick.md
@@ -9,9 +9,9 @@ We've also added the `storefrontId` property to the config. It's necessary to ad
 
 Lastly we also updagted all Oxygen environment variable references to a more consistent naming convention. The previous variables are still available, but are deprecated, and will be removed down the road. If you still reference them, a warning will be given:
 
-| **Current Oxygen Variable**              | **New Oxygen Variable**              |
-| ---------------------------------------- | ------------------------------------ |
-| SHOPIFY_STORE_DOMAIN                     | PUBLIC_SHOPIFY_STORE_DOMAIN          |
-| SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN      | PUBLIC_SHOPIFY_STOREFRONT_API_TOKEN  |
-| OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE | PRIVATE_SHOPIFY_STOREFRONT_API_TOKEN |
-| SHOPIFY_STOREFRONT_ID                    | PUBLIC_SHOPIFY_STOREFRONT_ID         |
+| **Current Oxygen Variable**         | **New Oxygen Variable**     |
+| ----------------------------------- | --------------------------- |
+| SHOPIFY_STORE_DOMAIN                | PUBLIC_STORE_DOMAIN         |
+| SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN | PUBLIC_STOREFRONT_API_TOKEN |
+| SHOPIFY_STOREFRONT_API_SECRET_TOKEN | SECRET_STOREFRONT_API_TOKEN |
+| SHOPIFY_STOREFRONT_ID               | PUBLIC_STOREFRONT_ID        |

--- a/.changeset/empty-rocks-lick.md
+++ b/.changeset/empty-rocks-lick.md
@@ -3,13 +3,13 @@
 'create-hydrogen-app': patch
 ---
 
-We've exposed the private server-to-server storefront API token in the hydrogen config. The private token is necessary when deploying to production, otherwise the requests to the storefront API will be rate limited. This should make it easier to properly configure hydrogen when deploying to non-Oxygen environments. We'll also warn when in production mode and the token is not defined.
+We've exposed the private server-to-server Storefront API token in the Hydrogen config file. This private token is required when deploying to production, otherwise the requests to the storefront API will be rate-limited. This change will make it easier to configure Hydrogen when deploying to non-Oxygen environments. We'll also display a warning in production mode if this token is not defined.
 
-We've also added the `storefrontId` property to the config. It's necessary to add this as well, otherwise your analytics dashboard on the admin will be broken.
+We've also added the `storefrontId` property to the config. This enables Hydrogen data to display properly in the Shopify admin analytics dashboard.
 
-Lastly we also updagted all Oxygen environment variable references to a more consistent naming convention. The previous variables are still available, but are deprecated, and will be removed down the road. If you still reference them, a warning will be given:
+Lastly, we've updated all Oxygen environment variables to a more consistent naming convention. The previous variables are still available, but are deprecated, and will be removed in the future. You’ll see a warning in your console if you use the old environment variables. You can update your variable references using this table:
 
-| **Current Oxygen Variable**         | **New Oxygen Variable**     |
+| **Old Oxygen variable**         | **New Oxygen variable**     |
 | ----------------------------------- | --------------------------- |
 | SHOPIFY_STORE_DOMAIN                | PUBLIC_STORE_DOMAIN         |
 | SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN | PUBLIC_STOREFRONT_API_TOKEN |

--- a/.changeset/empty-rocks-lick.md
+++ b/.changeset/empty-rocks-lick.md
@@ -9,9 +9,9 @@ We've also added the `storefrontId` property to the config. This enables Hydroge
 
 Lastly, we've updated all Oxygen environment variables to a more consistent naming convention. The previous variables are still available, but are deprecated, and will be removed in the future. You’ll see a warning in your console if you use the old environment variables. You can update your variable references using this table:
 
-| **Old Oxygen variable**         | **New Oxygen variable**     |
-| ----------------------------------- | --------------------------- |
-| SHOPIFY_STORE_DOMAIN                | PUBLIC_STORE_DOMAIN         |
-| SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN | PUBLIC_STOREFRONT_API_TOKEN |
-| SHOPIFY_STOREFRONT_API_SECRET_TOKEN | SECRET_STOREFRONT_API_TOKEN |
-| SHOPIFY_STOREFRONT_ID               | PUBLIC_STOREFRONT_ID        |
+| **Old Oxygen variable**             | **New Oxygen variable**      |
+| ----------------------------------- | ---------------------------- |
+| SHOPIFY_STORE_DOMAIN                | PUBLIC_STORE_DOMAIN          |
+| SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN | PUBLIC_STOREFRONT_API_TOKEN  |
+| SHOPIFY_STOREFRONT_API_SECRET_TOKEN | PRIVATE_STOREFRONT_API_TOKEN |
+| SHOPIFY_STOREFRONT_ID               | PUBLIC_STOREFRONT_ID         |

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -1,5 +1,5 @@
 import type {
-  ShopifyContextValue,
+  ShopifyContextServerValue,
   LocalizationContextValue,
 } from '../ShopifyProvider/types.js';
 import {getTime} from '../../utilities/timing.js';
@@ -69,7 +69,7 @@ export class HydrogenRequest extends Request {
     cache: Map<string, any>;
     head: HeadData;
     hydrogenConfig?: ResolvedHydrogenConfig;
-    shopifyConfig?: ShopifyContextValue;
+    shopifyConfig?: ShopifyContextServerValue;
     queryCacheControl: Array<QueryCacheControlHeaders>;
     queryTimings: Array<QueryTiming>;
     preloadQueries: PreloadQueriesByURL;

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.client.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.client.tsx
@@ -1,7 +1,12 @@
-import type {ShopifyContextValue, LocalizationContextValue} from './types.js';
+import type {
+  ShopifyContextClientValue,
+  LocalizationContextValue,
+} from './types.js';
 import React, {createContext, ReactNode} from 'react';
 
-export const ShopifyContext = createContext<ShopifyContextValue | null>(null);
+export const ShopifyContext = createContext<ShopifyContextClientValue | null>(
+  null
+);
 export const LocalizationContext =
   createContext<LocalizationContextValue | null>(null);
 
@@ -11,7 +16,7 @@ export function ShopifyProviderClient({
   localization,
 }: {
   children: ReactNode;
-  shopifyConfig: ShopifyContextValue;
+  shopifyConfig: ShopifyContextClientValue;
   localization: LocalizationContextValue;
 }): JSX.Element {
   if (!shopifyConfig) {

--- a/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
@@ -6,7 +6,6 @@ export interface ShopifyContextValue
   extends Omit<ShopifyConfig, 'defaultLanguageCode' | 'defaultCountryCode'> {
   defaultLanguageCode: `${LanguageCode}`;
   defaultCountryCode: `${CountryCode}`;
-  storefrontId: string | null;
 }
 
 // TODO: improve types with intrinsic string manipulation

--- a/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/types.ts
@@ -1,12 +1,20 @@
 import type {CountryCode, LanguageCode} from '../../storefront-api-types.js';
 import type {ReactNode} from 'react';
 import type {ShopifyConfigFetcher, ShopifyConfig} from '../../types.js';
+import type {CLIENT_CONTEXT_ALLOW_LIST} from './ShopifyProvider.server.js';
 
-export interface ShopifyContextValue
+export interface ShopifyContextServerValue
   extends Omit<ShopifyConfig, 'defaultLanguageCode' | 'defaultCountryCode'> {
   defaultLanguageCode: `${LanguageCode}`;
   defaultCountryCode: `${CountryCode}`;
 }
+
+type CLIENT_KEYS = typeof CLIENT_CONTEXT_ALLOW_LIST[number];
+
+export type ShopifyContextClientValue = Pick<
+  ShopifyContextServerValue,
+  CLIENT_KEYS
+>;
 
 // TODO: improve types with intrinsic string manipulation
 export type Locale = string;

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -226,8 +226,8 @@ function useCreateShopRequest(body: string) {
 
   const extraHeaders = getStorefrontApiRequestHeaders({
     buyerIp,
-    storefrontToken,
-    secretToken: privateStorefrontToken,
+    publicStorefrontToken: storefrontToken,
+    privateStorefrontToken,
     storefrontId,
   });
 

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -213,7 +213,13 @@ export function useShopQuery<T>({
 }
 
 function useCreateShopRequest(body: string) {
-  const {storeDomain, storefrontToken, storefrontApiVersion} = useShop();
+  const {
+    storeDomain,
+    storefrontToken,
+    storefrontApiVersion,
+    storefrontId,
+    privateStorefrontToken,
+  } = useShop();
 
   const request = useServerRequest();
   const buyerIp = request.getBuyerIp();
@@ -221,6 +227,8 @@ function useCreateShopRequest(body: string) {
   const extraHeaders = getStorefrontApiRequestHeaders({
     buyerIp,
     storefrontToken,
+    secretToken: privateStorefrontToken,
+    storefrontId,
   });
 
   return {

--- a/packages/hydrogen/src/shared-types.ts
+++ b/packages/hydrogen/src/shared-types.ts
@@ -35,7 +35,6 @@ export type ShopifyConfig = {
   storeDomain: string;
   storefrontToken: string;
   storefrontApiVersion: string;
-  multipassSecret?: string;
   privateStorefrontToken?: string;
   storefrontId?: string;
 };

--- a/packages/hydrogen/src/shared-types.ts
+++ b/packages/hydrogen/src/shared-types.ts
@@ -36,4 +36,6 @@ export type ShopifyConfig = {
   storefrontToken: string;
   storefrontApiVersion: string;
   multipassSecret?: string;
+  privateStorefrontToken?: string;
+  storefrontId?: string;
 };

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -183,8 +183,8 @@ function queryShopBuilder(
 
     const extraHeaders = getStorefrontApiRequestHeaders({
       buyerIp,
-      storefrontToken,
-      secretToken: privateStorefrontToken,
+      publicStorefrontToken: storefrontToken,
+      privateStorefrontToken,
       storefrontId,
     });
 

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -172,12 +172,20 @@ function queryShopBuilder(
       );
     }
 
-    const {storeDomain, storefrontApiVersion, storefrontToken} = shopifyConfig;
+    const {
+      storeDomain,
+      storefrontApiVersion,
+      storefrontToken,
+      privateStorefrontToken,
+      storefrontId,
+    } = shopifyConfig;
     const buyerIp = request.getBuyerIp();
 
     const extraHeaders = getStorefrontApiRequestHeaders({
       buyerIp,
       storefrontToken,
+      secretToken: privateStorefrontToken,
+      storefrontId,
     });
 
     const fetcher = fetchBuilder<T>(

--- a/packages/hydrogen/src/utilities/storefrontApi.ts
+++ b/packages/hydrogen/src/utilities/storefrontApi.ts
@@ -14,26 +14,28 @@ let storefrontIdWarned = false;
 
 export function getStorefrontApiRequestHeaders({
   buyerIp,
-  storefrontToken,
-  secretToken,
+  publicStorefrontToken,
+  privateStorefrontToken,
   storefrontId,
 }: {
   buyerIp?: string | null;
-  storefrontToken: string;
-  secretToken: string | undefined;
+  publicStorefrontToken: string;
+  privateStorefrontToken: string | undefined;
   storefrontId: string | undefined;
 }) {
   const headers = {} as Record<string, any>;
 
-  if (!secretToken && !secretTokenWarned) {
+  if (!privateStorefrontToken && !secretTokenWarned) {
     secretTokenWarned = true;
-    secretToken = getOxygenVariable(OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE);
+    privateStorefrontToken = getOxygenVariable(
+      OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE
+    );
 
-    if (!secretToken && !__HYDROGEN_DEV__) {
+    if (!privateStorefrontToken && !__HYDROGEN_DEV__) {
       log.error(
         'No secret Shopify storefront API token was defined. This means your app will be rate limited!\nSee how to add the token: '
       );
-    } else if (secretToken) {
+    } else if (privateStorefrontToken) {
       log.warn(
         'The private shopify storefront API token was loaded implicitly by an environment variable. This is deprecated, and instead the variable should be defined directly in the Hydrogen Config.\nFor more information: '
       );
@@ -58,10 +60,10 @@ export function getStorefrontApiRequestHeaders({
   /**
    * Only pass one type of storefront token at a time.
    */
-  if (secretToken) {
-    headers[STOREFRONT_API_SECRET_TOKEN_HEADER] = secretToken;
+  if (privateStorefrontToken) {
+    headers[STOREFRONT_API_SECRET_TOKEN_HEADER] = privateStorefrontToken;
   } else {
-    headers[STOREFRONT_API_PUBLIC_TOKEN_HEADER] = storefrontToken;
+    headers[STOREFRONT_API_PUBLIC_TOKEN_HEADER] = publicStorefrontToken;
   }
 
   if (buyerIp) {

--- a/packages/hydrogen/src/utilities/storefrontApi.ts
+++ b/packages/hydrogen/src/utilities/storefrontApi.ts
@@ -7,20 +7,53 @@ import {
   SHOPIFY_STOREFRONT_ID_VARIABLE,
   SHOPIFY_STOREFRONT_ID_HEADER,
 } from '../constants.js';
+import {log} from './log/log.js';
+
+let secretTokenWarned = false;
+let storefrontIdWarned = false;
 
 export function getStorefrontApiRequestHeaders({
   buyerIp,
   storefrontToken,
+  secretToken,
+  storefrontId,
 }: {
   buyerIp?: string | null;
   storefrontToken: string;
+  secretToken?: string;
+  storefrontId?: string;
 }) {
   const headers = {} as Record<string, any>;
 
-  const secretToken = getOxygenVariable(
-    OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE
-  );
-  const storefrontId = getOxygenVariable(SHOPIFY_STOREFRONT_ID_VARIABLE);
+  if (!secretToken && !secretTokenWarned) {
+    secretTokenWarned = true;
+    secretToken = getOxygenVariable(OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE);
+
+    if (!secretToken && !__HYDROGEN_DEV__) {
+      log.error(
+        'No secret Shopify storefront API token was defined. This means your app will be rate limited!\nSee how to add the token: '
+      );
+    } else if (secretToken) {
+      log.warn(
+        'The private shopify storefront API token was loaded implicitly by an environment variable. This is deprecated, and instead the variable should be defined directly in the Hydrogen Config.\nFor more information: '
+      );
+    }
+  }
+
+  if (!storefrontId && !storefrontIdWarned) {
+    storefrontIdWarned = true;
+    storefrontId = getOxygenVariable(SHOPIFY_STOREFRONT_ID_VARIABLE);
+
+    if (!storefrontId && !__HYDROGEN_DEV__) {
+      log.warn(
+        'No storefrontId was defined. This means the analytics on your admin dashboard will be broken!\nSee how to fix it: '
+      );
+    } else if (storefrontId) {
+      log.warn(
+        'The storefrontId was loaded implicitly by an environment variable. This is deprecated, and instead the variable should be defined directly in the Hydrogen Config.\nFor more information: '
+      );
+    }
+  }
 
   /**
    * Only pass one type of storefront token at a time.

--- a/packages/hydrogen/src/utilities/storefrontApi.ts
+++ b/packages/hydrogen/src/utilities/storefrontApi.ts
@@ -20,8 +20,8 @@ export function getStorefrontApiRequestHeaders({
 }: {
   buyerIp?: string | null;
   storefrontToken: string;
-  secretToken?: string;
-  storefrontId?: string;
+  secretToken: string | undefined;
+  storefrontId: string | undefined;
 }) {
   const headers = {} as Record<string, any>;
 

--- a/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
+++ b/packages/hydrogen/src/utilities/tests/shopifyMount.tsx
@@ -64,6 +64,5 @@ export function getShopifyConfig(config: Partial<ShopifyConfig> = {}) {
     storeDomain: config.storeDomain ?? 'notashop.myshopify.io',
     storefrontToken: config.storefrontToken ?? 'abc123',
     storefrontApiVersion: config.storefrontApiVersion ?? '2022-07',
-    multipassSecret: config.multipassSecret,
   };
 }

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       // @ts-ignore
       Oxygen?.env?.PRIVATE_SHOPIFY_STOREFRONT_API_TOKEN,
     // @ts-ignore
-    storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
+    storefrontId: Oxygen?.env?.PUBLIC_SHOPIFY_STOREFRONT_ID,
     storefrontApiVersion: '2022-07',
   },
   session: CookieSessionStorage('__session', {

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -6,17 +6,16 @@ export default defineConfig({
     defaultLanguageCode: 'EN',
     storeDomain:
       // @ts-ignore
-      Oxygen?.env?.PUBLIC_SHOPIFY_STORE_DOMAIN ||
-      'hydrogen-preview.myshopify.com',
+      Oxygen?.env?.PUBLIC_STORE_DOMAIN || 'hydrogen-preview.myshopify.com',
     storefrontToken:
       // @ts-ignore
-      Oxygen?.env?.PUBLIC_SHOPIFY_STOREFRONT_API_TOKEN ||
+      Oxygen?.env?.PUBLIC_STOREFRONT_API_TOKEN ||
       '3b580e70970c4528da70c98e097c2fa0',
     privateStorefrontToken:
       // @ts-ignore
-      Oxygen?.env?.PRIVATE_SHOPIFY_STOREFRONT_API_TOKEN,
+      Oxygen?.env?.SECRET_STOREFRONT_API_TOKEN,
     // @ts-ignore
-    storefrontId: Oxygen?.env?.PUBLIC_SHOPIFY_STOREFRONT_ID,
+    storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
     storefrontApiVersion: '2022-07',
   },
   session: CookieSessionStorage('__session', {

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -6,11 +6,17 @@ export default defineConfig({
     defaultLanguageCode: 'EN',
     storeDomain:
       // @ts-ignore
-      Oxygen?.env?.SHOPIFY_STORE_DOMAIN || 'hydrogen-preview.myshopify.com',
+      Oxygen?.env?.PUBLIC_SHOPIFY_STORE_DOMAIN ||
+      'hydrogen-preview.myshopify.com',
     storefrontToken:
       // @ts-ignore
-      Oxygen?.env?.SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN ||
+      Oxygen?.env?.PUBLIC_SHOPIFY_STOREFRONT_API_TOKEN ||
       '3b580e70970c4528da70c98e097c2fa0',
+    privateStorefrontToken:
+      // @ts-ignore
+      Oxygen?.env?.PRIVATE_SHOPIFY_STOREFRONT_API_TOKEN,
+    // @ts-ignore
+    storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
     storefrontApiVersion: '2022-07',
   },
   session: CookieSessionStorage('__session', {

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       '3b580e70970c4528da70c98e097c2fa0',
     privateStorefrontToken:
       // @ts-ignore
-      Oxygen?.env?.SECRET_STOREFRONT_API_TOKEN,
+      Oxygen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
     // @ts-ignore
     storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
     storefrontApiVersion: '2022-07',

--- a/yarn.lock
+++ b/yarn.lock
@@ -16677,7 +16677,7 @@ unified-message-control@^3.0.0:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
 
-unified@^9.0.0:
+unified@9.2.2, unified@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We've exposed the private server-to-server Storefront API token in the Hydrogen config file. This private token is required when deploying to production, otherwise the requests to the storefront API will be rate-limited. This change will make it easier to configure Hydrogen when deploying to non-Oxygen environments. We'll also display a warning in production mode if this token is not defined.

We've also added the `storefrontId` property to the config. This enables Hydrogen data to display properly in the Shopify admin analytics dashboard.

Lastly, we've updated all Oxygen environment variables to a more consistent naming convention. The previous variables are still available, but are deprecated, and will be removed in the future. You’ll see a warning in your console if you use the old environment variables. You can update your variable references using this table:

| **Old Oxygen variable**             | **New Oxygen variable**      |
| ----------------------------------- | ---------------------------- |
| SHOPIFY_STORE_DOMAIN                | PUBLIC_STORE_DOMAIN          |
| SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN | PUBLIC_STOREFRONT_API_TOKEN  |
| SHOPIFY_STOREFRONT_API_SECRET_TOKEN | PRIVATE_STOREFRONT_API_TOKEN |
| SHOPIFY_STOREFRONT_ID               | PUBLIC_STOREFRONT_ID         |


### Additional context

This fixes a part of https://github.com/Shopify/hydrogen/issues/1879

---

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
