### PR TITLE
Add line level cart discounts to cart-queries

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/cart-queries.ts
+++ b/packages/hydrogen/src/components/CartProvider/cart-queries.ts
@@ -131,6 +131,12 @@ fragment CartFragment on Cart {
       node {
         id
         quantity
+        discountAllocations {
+          discountedAmount {
+            amount
+            currencyCode
+          }
+        }
         attributes {
           key
           value


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Problem: Impossible to add line level discount summaries to the cart drawer using default useCart hook

Reason: The the cart query fragrament on the CartProvider does not include cart level 'discountAllocations'.

Solution: Add line level 'discountAllocations' to the default cart query fragment used by the CartProvider component.

### Additional context

I think the default cart provider cart query should include line level discounts - it already includes cart level discounts and this seems to be of equal relevance to those building e.g. carts that show discounts at the cart drawer level.

