### PR TITLE
Don't have h-ui run builds in dev npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "dev": "yarn turbo run dev --parallel --filter=@shopify/hydrogen-ui --filter=@shopify/hydrogen",
+    "dev": "yarn turbo run dev --parallel --filter=@shopify/hydrogen",
     "build": "yarn turbo run build --filter=!test-*",
     "lint": "run-p lint:js lint:language lint:schema",
     "lint:js": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx packages/*/src",

--- a/packages/hydrogen-ui/package.json
+++ b/packages/hydrogen-ui/package.json
@@ -44,9 +44,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "dev": "run-p dev:vite dev:ts copy-storefront-types",
-    "dev:vite": "vite build --watch --emptyOutDir false --clearScreen false",
-    "dev:ts": "tsc --watch",
+    "dev": "vite dev",
     "build": "npm-run-all --parallel build:vite:* build:tsc:es --parallel build:tsc:cjs copy-storefront-types",
     "build:vite:dev": "vite build --mode devbuild",
     "build:vite:prod": "vite build",
@@ -55,7 +53,6 @@
     "copy-storefront-types": "cpy ./src/storefront-api-types.d.ts ./dist/types/ --flat",
     "format": "prettier --write \"src/**/*\"",
     "graphql-types": "graphql-codegen --config codegen.yml && yarn format",
-    "preview": "vite dev",
     "test": "vitest",
     "test:ci": "vitest run --coverage",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Fixes an issue where if you run `yarn dev` in the monorepo root, then h-ui would spit out some files that shouldn't be tracked. 

I'm still working on the actual dev experience, so for now this is just a bandaid to remove an annoying bug. 