### PR TITLE
E2e tests overhaul

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     'jest/no-disabled-tests': 'off',
     'jest/no-export': 'off',
     'jsx-a11y/iframe-has-title': 'off',
+    'jest/no-standalone-expect': 'off',
     'no-console': 'off',
     'no-constant-condition': 'off',
     'jest/no-done-callback': 'off',

--- a/.github/workflows/tests_and_lint.yml
+++ b/.github/workflows/tests_and_lint.yml
@@ -71,3 +71,8 @@ jobs:
         working-directory: ./templates/demo-store
         env:
           CI: true
+
+      - name: Run the Vitest E2E tests
+        run: yarn test-e2e-new
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "templates/*",
     "packages/*",
-    "packages/playground/*"
+    "packages/playground/*",
+    "test/**/fixture"
   ],
   "engines": {
     "node": ">=14"
@@ -23,6 +24,7 @@
     "test:base": "jest",
     "test:coverage": "jest --coverage",
     "test-e2e": "jest --config jest-e2e.config.ts --runInBand",
+    "test-e2e-new": "vitest run --config ./test/vitest.config.ts",
     "test:vite-ci": "cross-env FORCE_COLOR=true jest && jest --config jest-e2e.config.ts",
     "test:hydrogen:vite": "yarn workspace @shopify/hydrogen test:vitest:ci",
     "test:hydrogen-ui": "yarn workspace @shopify/hydrogen-ui test:ci",
@@ -45,7 +47,9 @@
     "@typescript-eslint/parser": "^4.20.0",
     "abort-controller": "^3.0.0",
     "alex": "^9.1.0",
+    "change-case": "^4.1.2",
     "cross-env": "^7.0.3",
+    "debug": "^4.3.4",
     "eslint": "^8.16.0",
     "eslint-plugin-hydrogen": "^0.12.1",
     "eslint-plugin-node": "^11.1.0",
@@ -55,12 +59,15 @@
     "faker": "^5.5.3",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.0.0",
+    "get-port": "^3.1.0",
     "glob": "^7.2.0",
     "jest": "^26.6.3",
     "jsonlint": "^1.6.3",
     "lint-staged": "^10.5.4",
+    "miniflare": "^1.3.3",
     "node-fetch": "^2.6.7",
     "npm-run-all": "^4.1.5",
+    "playwright": "^1.22.2",
     "playwright-chromium": "^1.13.0",
     "prettier": "^2.2.1",
     "sirv": "^1.0.12",
@@ -70,6 +77,7 @@
     "type-fest": "^2.12.0",
     "typescript": "^4.7.2",
     "vite": "^2.9.0",
+    "vitest": "^0.19.1",
     "yorkie": "^2.0.0"
   },
   "gitHooks": {
@@ -91,7 +99,6 @@
     ]
   },
   "resolutions": {
-    "unified": "9.2.2",
     "@shopify/cli-kit": "3.6.1"
   },
   "version": "0.0.0"

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -10,6 +10,7 @@ export * from './client.js';
  * The following are exported from this file because they are intended to be available
  * *only* on the server.
  */
+
 export {
   ServerPropsProvider,
   ServerPropsContext,

--- a/test/basic-route/basic-route.test.ts
+++ b/test/basic-route/basic-route.test.ts
@@ -1,0 +1,14 @@
+import {beforeAll} from 'vitest';
+import {describe, MINIMAL_TEMPLATE} from '../test-framework';
+
+describe(
+  'basic-route',
+  ({fs}) => {
+    beforeAll(async () => {
+      await fs.write(MINIMAL_TEMPLATE);
+    });
+  },
+  {
+    routes: import.meta.glob('./routes/*.server.*'),
+  }
+);

--- a/test/basic-route/routes/index.server.tsx
+++ b/test/basic-route/routes/index.server.tsx
@@ -1,0 +1,13 @@
+export default function home() {
+  return <div className="text">Hello world</div>;
+}
+
+export const tests = ({expect, it, browser}) => {
+  it('Loads hello world', async () => {
+    await browser.navigate('/');
+
+    const text = await browser.text('.text');
+
+    expect(text).toBe('Hello world');
+  });
+};

--- a/test/multiple-routes/multiple-routes.test.tsx
+++ b/test/multiple-routes/multiple-routes.test.tsx
@@ -1,0 +1,81 @@
+import {beforeAll, expect} from 'vitest';
+import {describe, MINIMAL_TEMPLATE} from '../test-framework';
+
+describe(
+  'multiple-routes',
+  ({fs, browser, it}) => {
+    beforeAll(async () => {
+      await fs.write(MINIMAL_TEMPLATE);
+
+      await fs.write(
+        'src/routes/index.server.jsx',
+        `
+        import {Link} from '@shopify/hydrogen';
+
+        export default function Home() {
+          return (
+            <>
+              <h1>Home</h1>
+              <Link className="btn" to="/about">About</Link>
+            </>
+          );
+        }
+        `
+      );
+      await fs.write(
+        'src/routes/about.server.jsx',
+        `
+        import Counter from '../components/Counter.client';
+
+        export default function About() {
+          return (
+            <>
+              <h1 className="about">About</h1>
+              <Counter />
+            </>
+          );
+        }
+        `
+      );
+      await fs.write(
+        'src/components/Counter.client.jsx',
+        `
+        import {useState} from 'react';
+
+        export default function Counter() {
+          const [count, setCount] = useState(0);
+
+          return (
+            <div>
+              <h2 className="count">Count is {count}</h2>
+              <button className="increase" onClick={() => setCount(count + 1)}>
+                increase count
+              </button>
+            </div>
+          );
+        }
+        `
+      );
+    });
+
+    it('shows the homepage, navigates to about, and increases the count', async () => {
+      await browser.navigate('/');
+
+      expect(await browser.text('h1')).toBe('Home');
+
+      await browser.click('.btn');
+
+      expect(await browser.url().endsWith('/about')).toBeTruthy();
+      expect(await browser.text('.about')).toBe('About');
+      expect(await browser.text('.count')).toBe('Count is 0');
+
+      await browser.click('.increase');
+
+      expect(await browser.text('.count')).toBe('Count is 1');
+    });
+  },
+  {
+    modes: ['node-dev', 'node-prod'],
+    routes: import.meta.glob('./routes/*.server.*'),
+  }
+);

--- a/test/test-framework.ts
+++ b/test/test-framework.ts
@@ -1,0 +1,639 @@
+import {paramCase} from 'change-case';
+import {resolve, dirname, sep, join, extname} from 'path';
+import {
+  TestContext,
+  it as vitestIt,
+  describe as vitestDescribe,
+  beforeAll as vitestBeforeAll,
+  afterAll as vitestAfterAll,
+  beforeEach as vitestBeforeEach,
+  expect,
+} from 'vitest';
+import {
+  readFile,
+  mkdirp,
+  writeFile,
+  pathExists,
+  emptyDir,
+  remove,
+  copy,
+} from 'fs-extra';
+import debug from 'debug';
+import {
+  InlineConfig,
+  createServer as createViteServer,
+  loadEnv as viteLoadEnv,
+  build as viteBuild,
+} from 'vite';
+import {chromium} from 'playwright';
+import type {Browser, Page} from 'playwright';
+import {format as prettierFormat} from 'prettier';
+import getPort from 'get-port';
+import {Miniflare} from 'miniflare';
+
+interface Context {
+  fs: SandboxFileSystem;
+  instance: SandboxInstance;
+  browser: SandboxBrowser;
+  it: any;
+}
+
+type Mode = 'node-prod' | 'worker-prod' | 'node-dev';
+
+interface SandboxOptions {
+  debug?: boolean;
+  persist?: boolean;
+  modes?: Mode[];
+  routes?: Record<
+    string,
+    () => Promise<{
+      [key: string]: any;
+    }>
+  >;
+}
+
+const log = debug('hydrogen:test');
+
+const DefaultOptions = {
+  modes: ['node-dev', 'node-prod', 'worker-prod'] as Mode[],
+};
+
+export function describe(
+  name: string,
+  runner: (context: Context & Omit<TestContext, 'error'>) => void,
+  options: SandboxOptions = DefaultOptions
+) {
+  const {routes, modes = DefaultOptions.modes} = options;
+  const root = join(__dirname, paramCase(name));
+  const directory = join(root, 'fixture');
+  const fs = new SandboxFileSystem(directory, options);
+  const instance = new SandboxInstance(directory, options);
+  const browser = new SandboxBrowser(options);
+
+  const it = (name: string, runner: (mode: string) => void) => {
+    vitestIt.each(modes)(`[%s] ${name}`, runner);
+  };
+
+  vitestDescribe(name, async (context: TestContext) => {
+    await addRoutesToFixture(root, routes);
+
+    await vitestDescribe.each(modes)('[%s] routes', async (mode) => {
+      vitestBeforeAll(async () => {
+        await fs.init();
+        await instance.init(mode);
+      });
+
+      vitestBeforeEach(async () => {
+        await browser.open(instance.servers[mode].url());
+      });
+
+      vitestBeforeEach(async () => {
+        await browser.close();
+      });
+
+      const routeEntries = Object.entries(routes);
+
+      if (!routeEntries.length) {
+        vitestIt('ping', async () => {
+          await browser.navigate('/ping');
+          expect(await browser.text('div')).toBe('PONG');
+        });
+      }
+
+      for (const route of routeEntries) {
+        const [name, module] = route;
+        const tests = (await module()).tests;
+
+        await tests({
+          expect,
+          it: vitestIt,
+          browser,
+          instance,
+          name,
+          mode,
+          ...context,
+        });
+      }
+    });
+
+    await runner({fs, it, browser, instance, ...context});
+
+    vitestAfterAll(async () => {
+      if (!options.persist) {
+        await browser.close();
+        await instance.destroy();
+        await fs.cleanup();
+      }
+    });
+  });
+}
+
+export class SandboxFileSystem {
+  debug?: boolean;
+  initialized?: boolean;
+  files: Map<string, string> = new Map();
+
+  constructor(public readonly root: string, options: SandboxOptions = {}) {
+    this.debug = options.debug;
+
+    log(`Creating sandbox filesystem at ${root} ${options.debug}`);
+
+    mkdirp(this.root);
+  }
+
+  async init() {
+    const paths = this.root.split('/');
+    const name = paths[paths.length - 2];
+    writeFile(join(this.root, '.gitignore'), '*');
+    writeFile(
+      join(this.root, 'package.json'),
+      JSON.stringify(
+        {
+          name: `@fixture/${name}`,
+          private: true,
+          version: '0.0.0',
+          devDependencies: {
+            vite: '^3.0.0',
+          },
+          dependencies: {
+            react: '^18.2.0',
+            'react-dom': '^18.2.0',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    mkdirp(join(this.root, 'public'));
+    mkdirp(join(this.root, 'src', 'routes'));
+    writeFile(
+      join(this.root, 'src', 'routes', 'ping.server.jsx'),
+      `
+        export default function Ping() {
+          return <div>PONG</div>;
+        }
+    `
+    );
+
+    this.initialized = true;
+  }
+
+  private resolvePath(...parts: string[]) {
+    return resolve(this.root, ...parts);
+  }
+
+  async write(
+    file: string | [string, ((a: any) => string) | string][],
+    contents?: ((a: any) => string) | string
+  ) {
+    if (Array.isArray(file)) {
+      for (const [filePath, contents] of file) {
+        await this.write(filePath, contents);
+      }
+      return;
+    }
+
+    const filePath = this.resolvePath(file);
+    const content = contents instanceof Function ? contents(file) : contents;
+    const formattedContent = await this.format(filePath, content);
+
+    await mkdirp(dirname(filePath));
+
+    if (this.initialized) {
+      this.files.set(filePath, formattedContent);
+    }
+
+    await writeFile(filePath, formattedContent, {encoding: 'utf8'});
+  }
+
+  async reset() {
+    for (const [filePath] of Array.from(this.files.entries())) {
+      await remove(filePath);
+    }
+  }
+
+  async edit(file: string) {
+    // TODO move our utility for this over to the sandbox instance
+  }
+
+  async read(file: string) {
+    const filePath = this.resolvePath(file);
+    return readFile(filePath, 'utf8');
+  }
+
+  async exists(file: string) {
+    const filePath = this.resolvePath(file);
+    return pathExists(filePath);
+  }
+
+  async cleanup() {
+    await emptyDir(this.root);
+    await remove(this.root);
+  }
+
+  async format(path, content) {
+    if (!this.debug) {
+      return content;
+    }
+
+    const ext = extname(path);
+    const prettierConfig = {
+      arrowParens: 'always' as const,
+      singleQuote: true,
+      bracketSpacing: false,
+      trailingComma: 'all' as const,
+      parser: 'babel',
+    };
+
+    switch (ext) {
+      case '.md':
+        prettierConfig.parser = 'markdown';
+        break;
+      case '.html':
+      case '.svg':
+        prettierConfig.parser = 'html';
+        break;
+      case '.json':
+      case '.css':
+        prettierConfig.parser = ext.slice(1);
+        break;
+    }
+
+    const formattedContent = await prettierFormat(content, prettierConfig);
+
+    return formattedContent;
+  }
+}
+
+interface Server {
+  url: string;
+  close: () => Promise<void>;
+}
+
+// Instance
+export class SandboxInstance {
+  debug?: boolean;
+  servers: Server[] = [];
+
+  constructor(public readonly root: string, options: SandboxOptions = {}) {
+    this.debug = options.debug;
+
+    log(`Creating sandbox instance at ${root}`);
+  }
+
+  async init(mode: Mode) {
+    log(`Initiating SandboxInstance in ${mode}`);
+
+    await this.mount(mode, async ({port, ip}) => {
+      const config = {
+        port,
+        ip,
+        watch: false,
+        root: this.root,
+        mode,
+      };
+
+      let server;
+
+      try {
+        switch (mode) {
+          case 'node-dev':
+            server = await createNodeDevServer(config);
+
+            break;
+          case 'worker-prod':
+            await build(config);
+            server = await createWorkerProdServer(config);
+
+            break;
+          case 'node-prod':
+            await build(config);
+            server = await createNodeProdServer(config);
+
+            break;
+          default:
+            throw new Error(`Unknown mode: ${mode}`);
+        }
+      } catch (error) {
+        throw new Error(
+          `Error during ${mode} instantiation. This indicates a problem with the test fixture during build and/or serve. 
+          ${error}`
+        );
+      }
+      return server;
+    });
+  }
+
+  async mount(mode, mountFunction: ({port: number, ip: string}) => any) {
+    const port = await getPort();
+    const ip = 'http://localhost';
+    const url = () => `${ip}:${port}`;
+
+    const server = await mountFunction({port, ip});
+
+    this.servers[mode] = {...server, url};
+  }
+
+  async destroy() {
+    this.servers.forEach((server) => {
+      server.close();
+    });
+  }
+}
+
+export class SandboxBrowser {
+  page: Page;
+  chrome: Browser;
+  debug?: boolean;
+
+  constructor(public readonly options: SandboxOptions = {}) {
+    this.debug = options.debug;
+  }
+
+  async open(url: string) {
+    this.chrome = await chromium.launch({
+      headless: !this.debug,
+      slowMo: this.debug ? 2000 : 0,
+      devtools: this.debug,
+      args: process.env.CI
+        ? ['--no-sandbox', '--disable-setuid-sandbox']
+        : undefined,
+    });
+
+    this.page = await this.chrome.newPage({baseURL: url});
+  }
+
+  async click(selector: string) {
+    await this.page.click(selector);
+  }
+
+  async navigate(url: string) {
+    await this.page.goto(url);
+  }
+
+  async text(selector: string) {
+    await this.page.waitForSelector(selector);
+
+    const text = await this.page.evaluate(
+      (querySelector) => document.querySelector(querySelector)?.textContent,
+      selector
+    );
+
+    return text;
+  }
+
+  url() {
+    return this.page.url();
+  }
+
+  async close() {
+    this.chrome?.close();
+  }
+}
+
+interface BuildConfig {
+  root: string;
+  mode: Mode;
+}
+
+interface ServerConfig extends BuildConfig {
+  port?: number;
+  ip?: string;
+}
+
+async function createWorkerProdServer({root, port}: ServerConfig) {
+  const mf = new Miniflare({
+    scriptPath: resolve(root, 'dist/worker/index.js'),
+    sitePath: resolve(root, 'dist/client'),
+    bindings: await loadEnv(root),
+  });
+
+  const app = mf.createServer();
+
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        resolve({
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve);
+            });
+          },
+        });
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function createNodeProdServer({port, root}: ServerConfig) {
+  const env = await loadEnv(root);
+
+  Object.assign(process.env, env);
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const {createServer} = require(join(root, 'dist', 'node'));
+
+  const {app} = await createServer({cwd: root});
+
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        resolve({
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve);
+            });
+          },
+        });
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function createNodeDevServer({port, ip, root}) {
+  const server = await createViteServer({
+    root,
+    logLevel: 'silent',
+    server: {
+      watch: {
+        usePolling: true,
+        interval: 100,
+      },
+      host: true,
+      port,
+    },
+  });
+
+  await server.listen();
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.httpServer?.close((error) =>
+          error ? reject(error) : resolve()
+        );
+      }),
+  };
+}
+
+async function build({root, mode}: BuildConfig) {
+  log('building', mode, root);
+
+  const entries: Record<Mode, string | boolean> = {
+    'node-prod': `@shopify/hydrogen/platforms/node`,
+    'worker-prod': `@shopify/hydrogen/platforms/worker-event`,
+    'node-dev': false,
+  };
+
+  const entry = entries[mode];
+
+  if (!entry) {
+    return;
+  }
+
+  const targets = {
+    client: async () =>
+      !(await pathExists(join(root, 'dist', 'client', 'index.html'))),
+    worker: mode === 'worker-prod' ? entry : false,
+    node: mode === 'node-prod' ? entry : false,
+  };
+
+  for (const [key, value] of Object.entries(targets)) {
+    log(key, value);
+
+    const ssr = typeof value === 'function' ? await value() : value;
+
+    if (!ssr) {
+      continue;
+    }
+
+    if (key === 'worker') {
+      process.env.WORKER = 'true';
+    }
+
+    const config: InlineConfig = {
+      root,
+      logLevel: 'silent',
+      build: {
+        outDir: `dist/${key}`,
+        ssr: typeof ssr === 'string' ? ssr : undefined,
+        manifest: key === 'client',
+      },
+    };
+
+    await viteBuild(config);
+  }
+}
+
+async function addRoutesToFixture(root, routes) {
+  for (const route of Object.entries(routes)) {
+    const [name] = route;
+    const source = join(root, name);
+    const paths = source.split(sep);
+    const routesIndex = paths.indexOf('routes');
+    const dest = [
+      ...paths.slice(0, routesIndex),
+      'fixture',
+      'src',
+      'routes',
+      ...paths.slice(routesIndex + 1),
+    ].join(sep);
+
+    await copy(source, dest);
+  }
+}
+
+async function loadEnv(root) {
+  const env = await viteLoadEnv('production', root, '');
+  Object.keys(env).forEach((key) => {
+    if (['VITE_', 'PUBLIC_'].some((prefix) => key.startsWith(prefix))) {
+      delete env[key];
+    }
+  });
+
+  return env;
+}
+
+export const MINIMAL_TEMPLATE: [string, ((a: any) => string) | string][] = [
+  [
+    'index.html',
+    ({title}) => `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>${title || 'Hydrogen App'}</title>
+      </head>
+      <body>
+        <div id="root"></div>
+        <script type="module" src="/@shopify/hydrogen/entry-client"></script>
+      </body>
+    </html>
+  `,
+  ],
+
+  [
+    'vite.config.js',
+    () =>
+      `
+    import {defineConfig} from 'vite';
+    import hydrogen from '@shopify/hydrogen/plugin';
+
+    export default defineConfig({
+      plugins: [hydrogen()],
+    });
+
+  `,
+  ],
+
+  [
+    'hydrogen.config.js',
+    () => `
+    import {defineConfig} from '@shopify/hydrogen/config';
+
+    export default defineConfig({
+      shopify: {
+        storeDomain: 'hydrogen-preview.myshopify.com',
+        storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
+        storefrontApiVersion: '2022-07',
+      },
+      logger: {
+        trace: () => {},
+        debug: () => {},
+        warn: () => {},
+        error: () => {},
+        fatal: () => {},
+      }
+    });
+  `,
+  ],
+  [
+    'src/App.Server.jsx',
+    () => `
+    import React from 'react';
+    import renderHydrogen from '@shopify/hydrogen/entry-server';
+    import {Router, FileRoutes, ShopifyProvider} from '@shopify/hydrogen';
+    import {Suspense} from 'react';
+
+    function App() {
+      return (
+        <Suspense fallback={null}>
+          <ShopifyProvider>
+            <Router>
+              <FileRoutes />
+            </Router>
+          </ShopifyProvider>
+        </Suspense>
+      );
+    }
+
+    export default renderHydrogen(App);
+  `,
+  ],
+];

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    include: ['test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    watchExclude: ['**/node_modules/**', '**/dist/**', '**/fixture/**'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,6 +1983,11 @@
     ts-node "^9"
     tslib "^2"
 
+"@esbuild/linux-loong64@0.14.54":
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
+  integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
+
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
@@ -3434,9 +3439,9 @@
     tslib "^2"
 
 "@oclif/core@^1.0", "@oclif/core@^1.0.0":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.12.1.tgz#685bf58026fc3bfa6fc45afa4dbc9bdababf680f"
-  integrity sha512-9ZPh9MLirv2CbOHMybPw3Fczr56OAVi8UQZXTBM4AYmtuL3nHsovV5lvsNPvtAqa+IQuJQb//ERpKTThwJY6WA==
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.13.10.tgz#d2014cd75efcd8529d78f1eda5ddc2a4d07c860e"
+  integrity sha512-nwpjXwWscETdvO+/z94V1zd95vnzmCB6VRaobR4BdBllwWU6jHF/eCi1Ud2Tk9RSedChoLneZuDCkKnRCmxyng==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
     "@oclif/screen" "^3.0.2"
@@ -3591,12 +3596,12 @@
     any-observable "^0.3.0"
 
 "@shopify/cli-hydrogen@^3.3.3":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@shopify/cli-hydrogen/-/cli-hydrogen-3.6.1.tgz#554f99d75bc1e4dac61b32445c5271fdabf4e327"
-  integrity sha512-Qte9+ZKZZ1+EwG1auO8+qiAsd0C4nA2hL6HIRyoLexBFZ7FQ6pDvzfaTU6fMtRnGU11jnjgyxXjAe8qzDQpMkQ==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@shopify/cli-hydrogen/-/cli-hydrogen-3.6.2.tgz#9a59c21903dc1e093410d3de94a54bb9f6a6a14e"
+  integrity sha512-fIJmKwaEtfiozif+m6I3ZXVAQrgEaVaqbftB1PA2zGcAt9SWu2G3jgfCh/OAc9ZlGTmOKjSLFaEhgnXuYRE45w==
   dependencies:
     "@oclif/core" "^1.0.0"
-    "@shopify/cli-kit" "3.6.1"
+    "@shopify/cli-kit" "3.6.2"
     "@shopify/hydrogen" "^0.26.0"
     "@shopify/mini-oxygen" "^0.1.0"
     "@shopify/prettier-config" "^1.1.2"
@@ -3607,7 +3612,7 @@
     typescript "^4.7.4"
     vite "^2.9.9"
 
-"@shopify/cli-kit@3.6.1", "@shopify/cli-kit@^3.0.0":
+"@shopify/cli-kit@3.6.1", "@shopify/cli-kit@3.6.2", "@shopify/cli-kit@^3.0.0":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@shopify/cli-kit/-/cli-kit-3.6.1.tgz#64fab589b65b0661b921569b3e019295fd3f8eed"
   integrity sha512-JUOinqCG7FGG9mcVQIsFawTWJQLWwymnJnfasiXZilUMfwi7I1GKZ6aPP4OvuSzuvUQeyL139nR6vtweWtUEFg==
@@ -3666,14 +3671,14 @@
     zod "^3.17.3"
 
 "@shopify/cli@^3.3.3":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@shopify/cli/-/cli-3.6.1.tgz#9907bdc74661441590f695731407e973e2999e0e"
-  integrity sha512-cWtE77QZXA6+9deaicOx+TOQGgAchjXrkRvk6bwDQOqaIezhPeAADctGzrpVwmxPfwRhIHXs6TQGnzeFOpbxXg==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@shopify/cli/-/cli-3.6.2.tgz#8556dada6dba3c73fec8c9126fa6462561383bf3"
+  integrity sha512-EGQ9yaiL++MqZSG/06C8lt4PRAsQj3QY7cuUR44wE2TF4Un1V2tJz1OyGHSruf2HzuVEqwa+tLW957NccZtd3A==
   dependencies:
     "@oclif/core" "^1.0"
     "@oclif/plugin-help" "^5.1.12"
     "@oclif/plugin-plugins" "^2.1.0"
-    "@shopify/cli-kit" "3.6.1"
+    "@shopify/cli-kit" "3.6.2"
     "@shopify/plugin-ngrok" "^0.2.9"
 
 "@shopify/hydrogen@^0.26.0":
@@ -6260,9 +6265,9 @@ concat-stream@^2.0.0:
     typedarray "^0.0.6"
 
 conf@^10.1.2:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/conf/-/conf-10.1.2.tgz#50132158f388756fa9dea3048f6b47935315c14e"
-  integrity sha512-o9Fv1Mv+6A0JpoayQ8JleNp3hhkbOJP/Re/Q+QqxMPHPkABVsRjQGWZn9A5GcqLiTNC6d89p2PB5ZhHVDSMwyg==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-10.2.0.tgz#838e757be963f1a2386dfe048a98f8f69f7b55d6"
+  integrity sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==
   dependencies:
     ajv "^8.6.3"
     ajv-formats "^2.1.1"
@@ -7229,200 +7234,200 @@ esbuild-android-64@0.14.41:
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.41.tgz#34de1b983a81b22207db6faf937a600f15c5ca9b"
   integrity sha512-byyo8LPOGHzAqxbwh2Q72d7L+rXXTsr/KALjsiCySrJ60CGMe80i3bwoQ+WODxsGaH08R//yg5oc7xHKgQz4uw==
 
-esbuild-android-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz#9e4682c36dcf6e7b71b73d2a3723a96e0fdc5054"
-  integrity sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==
+esbuild-android-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz#505f41832884313bbaffb27704b8bcaa2d8616be"
+  integrity sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==
 
 esbuild-android-arm64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.41.tgz#42ff3d409d4962342a67aef3d2caa9be502e3def"
   integrity sha512-7koo9Dm/mwK4M8PGQX8JQRc4UQ4Wj7DT1nD4BQkVs2jxtHbYOlnsQH0fneKSXZVmnBIHYcntr/e1VU5gnYLvGQ==
 
-esbuild-android-arm64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz#9861b1f7e57d1dd1f23eeef6198561c5f34b51f6"
-  integrity sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==
+esbuild-android-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz#8ce69d7caba49646e009968fe5754a21a9871771"
+  integrity sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==
 
 esbuild-darwin-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.41.tgz#73d8789b59c6086cfeba9aa59f60cb12cfbe4439"
   integrity sha512-kW8fC2auh9jjmBXudTmlMfbBCMYMuujhxG40CxMhKiQ8NLBK4RU9yUYY6ss7QJp24kVTtKd4IvfwOio9SE53MA==
 
-esbuild-darwin-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.49.tgz#fd30a5ebe28704a3a117126c60f98096c067c8d1"
-  integrity sha512-3rvqnBCtX9ywso5fCHixt2GBCUsogNp9DjGmvbBohh31Ces34BVzFltMSxJpacNki96+WIcX5s/vum+ckXiLYg==
+esbuild-darwin-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz#24ba67b9a8cb890a3c08d9018f887cc221cdda25"
+  integrity sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==
 
 esbuild-darwin-arm64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.41.tgz#faf5eecd8e8a170aea741f0f0896e73f5b0e0716"
   integrity sha512-cO0EPkiQt0bERH9sZFIoTywWfGhEpshdpvQpDfLh/ZJLeioQfaarM9YDrmID+f7k77djh0mdyfsC6XpS0HlLsw==
 
-esbuild-darwin-arm64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz#c04a3a57dad94a972c66a697a68a25aa25947f41"
-  integrity sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==
+esbuild-darwin-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz#3f7cdb78888ee05e488d250a2bdaab1fa671bf73"
+  integrity sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==
 
 esbuild-freebsd-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.41.tgz#b44923dfdf84bb3ec3a84739817ea08e4b50c0fb"
   integrity sha512-6tsMDK6b7czCOjsr68BgVogFXcTCWL3T7yFXRFuAmXwY9ybYgX8sybD7ztrRB03dLAPeMxHo+PzeMD6LdVrLdQ==
 
-esbuild-freebsd-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz#c404dbd66c98451395b1eef0fa38b73030a7be82"
-  integrity sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==
+esbuild-freebsd-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz#09250f997a56ed4650f3e1979c905ffc40bbe94d"
+  integrity sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==
 
 esbuild-freebsd-arm64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.41.tgz#91dac0d5d5a3f9dc4a422628556bd64c98d62c1e"
   integrity sha512-AQ2S/VCLKVBe/+HNiFLyp3w9i7AEtCOWEzKHSkfHk0VO5bPzHd7WJfWmj1Bxliu7vdPESbiDUTJIH3rDt4bzSA==
 
-esbuild-freebsd-arm64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz#b62cec96138ebc5937240ce3e1b97902963ea74a"
-  integrity sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==
+esbuild-freebsd-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz#bafb46ed04fc5f97cbdb016d86947a79579f8e48"
+  integrity sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==
 
 esbuild-linux-32@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.41.tgz#6342094df325df46ad7a3d920af7af04c1a495a9"
   integrity sha512-sb7Kah5Px6BNZ6gzm0nJLuDeAJKbIlaKIoI9zgZ5dFDxZSn91TMAHJz5W39YDJ8+ZaGJYIdqZSpDo+4G769mZw==
 
-esbuild-linux-32@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz#495b1cc011b8c64d8bbaf65509c1e7135eb9ddbf"
-  integrity sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==
+esbuild-linux-32@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz#e2a8c4a8efdc355405325033fcebeb941f781fe5"
+  integrity sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==
 
 esbuild-linux-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.41.tgz#e7e193c229aa3988202adb92b8567ae504767b8e"
   integrity sha512-PeI0bfbv+5ondZRhPRszptp3RQRRAPxpOB2CYDphKske5+UlCXPi4Af+T++OqhV5TEpymTfxJdJQ1sn1w32coA==
 
-esbuild-linux-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz#3f28dd8f986e6ff42f38888ee435a9b1fb916a56"
-  integrity sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==
+esbuild-linux-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz#de5fdba1c95666cf72369f52b40b03be71226652"
+  integrity sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==
 
 esbuild-linux-arm64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.41.tgz#ca3d83b2a8ae1f160c05bdc08daa88f54279506c"
   integrity sha512-aAhBX6kVG8hTVuANE90ORobioHdpZLzy8Fibf4XBuG4IuJfjgM5N4wFIq2Tpd+Ykit432PL/YOQhZ4W6nVc4cQ==
 
-esbuild-linux-arm64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz#a52e99ae30246566dc5f33e835aa6ca98ef70e33"
-  integrity sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==
+esbuild-linux-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz#dae4cd42ae9787468b6a5c158da4c84e83b0ce8b"
+  integrity sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==
 
 esbuild-linux-arm@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.41.tgz#6f9b5ca9cbdb33b4751b658f7d64c0e907b64685"
   integrity sha512-8DQ6Sv3XNwgu0cnPA3q+kJSqfOYLDqWzpW8dPF+/Or23bS/5EIT/CzN73uIhR8A3AokXIczn88VKti7Xtv+V2g==
 
-esbuild-linux-arm@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz#7c33d05a64ec540cf7474834adaa57b3167bbe97"
-  integrity sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==
+esbuild-linux-arm@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz#a2c1dff6d0f21dbe8fc6998a122675533ddfcd59"
+  integrity sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==
 
 esbuild-linux-mips64le@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.41.tgz#e21b8dc51d6d3d78e4e3de0ccae20a6b0aae28a1"
   integrity sha512-88xo4FRYQ2laMJnrqZu8j5q531XT/odZnhO5NLWO/NdweIdT8F+QL0fNIBIf+nVkC1d0Psgmt+g35GAODMDl8g==
 
-esbuild-linux-mips64le@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz#ed062bd844b587be649443831eb84ba304685f25"
-  integrity sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==
+esbuild-linux-mips64le@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz#d9918e9e4cb972f8d6dae8e8655bf9ee131eda34"
+  integrity sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==
 
 esbuild-linux-ppc64le@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.41.tgz#bd70331c3df64ed3c74947d8ec5354a7cb11abae"
   integrity sha512-kJ0r/Cg3LzFzHhbBsvqi/hDPGKMGzFiPGOmUvqTkfVXhRUQtOMkXkyKdP7OEMRb8ctPtnptsZOOXPHRdU0NdJQ==
 
-esbuild-linux-ppc64le@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz#c0786fb5bddffd90c10a2078181513cbaf077958"
-  integrity sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==
+esbuild-linux-ppc64le@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz#3f9a0f6d41073fb1a640680845c7de52995f137e"
+  integrity sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==
 
 esbuild-linux-riscv64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.41.tgz#2272aff043bf1fe7b397df25698c8f79605b9b71"
   integrity sha512-ZJ7d/qFRx14J3aP75ccrFSZyuYZ1hu8IVfwVqyQg4jQFgNME2FMz7pZMskBJ0fSW8QcYUnN3RubFXWijyjKUug==
 
-esbuild-linux-riscv64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz#579b0e7cc6fce4bfc698e991a52503bb616bec49"
-  integrity sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==
+esbuild-linux-riscv64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz#618853c028178a61837bc799d2013d4695e451c8"
+  integrity sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==
 
 esbuild-linux-s390x@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.41.tgz#01916946a31c1aeb2de5b1b4f21432843fb88f91"
   integrity sha512-xeWAEZt1jAfYkYuyIUuHKpH/oj7O862Je5HTH9E+4sEfoOnZaAmFrisbXjGDKXjMRKYscFlM8wXdNBmiqQlT8g==
 
-esbuild-linux-s390x@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz#09eb15c753e249a500b4e28d07c5eef7524a9740"
-  integrity sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==
+esbuild-linux-s390x@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz#d1885c4c5a76bbb5a0fe182e2c8c60eb9e29f2a6"
+  integrity sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==
 
 esbuild-netbsd-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.41.tgz#0a9d3e5c73d362f91178ad21a7e020d246a039e7"
   integrity sha512-X/UE3Asqy594/atYi/STgYtaMQBJwtZKF0KFFdJTkwb6rtaoHCM1o482iHibgnSK7CicuRhyTZ+cNx4OFqRQAg==
 
-esbuild-netbsd-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz#f7337cd2bddb7cc9d100d19156f36c9ca117b58d"
-  integrity sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==
+esbuild-netbsd-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz#69ae917a2ff241b7df1dbf22baf04bd330349e81"
+  integrity sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==
 
 esbuild-openbsd-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.41.tgz#32c0ec0678a206b0e75340f3a3303f38cb5b3408"
   integrity sha512-6m+1dtdO+4KaU3R0UTT82hxWxWpFCjgSHhQl/PKtMmq+CvvxRQDcTwujLC843M7ChGVWNM2q1s6YCwoA0WQ9kw==
 
-esbuild-openbsd-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz#1f8bdc49f8a44396e73950a3fb6b39828563631d"
-  integrity sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==
+esbuild-openbsd-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz#db4c8495287a350a6790de22edea247a57c5d47b"
+  integrity sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==
 
 esbuild-sunos-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.41.tgz#2f6f26fbc88778382d61145d2d6ec1c6ad5d47c2"
   integrity sha512-p96tTTcE8/WY7A4Udh+fxVUTGL8rIXOpyxyhZiXug+f7DGbjE24PbewqgIBRSDyM7xRUty+1RzqyJz73YIV6yg==
 
-esbuild-sunos-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz#47d042739365b61aa8ca642adb69534a8eef9f7a"
-  integrity sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==
+esbuild-sunos-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz#54287ee3da73d3844b721c21bc80c1dc7e1bf7da"
+  integrity sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==
 
 esbuild-windows-32@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.41.tgz#0e7a64b739045596a83ecd9cb0af8c0d85e4d5ed"
   integrity sha512-jS+/pGyPPzrL8tgcvOxLEatV1QPICghKm13EjEVgkeRftl8X6tqRyFv/9eKutczdD3sklMDOJfivoPD32D46Ww==
 
-esbuild-windows-32@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz#79198c88ec9bde163c18a6b430c34eab098ec21a"
-  integrity sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==
+esbuild-windows-32@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz#f8aaf9a5667630b40f0fb3aa37bf01bbd340ce31"
+  integrity sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==
 
 esbuild-windows-64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.41.tgz#14886c72949e8630160d2277e21fae59778c2b62"
   integrity sha512-vLqmKbV8FJ7LFMrT3zEQpojnUUbXyqhRPVGnAYzc0ESY5yAuom4E9tL7KzZ5H8KEuCUf//AvbyxpE+yOcjpyjA==
 
-esbuild-windows-64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz#b36b230d18d1ee54008e08814c4799c7806e8c79"
-  integrity sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==
+esbuild-windows-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz#bf54b51bd3e9b0f1886ffdb224a4176031ea0af4"
+  integrity sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==
 
 esbuild-windows-arm64@0.14.41:
   version "0.14.41"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.41.tgz#ad425b8a9fe29bd38b3028af387b5e923e4c54e1"
   integrity sha512-TOvj7kRTfpH4GPPmblvuMNf8oNJ3y2h7a6HttanVnc3QLMm5bNFYLSo6TShLOn0SbqFWGJwHIhGhw2JK96aVhg==
 
-esbuild-windows-arm64@0.14.49:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz#d83c03ff6436caf3262347cfa7e16b0a8049fae7"
-  integrity sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==
+esbuild-windows-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz#937d15675a15e4b0e4fafdbaa3a01a776a2be982"
+  integrity sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==
 
 esbuild@^0.14.27:
   version "0.14.41"
@@ -7451,30 +7456,31 @@ esbuild@^0.14.27:
     esbuild-windows-arm64 "0.14.41"
 
 esbuild@^0.14.47:
-  version "0.14.49"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.49.tgz#b82834760eba2ddc17b44f05cfcc0aaca2bae492"
-  integrity sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.54.tgz#8b44dcf2b0f1a66fc22459943dccf477535e9aa2"
+  integrity sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==
   optionalDependencies:
-    esbuild-android-64 "0.14.49"
-    esbuild-android-arm64 "0.14.49"
-    esbuild-darwin-64 "0.14.49"
-    esbuild-darwin-arm64 "0.14.49"
-    esbuild-freebsd-64 "0.14.49"
-    esbuild-freebsd-arm64 "0.14.49"
-    esbuild-linux-32 "0.14.49"
-    esbuild-linux-64 "0.14.49"
-    esbuild-linux-arm "0.14.49"
-    esbuild-linux-arm64 "0.14.49"
-    esbuild-linux-mips64le "0.14.49"
-    esbuild-linux-ppc64le "0.14.49"
-    esbuild-linux-riscv64 "0.14.49"
-    esbuild-linux-s390x "0.14.49"
-    esbuild-netbsd-64 "0.14.49"
-    esbuild-openbsd-64 "0.14.49"
-    esbuild-sunos-64 "0.14.49"
-    esbuild-windows-32 "0.14.49"
-    esbuild-windows-64 "0.14.49"
-    esbuild-windows-arm64 "0.14.49"
+    "@esbuild/linux-loong64" "0.14.54"
+    esbuild-android-64 "0.14.54"
+    esbuild-android-arm64 "0.14.54"
+    esbuild-darwin-64 "0.14.54"
+    esbuild-darwin-arm64 "0.14.54"
+    esbuild-freebsd-64 "0.14.54"
+    esbuild-freebsd-arm64 "0.14.54"
+    esbuild-linux-32 "0.14.54"
+    esbuild-linux-64 "0.14.54"
+    esbuild-linux-arm "0.14.54"
+    esbuild-linux-arm64 "0.14.54"
+    esbuild-linux-mips64le "0.14.54"
+    esbuild-linux-ppc64le "0.14.54"
+    esbuild-linux-riscv64 "0.14.54"
+    esbuild-linux-s390x "0.14.54"
+    esbuild-netbsd-64 "0.14.54"
+    esbuild-openbsd-64 "0.14.54"
+    esbuild-sunos-64 "0.14.54"
+    esbuild-windows-32 "0.14.54"
+    esbuild-windows-64 "0.14.54"
+    esbuild-windows-arm64 "0.14.54"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -8184,9 +8190,9 @@ fastest-stable-stringify@^2.0.2:
   integrity sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==
 
 fastify@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/fastify/-/fastify-4.3.0.tgz#f5ed96a3fc533b92018c3968340897badf036eb8"
-  integrity sha512-9q5Ron8jWmX6ElFkgZH4zmIIXdnkGIu16JozWG2ohcs7th5rAo1ymNi+rn6xCmbWc6jl9lf+9OxVe93LOg6/2w==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-4.4.0.tgz#0543aa039c70d49df4ddcca796679f305f10d2ae"
+  integrity sha512-ePI4g9vPJXIBF4YlVcDSLxjvtdTrlM8QzdgYAPFGdCH+rot+4MXoFFAUb10fGrIcRRjaq6CvcbIzxiWQzMMHkw==
   dependencies:
     "@fastify/ajv-compiler" "^3.1.1"
     "@fastify/error" "^3.0.0"
@@ -8364,9 +8370,9 @@ find-cache-dir@^3.3.1:
     pkg-dir "^4.1.0"
 
 find-my-way@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-7.0.0.tgz#8e79fde2606624af61775e3d097da4f1872e58d9"
-  integrity sha512-NHVohYPYRXgj6jxXVRwm4iMQjA2ggJpyewHz7Nq7hvBnHoYJJIyHuxNzs8QLPTLQfoqxZzls2g6Zm79XMbhXjA==
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-7.0.1.tgz#079d6a8b474754e073c75778da678f59dedd620f"
+  integrity sha512-w05SaOPg54KqBof/RDA+75n1R48V7ZZNPL3nR17jJJs5dgZpR3ivfrMWOyx7BVFQgCLhYRG05hfgFCohYvSUXA==
   dependencies:
     fast-deep-equal "^3.1.3"
     safe-regex2 "^2.0.0"
@@ -8685,9 +8691,9 @@ get-package-type@^0.1.0:
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
 get-port-please@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/get-port-please/-/get-port-please-2.5.0.tgz#1e2d40a6f55c02a1caed99991c64ed84afe50c72"
-  integrity sha512-NblPebBznYARC1R2r1qmusbJAAgBr954gWhEZgwTerzR8r3ud6U5PI1SG4Lue43r87aikPPjObs85VieIDK99A==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/get-port-please/-/get-port-please-2.6.1.tgz#80143de24fcaab39b01df977f66ad967e06b17d1"
+  integrity sha512-4PDSrL6+cuMM1xs6w36ZIkaKzzE0xzfVBCfebHIJ3FE8iB9oic/ECwPw3iNiD4h1AoJ5XLLBhEviFAVrZsDC5A==
   dependencies:
     fs-memo "^1.2.0"
 
@@ -9525,9 +9531,9 @@ inquirer@^8.0.0, inquirer@^8.2.4:
     wrap-ansi "^7.0.0"
 
 inquirer@^9.0.0:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.0.2.tgz#81d830044718528485d7b9f7d47c6d590ccd1a7f"
-  integrity sha512-AqmDHmz3bIe573OiM4svTZzajBzff1xpuzYAimW8gjzW5ncuPllWB8t/GKl+NSuKRJaKyIF2bU2RCx8H1dwqyQ==
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.1.0.tgz#446a09abe2e5a18973322bee89b42a6c304f2cd3"
+  integrity sha512-eukdjrBljg9t55ZnvJjvGi1OyYEzVBFsO/8o5d2MV3mc28u3x4X2kS4eJ/+9U10KiREfPkEBSeCrU/S2G/uRtw==
   dependencies:
     ansi-escapes "^5.0.0"
     chalk "^5.0.1"
@@ -11283,9 +11289,9 @@ libnpmconfig@^1.0.0:
     ini "^1.3.5"
 
 light-my-request@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-5.3.0.tgz#183b2f2db5e7b021b4a7dd450d2406c45f8a1c9d"
-  integrity sha512-AdBNkWTD+CnFYGa6lCowLU0DMNBelq58vQXl1jWOvbMsMVzZzJyN5K94VOI2EhqLtskJNUi2ALgI8KNmXl+74A==
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-5.4.0.tgz#bcd483a9157592b16101cb2042275ca89b79aec1"
+  integrity sha512-lWwUibGSDifLsCGKVy5mCktifWGYiZUCzuKqXgrb3Na7wHPl8aPShxjDhUGQE3MI8k2wJSuvSJh5lyHkMnOTMg==
   dependencies:
     cookie "^0.5.0"
     process-warning "^2.0.0"
@@ -11452,12 +11458,7 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-local-pkg@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.1.tgz#e7b0d7aa0b9c498a1110a5ac5b00ba66ef38cfff"
-  integrity sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==
-
-local-pkg@^0.4.2:
+local-pkg@^0.4.1, local-pkg@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
   integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
@@ -12250,9 +12251,9 @@ node-fetch@2.6.7, node-fetch@^2.5.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-
     whatwg-url "^5.0.0"
 
 node-fetch@^3.2.4:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.9.tgz#3f6070bf854de20f21b9fe8479f823462e615d7d"
-  integrity sha512-/2lI+DBecVvVm9tDhjziTVjo2wmTsSxSk58saUYP0P/fRJ3xxtfMDY24+CKTkfm0Dlhyn3CSXNL0SoRiCZ8Rzg==
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.10.tgz#e8347f94b54ae18b57c9c049ef641cef398a85c8"
+  integrity sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==
   dependencies:
     data-uri-to-buffer "^4.0.0"
     fetch-blob "^3.1.4"
@@ -13082,9 +13083,9 @@ pino-std-serializers@^6.0.0:
   integrity sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==
 
 pino@^8.0.0:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-8.3.1.tgz#99be4376d9577e3508bd6b18cd767339d4a640f4"
-  integrity sha512-G5KDVXr8viwc/n7iKfDyqqRZflY7OpJn0SDq1wagUhXkcPodZuSymLFziSuD/gCEcVG65IN5MPDY4ZMT9OJWfg==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.4.0.tgz#fb8622b70670068cc9d10ccf04c168580cef00c0"
+  integrity sha512-R95U66WOb4Ggtb1RPGnC2uvtc8T0i1FSbrKHrAudRtiLDrlNxKjM1MyCJu+V4gL0qdE/7/LoXAmkEY/TlX6ELA==
   dependencies:
     atomic-sleep "^1.0.0"
     fast-redact "^3.1.1"
@@ -13431,7 +13432,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8, postcss@^8.4.12, postcss@^8.4.13, postcss@^8.4.14:
+postcss@^8, postcss@^8.4.12, postcss@^8.4.14:
   version "8.4.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
@@ -13440,7 +13441,7 @@ postcss@^8, postcss@^8.4.12, postcss@^8.4.13, postcss@^8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.16:
+postcss@^8.4.13, postcss@^8.4.16:
   version "8.4.16"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
   integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
@@ -13972,11 +13973,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-real-require@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.1.0.tgz#736ac214caa20632847b7ca8c1056a0767df9381"
-  integrity sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==
-
 real-require@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
@@ -14463,7 +14459,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-"rollup@>=2.75.6 <2.77.0 || ~2.77.0":
+"rollup@>=2.59.0 <2.78.0", "rollup@>=2.75.6 <2.77.0 || ~2.77.0":
   version "2.77.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.3.tgz#8f00418d3a2740036e15deb653bed1a90ee0cc12"
   integrity sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==
@@ -14474,13 +14470,6 @@ rollup@^2.59.0:
   version "2.75.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.0.tgz#c4c1c2bf46c706823f5f0eee046c7a1cbdda5038"
   integrity sha512-1/wxtweHJ7YwI2AIK3ZgCBU3nbW8sLnBIFwN46cwOTnVzt8f1o6J8zPKjwoiuADvzSjmnLqJce31p0q2vQ+dqw==
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-rollup@^2.75.6:
-  version "2.76.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.76.0.tgz#c69fe03db530ac53fcb9523b3caa0d3c0b9491a1"
-  integrity sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -14636,9 +14625,9 @@ scuid@^1.1.0:
   integrity sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==
 
 secure-json-parse@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.4.0.tgz#5aaeaaef85c7a417f76271a4f5b0cc3315ddca85"
-  integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.5.0.tgz#f929829df2adc7ccfb53703569894d051493a6ac"
+  integrity sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w==
 
 selfsigned@^1.10.11:
   version "1.10.14"
@@ -14842,9 +14831,9 @@ simple-get@^4.0.0:
     simple-concat "^1.0.0"
 
 simple-git@^3.5.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.10.0.tgz#f20031dd121d3c49e215ef0186a102bece3f89b2"
-  integrity sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.12.0.tgz#12fa8e762d8d9629fb1c72a0e2b4e6ae5b1f11e8"
+  integrity sha512-cy1RSRFHGZSrlYa3MnUuNVOXLUdifEZD2X8+AZjg8mKCdRvtCFSga6acq5N2g0ggb8lH3jBi369MrFZ+Y6sfsA==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
@@ -15675,11 +15664,11 @@ then-request@^6.0.0:
     qs "^6.4.0"
 
 thread-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.0.0.tgz#1ecb450324ebb1bb284d4398b8af15cb6905028c"
-  integrity sha512-tnbzCbIrA4Khq5SJt/Fyz5DlE8pUnPR3//nWv+cqdRktvAl2NuC9O08HHq2Ifa10bhkvHLuzcesNjaH15EgTXA==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.0.1.tgz#3fa74e2223e661a48f836494f7a64eeac5ac03c0"
+  integrity sha512-X7vWOdsHLkBq0si20ruEE2ttpS7WOVyD52xKu+TOjrRP9Qi9uB9ynHYpzZUbBptArBSuKYUn4mH+jEBnO2CRGg==
   dependencies:
-    real-require "^0.1.0"
+    real-require "^0.2.0"
 
 throat@^5.0.0:
   version "5.0.0"
@@ -16197,15 +16186,15 @@ type-fest@^2.12.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.0.tgz#d1ecee38af29eb2e863b22299a3d68ef30d2abfb"
   integrity sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==
 
-type-fest@^2.12.2, type-fest@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
-  integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
-
-type-fest@^2.13.0:
+type-fest@^2.12.2, type-fest@^2.13.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.18.0.tgz#fdef3a74e0a9e68ebe46054836650fb91ac3881e"
   integrity sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==
+
+type-fest@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.17.0.tgz#c677030ce61e5be0c90c077d52571eb73c506ea9"
+  integrity sha512-U+g3/JVXnOki1kLSc+xZGPRll3Ah9u2VIG6Sn9iH9YX6UkPERmt6O/0fIyTgsd2/whV0+gAaHAg8fz6sG1QzMA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -16470,7 +16459,7 @@ unified-message-control@^3.0.0:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
 
-unified@9.2.2, unified@^9.0.0:
+unified@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==
@@ -16820,57 +16809,33 @@ vite-tsconfig-paths@^3.5.0:
     tsconfig-paths "^4.0.0"
 
 vite@^2.9.0:
-  version "2.9.9"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.9.tgz#8b558987db5e60fedec2f4b003b73164cb081c5e"
-  integrity sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.0.tgz#4417ce84a09d93c9e5a796b296285bc2f75d6c41"
+  integrity sha512-5NAnNqzPmZzJvrswZGeTS2JHrBGIzIWJA2hBTTMYuoBVEMh0xwE0b5yyIXFxf7F07hrK4ugX2LJ7q6t7iIbd4Q==
   dependencies:
     esbuild "^0.14.27"
-    postcss "^8.4.13"
+    postcss "^8.4.12"
     resolve "^1.22.0"
     rollup "^2.59.0"
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@^2.9.12:
-  version "2.9.12"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.12.tgz#b1d636b0a8ac636afe9d83e3792d4895509a941b"
-  integrity sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==
+vite@^2.9.12, vite@^2.9.9:
+  version "2.9.15"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.15.tgz#2858dd5b2be26aa394a283e62324281892546f0b"
+  integrity sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==
   dependencies:
     esbuild "^0.14.27"
     postcss "^8.4.13"
     resolve "^1.22.0"
-    rollup "^2.59.0"
+    rollup ">=2.59.0 <2.78.0"
   optionalDependencies:
     fsevents "~2.3.2"
 
-"vite@^2.9.12 || ^3.0.0-0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.0.tgz#b4675cb9ab83ec0803b9c952ffa6519bcce033a7"
-  integrity sha512-M7phQhY3+fRZa0H+1WzI6N+/onruwPTBTMvaj7TzgZ0v2TE+N2sdLKxJOfOv9CckDWt5C4HmyQP81xB4dwRKzA==
-  dependencies:
-    esbuild "^0.14.47"
-    postcss "^8.4.14"
-    resolve "^1.22.1"
-    rollup "^2.75.6"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-vite@^2.9.9:
-  version "2.9.14"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.14.tgz#c438324c6594afd1050df3777da981dee988bb1b"
-  integrity sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==
-  dependencies:
-    esbuild "^0.14.27"
-    postcss "^8.4.13"
-    resolve "^1.22.0"
-    rollup "^2.59.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-vite@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.7.tgz#f1e379857e9c5d652126f8b20d371e1365eb700f"
-  integrity sha512-dILhvKba1mbP1wCezVQx/qhEK7/+jVn9ciadEcyKMMhZpsuAi/eWZfJRMkmYlkSFG7Qq9NvJbgFq4XOBxugJsA==
+"vite@^2.9.12 || ^3.0.0-0", vite@^3.0.7, vite@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.8.tgz#aa095ad8e3e5da46d9ec7e878f262678965d6531"
+  integrity sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==
   dependencies:
     esbuild "^0.14.47"
     postcss "^8.4.16"
@@ -16879,10 +16844,10 @@ vite@^3.0.7:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.8.tgz#aa095ad8e3e5da46d9ec7e878f262678965d6531"
-  integrity sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==
+vite@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.9.tgz#45fac22c2a5290a970f23d66c1aef56a04be8a30"
+  integrity sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==
   dependencies:
     esbuild "^0.14.47"
     postcss "^8.4.16"
@@ -16920,6 +16885,21 @@ vitest@^0.15.2:
     tinypool "^0.1.3"
     tinyspy "^0.3.3"
     vite "^2.9.12"
+
+vitest@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.19.1.tgz#8a89f4c873132d778d4206dbfbd6791c12f6d921"
+  integrity sha512-E/ZXpFMUahn731wzhMBNzWRp4mGgiZFT0xdHa32cbNO0CSaHpE9hTfteEU247Gi2Dula8uXo5vvrNB6dtszmQA==
+  dependencies:
+    "@types/chai" "^4.3.1"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    chai "^4.3.6"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    tinypool "^0.2.4"
+    tinyspy "^1.0.0"
+    vite "^2.9.12 || ^3.0.0-0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -17348,6 +17328,6 @@ zip-stream@^4.1.0:
     readable-stream "^3.6.0"
 
 zod@^3.17.3:
-  version "3.17.10"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.17.10.tgz#8716a05e6869df6faaa878a44ffe3c79e615defb"
-  integrity sha512-IHXnQYQuOOOL/XgHhgl8YjNxBHi3xX0mVcHmqsvJgcxKkEczPshoWdxqyFwsARpf41E0v9U95WUROqsHHxt0UQ==
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.18.0.tgz#2eed58b3cafb8d9a67aa2fee69279702f584f3bc"
+  integrity sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==


### PR DESCRIPTION
This PR suggests a new approach to our e2e tests for the Hydrogen framework and showcases a few basic test-suites. This is a Proof of Concept, want feedback before devoting too much effort into it. While the broad characteristics of this overhaul are defined here and outlined below, there will be more methods and functions added as we move all of the e2e tests over. 

### Dynamic fixtures

Each app runs in an isolated sandbox that is created/removed before/after each test is run. This is different than our current set up, where all fixtures are checked into git and live in the packages/playground directory. 

Before: Static fixtures        |  After: Dynamic fixtures
:-------------------------:|:-------------------------:
<img width="482" alt="Screenshot 2022-08-29 at 16 12 18" src="https://user-images.githubusercontent.com/462077/187221527-d1b70a34-7815-441f-acc6-1dc3ef2fe80b.png"> |  <img width="538" alt="Screenshot 2022-08-29 at 16 13 36" src="https://user-images.githubusercontent.com/462077/187222065-bb867c8c-05a4-4acf-8ed4-88c21c31fcba.png">

#### Our current setup has been problematic because:
- The `packages` folder should only contain actual packages from our monorepo and the additional files add unnecessary bloat. More files tends to lead to more confusion when trying to understand a single e2e test. This is solved with Dynamic Fixtures because these files will not exist in the repo at all unless a test is running or the `{persist: true}` config is given (this is for debugging only).
- Almost impossible to know instinctively what e2e tests corresponds to which fixture. This is solved with Dynamic Fixtures because only relevant fixtures are generated in the same folder as the tests that use them.

Generating the fixtures dynamically also follows the pattern of other frameworks (next, remix, astro, etc...).

### In-source testing for routes and components

An even further extension of the above point, many of our e2e tests are route or component specific and now we can define tests beneath the code they are testing. This is different than our current set up, where all the tests live in a single suite for each fixture and all the routes defined within that fixtures routes folder.

<img width="459" alt="Screenshot 2022-08-29 at 16 23 16" src="https://user-images.githubusercontent.com/462077/187223787-a41ac702-1768-4087-a9e5-c9146dd5899b.png">

#### Our current setup has been problematic because: 
- It is difficult to understand what code an individual test is referring to. (there are dozens of routes). Defining a test in the same file as the source code makes this a no-brainer.

Additionally, tests can even share variables, etc... between the source and test. This also follows a [trend in remix's Route Module API](https://remix.run/docs/en/v1/api/conventions#route-module-api), where a route-level component has multiple exports (`meta`, `links` etc... ) a `tests` export falls right inline with this way of collocating everything in a top-level route file.

### Contained setup and teardown

We export our own `describe` function that defines each suite and takes care of the nitty setup/teardown of each test. This is different than our current set up, where we reference at least 4 different files for the building of code, starting servers, and  other tasks required for each e2e test suit to run properly. 

The below files are not easy to reason about (this has come up in conversations with many on the team). The changes in this PR would remove all of them.

<img width="269" alt="Screenshot 2022-08-29 at 16 25 58" src="https://user-images.githubusercontent.com/462077/187224468-ed26e282-bd5a-4bed-a691-1bea55bf767d.png">

#### Our current setup has been problematic because:
- It is very difficult to follow how the full environment is constructed. By keeping this logic contained to a single function block that sets up the different primitives and injects them into the suite we can more easily understand and debug the full e2e environment.

The one draw back to this approach is that we are essentially "wrapping" vitest primitives and it may become unclear where that line is drawn. I might suggest we go full in on this approach and essentially re-export * from vitest inside of our test-framework so that a developer doesn't need to think about it. We could consider a "hydrogen/testing" package that sets this all up and a user test might look like:

```ts
import {describe, it, vi, beforeEach} from '@shopify/hydrogen-testing'

describe('...', () => {
//...

```

### Support for testing in multiple environments

Each suite runs in 3 environments: Node development using a vite dev server, Node production using our platform entry, and Worker production using our platform entry and worker runtime and we can opt-out of any of these at the suite level. This is different than our current set up, where we pass in a config to each test and use conditional blocks to return early if we don't want a test to run in a specific environment.

Our current setup has been problematic because: 
- Having control flow inside of a test is a bad practise 
- Passing a config into a separate shared file of test cases is indirect and makes tests harder to follow.

<img width="631" alt="Screenshot 2022-08-29 at 16 34 04" src="https://user-images.githubusercontent.com/462077/187226209-58167c32-80cf-4324-8e04-1d47f539bd58.png">

The above conditional logic can be omitted if we are able to declaratively tell a test suite how and where to run. 

### Vitest

We have been moving away from Jest entirely in our repo, in favour of Vitest. Not much to add on this point because it is a hard requirement for vite 3 among other reasons (ESM support, etc).

cc @pepicrft @lemonmade @heimidal 

## Running these new tests locally

Checkout this PR and run `yarn test-e2e-new`.

<img width="477" alt="Screenshot 2022-08-29 at 17 55 22" src="https://user-images.githubusercontent.com/462077/187243129-89886bb1-60c5-4724-8f62-7aaf7ef77ecf.png">


