### PR TITLE
Migrate ShopProvider to hydrogen-ui

### DIFF
--- a/packages/hydrogen-ui/src/ExternalVideo.stories.tsx
+++ b/packages/hydrogen-ui/src/ExternalVideo.stories.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react';
 import type {Story} from '@ladle/react';
 import {ExternalVideo, type ExternalVideoProps} from './ExternalVideo.js';
-
 import {PartialDeep} from 'type-fest';
 import type {
   ExternalVideo as ExternalVideoType,

--- a/packages/hydrogen-ui/src/ShopifyProvider.stories.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.stories.tsx
@@ -17,11 +17,9 @@ const Template: Story<{
     storefrontApiVersion: version,
     country: {
       isoCode: 'CA',
-      defaultIsoCode: 'CA',
     },
     language: {
       isoCode: 'EN',
-      defaultIsoCode: 'EN',
     },
     locale: 'en-CA',
   };

--- a/packages/hydrogen-ui/src/ShopifyProvider.stories.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.stories.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import type {Story} from '@ladle/react';
+import {
+  ShopifyProvider,
+  useShop,
+  type ShopifyContextValue,
+} from './ShopifyProvider.js';
+
+const Template: Story<{
+  storeDomain: string;
+  storefrontToken: string;
+  version: string;
+}> = ({storeDomain, storefrontToken, version}) => {
+  const config: ShopifyContextValue = {
+    storeDomain,
+    storefrontToken,
+    storefrontApiVersion: version,
+    country: {
+      isoCode: 'CA',
+      defaultIsoCode: 'CA',
+    },
+    language: {
+      isoCode: 'EN',
+      defaultIsoCode: 'EN',
+    },
+    locale: 'en-CA',
+  };
+  return (
+    <ShopifyProvider shopifyConfig={config}>
+      <TemplateChildren />
+    </ShopifyProvider>
+  );
+};
+
+const TemplateChildren = () => {
+  const shopValues = useShop();
+  return (
+    <>
+      Use the Controls tab change these values on the fly
+      {Object.keys(shopValues).map((key) => {
+        return (
+          <p key={key}>
+            <strong>{key}: </strong>
+            {typeof shopValues[key] === 'string'
+              ? shopValues[key]
+              : JSON.stringify(shopValues[key])}
+          </p>
+        );
+      })}
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  storeDomain: 'notashop.myshopify.com',
+  storefrontToken: 'abc123',
+  version: '2022-07',
+};

--- a/packages/hydrogen-ui/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.test.tsx
@@ -46,7 +46,9 @@ describe('<ShopifyProvider/>', () => {
       </ShopifyProvider>
     );
 
-    expect(screen.queryByText('https://notashop.myshopify.com')).toBeNull();
+    expect(
+      screen.queryByText('https://notashop.myshopify.com')
+    ).not.toBeInTheDocument();
     expect(screen.getByText('notashop.myshopify.com')).toBeInTheDocument();
   });
 });

--- a/packages/hydrogen-ui/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.test.tsx
@@ -12,11 +12,9 @@ const SHOPIFY_CONFIG: ShopifyContextValue = {
   storefrontApiVersion: '2022-07',
   country: {
     isoCode: 'CA',
-    defaultIsoCode: 'CA',
   },
   language: {
     isoCode: 'EN',
-    defaultIsoCode: 'EN',
   },
   locale: 'en-CA',
 };

--- a/packages/hydrogen-ui/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.test.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import {render, screen} from '@testing-library/react';
+import {
+  ShopifyProvider,
+  useShop,
+  type ShopifyContextValue,
+} from './ShopifyProvider.js';
+
+const SHOPIFY_CONFIG: ShopifyContextValue = {
+  storeDomain: 'notashop.myshopify.com',
+  storefrontToken: 'abc123',
+  storefrontApiVersion: '2022-07',
+  country: {
+    isoCode: 'CA',
+    defaultIsoCode: 'CA',
+  },
+  language: {
+    isoCode: 'EN',
+    defaultIsoCode: 'EN',
+  },
+  locale: 'en-CA',
+};
+
+describe('<ShopifyProvider/>', () => {
+  it('renders its children', () => {
+    render(
+      <ShopifyProvider shopifyConfig={SHOPIFY_CONFIG}>
+        <div>child</div>;
+      </ShopifyProvider>
+    );
+
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it(`contains 'storeDomain' without https:// prefix`, () => {
+    function OutputDomain() {
+      const {storeDomain} = useShop();
+      return <div>{storeDomain}</div>;
+    }
+    render(
+      <ShopifyProvider
+        shopifyConfig={{
+          ...SHOPIFY_CONFIG,
+          storeDomain: 'https://notashop.myshopify.com',
+        }}
+      >
+        <OutputDomain />
+      </ShopifyProvider>
+    );
+
+    expect(screen.queryByText('https://notashop.myshopify.com')).toBeNull();
+    expect(screen.getByText('notashop.myshopify.com')).toBeInTheDocument();
+  });
+});

--- a/packages/hydrogen-ui/src/ShopifyProvider.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.tsx
@@ -81,30 +81,14 @@ export type ShopifyContextValue = {
   country: {
     /**
      * The code designating a country, which generally follows ISO 3166-1 alpha-2 guidelines. If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision of another country. For example, the territories associated with Spain are represented by the country code `ES`, and the territories associated with the United States of America are represented by the country code `US`.
-     *
-     * This value can change depending on the customer's active country.
      */
     isoCode: CountryCode;
-    /**
-     * The code designating a country, which generally follows ISO 3166-1 alpha-2 guidelines. If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision of another country. For example, the territories associated with Spain are represented by the country code `ES`, and the territories associated with the United States of America are represented by the country code `US`.
-     *
-     * This value remains the same depsite changes in the customer's active country.
-     */
-    defaultIsoCode: CountryCode;
   };
   language: {
     /**
      * `ISO 369` language codes supported by Shopify.
-     *
-     * This value can change depending on the customer's active language.
      */
     isoCode: LanguageCode;
-    /**
-     * `ISO 369` language codes supported by Shopify.
-     *
-     * This value remains the same despite changes in the customer's active language.
-     */
-    defaultIsoCode: LanguageCode;
   };
   locale: string;
 };

--- a/packages/hydrogen-ui/src/ShopifyProvider.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.tsx
@@ -8,18 +8,16 @@ const ShopifyContext = createContext<ShopifyContextValue>({
   storefrontToken: 'abc123',
   storefrontApiVersion: SFAPI_VERSION,
   country: {
-    defaultIsoCode: 'CA',
     isoCode: 'CA',
   },
   language: {
-    defaultIsoCode: 'EN',
     isoCode: 'EN',
   },
   locale: 'en-CA',
 });
 
 /**
- * The `<ShopifyProvider/>` component should wrap your app and enables use of the `useShop()` and `useLocalization()` hooks.
+ * The `<ShopifyProvider/>` component should wrap your app and enables use of the `useShop()` hook.
  */
 export function ShopifyProvider({
   children,

--- a/packages/hydrogen-ui/src/ShopifyProvider.tsx
+++ b/packages/hydrogen-ui/src/ShopifyProvider.tsx
@@ -1,0 +1,110 @@
+import {createContext, useContext, useMemo, type ReactNode} from 'react';
+import type {LanguageCode, CountryCode, Shop} from './storefront-api-types.js';
+
+const SFAPI_VERSION = '2022-07';
+
+const ShopifyContext = createContext<ShopifyContextValue>({
+  storeDomain: 'test.myshopify.com',
+  storefrontToken: 'abc123',
+  storefrontApiVersion: SFAPI_VERSION,
+  country: {
+    defaultIsoCode: 'CA',
+    isoCode: 'CA',
+  },
+  language: {
+    defaultIsoCode: 'EN',
+    isoCode: 'EN',
+  },
+  locale: 'en-CA',
+});
+
+/**
+ * The `<ShopifyProvider/>` component should wrap your app and enables use of the `useShop()` and `useLocalization()` hooks.
+ */
+export function ShopifyProvider({
+  children,
+  shopifyConfig,
+}: {
+  children: ReactNode;
+  shopifyConfig: ShopifyContextValue;
+}) {
+  if (!shopifyConfig) {
+    throw new Error(
+      `The 'shopifyConfig' prop must be passed to '<ShopifyProvider/>'`
+    );
+  }
+
+  if (shopifyConfig.storefrontApiVersion !== SFAPI_VERSION) {
+    console.warn(
+      `This version of Hydrogen-UI is built for Shopify's Storefront API version ${SFAPI_VERSION}, but it appears you're using version ${shopifyConfig.storefrontApiVersion}. There may be issues or bugs if you use a mismatched version of Hydrogen-UI and the Storefront API.`
+    );
+  }
+
+  const finalConfig = useMemo<ShopifyContextValue>(
+    () => ({
+      ...shopifyConfig,
+      storeDomain: shopifyConfig.storeDomain.replace(/^https?:\/\//, ''),
+    }),
+    [shopifyConfig]
+  );
+
+  return (
+    <ShopifyContext.Provider value={finalConfig}>
+      {children}
+    </ShopifyContext.Provider>
+  );
+}
+
+/**
+ * Provides access to the `shopifyConfig` prop of `<ShopifyProvider/>`. Must be a descendent of `<ShopifyProvider/>`.
+ */
+export function useShop() {
+  const shopContext = useContext(ShopifyContext);
+  if (!shopContext) {
+    throw new Error(`'useShop()' must be a descendent of <ShopifyProvider/>`);
+  }
+  return shopContext;
+}
+
+/**
+ * Shopify-specific values that are used in various Hydrogen-UI components and hooks.
+ */
+export type ShopifyContextValue = {
+  /** The globally-unique identifier for the Shop */
+  storefrontId?: Shop['id'];
+  /** The host name of the domain (eg: `store.myshopify.com`). If a URL with a scheme (for example `https://`) is passed in, the scheme will be removed. */
+  storeDomain: Shop['primaryDomain']['host'];
+  /** The Storefront API access token. See [Authentication](https://shopify.dev/api/storefront#authentication) documentation for more details. */
+  storefrontToken: string;
+  /** The Storefront API version. This should almost always be the same as the version Hydrogen-UI was built for. See [Shopify API Versioning](https://shopify.dev/api/usage/versioning) for more details.  */
+  storefrontApiVersion: string;
+  country: {
+    /**
+     * The code designating a country, which generally follows ISO 3166-1 alpha-2 guidelines. If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision of another country. For example, the territories associated with Spain are represented by the country code `ES`, and the territories associated with the United States of America are represented by the country code `US`.
+     *
+     * This value can change depending on the customer's active country.
+     */
+    isoCode: CountryCode;
+    /**
+     * The code designating a country, which generally follows ISO 3166-1 alpha-2 guidelines. If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision of another country. For example, the territories associated with Spain are represented by the country code `ES`, and the territories associated with the United States of America are represented by the country code `US`.
+     *
+     * This value remains the same depsite changes in the customer's active country.
+     */
+    defaultIsoCode: CountryCode;
+  };
+  language: {
+    /**
+     * `ISO 369` language codes supported by Shopify.
+     *
+     * This value can change depending on the customer's active language.
+     */
+    isoCode: LanguageCode;
+    /**
+     * `ISO 369` language codes supported by Shopify.
+     *
+     * This value remains the same despite changes in the customer's active language.
+     */
+    defaultIsoCode: LanguageCode;
+  };
+  locale: string;
+};

--- a/packages/hydrogen-ui/src/index.ts
+++ b/packages/hydrogen-ui/src/index.ts
@@ -1,2 +1,3 @@
+export {ShopifyProvider, useShop} from './ShopifyProvider.js';
 export {ExternalVideo} from './ExternalVideo.js';
 export {Video} from './Video.js';


### PR DESCRIPTION
This PR has it all! 

- The first true migration of a component to hydrogen-ui
- Tests
- Vastly improved TS documentation for each property in the shopify config
- Merge of LocalizationProvider and ShopifyProvider
- A ladle story with controls 
<img width="423" alt="Screen Shot 2022-08-19 at 4 09 32 PM" src="https://user-images.githubusercontent.com/3054066/185713656-b4d0697a-fa28-4304-b59c-e04522296ed6.png">

