### PR TITLE
Add umd builds and package exports for module

### DIFF
--- a/packages/hydrogen-ui/README.md
+++ b/packages/hydrogen-ui/README.md
@@ -64,6 +64,12 @@ Depending on the bundler or runtime you're using, it may automatically choose th
 
 The production bundle is used by default if your bundler / runtime doesn't understand the export conditions.
 
+## Hydrogen-UI in the Browser
+
+There is also a `umd` build of Hydrogen-UI, meant to be used directly by `<script src=""></script>` tags in HTML, or by `AMD`-compatible loaders. There is also a production and development build version of the `umd` bundle.
+
+If you're using Hydrogen-UI as a global (through the `<script>` tag), then the components can be accessed through the `hydrogenui` global variable.
+
 ## Working on Hydrogen-UI
 
 There are two ways you can develop Hydrogen-UI components:

--- a/packages/hydrogen-ui/README.md
+++ b/packages/hydrogen-ui/README.md
@@ -66,9 +66,9 @@ The production bundle is used by default if your bundler / runtime doesn't under
 
 ## Hydrogen-UI in the Browser
 
-There is also a `umd` build of Hydrogen-UI, meant to be used directly by `<script src=""></script>` tags in HTML, or by `AMD`-compatible loaders. There is also a production and development build version of the `umd` bundle.
+There are two `umd` builds (development and production) of Hydrogen-UI, meant to be used directly by `<script src=""></script>` tags in HTML, or by `AMD`-compatible loaders.
 
-If you're using Hydrogen-UI as a global (through the `<script>` tag), then the components can be accessed through the `hydrogenui` global variable.
+If you're using Hydrogen-UI as a global through the `<script>` tag, then the components can be accessed through the `hydrogenui` global variable.
 
 ## Working on Hydrogen-UI
 

--- a/packages/hydrogen-ui/package.json
+++ b/packages/hydrogen-ui/package.json
@@ -15,6 +15,17 @@
   "type": "module",
   "exports": {
     ".": {
+      "script": {
+        "development": "./dist/umd/hydrogen-ui.dev.umd.js",
+        "production": "./dist/umd/hydrogen-ui.prod.umd.js",
+        "default": "./dist/umd/hydrogen-ui.prod.umd.js"
+      },
+      "module": {
+        "types": "./dist/types/index.d.ts",
+        "development": "./dist/dev/index.js",
+        "production": "./dist/prod/index.js",
+        "default": "./dist/prod/index.js"
+      },
       "import": {
         "types": "./dist/types/index.d.ts",
         "development": "./dist/dev/index.js",
@@ -30,7 +41,8 @@
       "default": "./dist/prod/index.js"
     },
     "./storefront-api-types": "./dist/types/storefront-api-types.d.ts",
-    "./storefront.schema.json": "./storefront.schema.json"
+    "./storefront.schema.json": "./storefront.schema.json",
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
@@ -52,6 +64,8 @@
     "build": "npm-run-all --parallel build:vite:* build:tsc:es --parallel build:tsc:cjs copy-storefront-types",
     "build:vite:dev": "vite build --mode devbuild",
     "build:vite:prod": "vite build",
+    "build:vite:umddev": "vite build --mode umdbuilddev",
+    "build:vite:umdprod": "vite build --mode umdbuild",
     "build:tsc:cjs": "cpy ./dist/types/index.d.ts ./dist/types/ --rename='index.d.cts' --flat",
     "build:tsc:es": "tsc --emitDeclarationOnly",
     "copy-storefront-types": "cpy ./src/storefront-api-types.d.ts ./dist/types/ --flat",

--- a/packages/hydrogen-ui/vite.config.ts
+++ b/packages/hydrogen-ui/vite.config.ts
@@ -4,6 +4,45 @@ import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig(({mode}) => {
+  if (mode.includes('umdbuild')) {
+    // config for our UMD builds, which are distinct enough that they need their own
+    return {
+      build: {
+        lib: {
+          entry: resolve(__dirname, 'src/index.ts'),
+          name: 'hydrogenui',
+          fileName: () =>
+            `hydrogen-ui.${mode === 'umdbuilddev' ? 'dev' : 'prod'}.umd.js`,
+          formats: ['umd'],
+        },
+        sourcemap: true,
+        minify: mode !== 'umdbuilddev',
+        emptyOutDir: false,
+        outDir: `dist/umd/`,
+        rollupOptions: {
+          // don't bundle these packages into our lib
+          external: ['react', 'react-dom'],
+          output: {
+            globals: {
+              react: 'React',
+              'react-dom': 'ReactDOM',
+            },
+          },
+        },
+      },
+      define: {
+        __HYDROGEN_DEV__: mode === 'umdbuilddev',
+        __HYDROGEN_TEST__: false,
+      },
+      plugins: [
+        react({
+          // use classic runtime so that it can rely on the global 'React' variable to createElements
+          jsxRuntime: 'classic',
+        }),
+      ],
+    };
+  }
+
   return {
     build: {
       outDir: `dist/${mode === 'devbuild' ? 'dev' : 'prod'}/`,

--- a/packages/hydrogen-ui/vite.config.ts
+++ b/packages/hydrogen-ui/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(({mode}) => {
           entry: resolve(__dirname, 'src/index.ts'),
           name: 'hydrogenui',
           fileName: () =>
-            `hydrogen-ui.${mode === 'umdbuilddev' ? 'dev' : 'prod'}.umd.js`,
+            `hydrogen-ui.${mode === 'umdbuilddev' ? 'dev' : 'prod'}.js`,
           formats: ['umd'],
         },
         sourcemap: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- We now create a `umd` bundle (output as a single file), so that hydrogen-ui can potentially be consumed directly through a `<script>` tag or `AMD`-compatible module loader. 
- Added the `package.json#exports` fields `module` and `script`:
    - `module` is a special field that [webpack and rollup](https://webpack.js.org/guides/package-exports/#conditions) agreed to use, as to prevent multiple copies of a library in a bundle. 
    - `script` is meant to indicate a bundle that can be used directly in the browser through a `<script>` tag (without `type="module"`; that should be directed to the `import` specifier). Which, conveniently for us, was just created through this `umd` bundle!
- Also added `package.json` to the exports list, so someone can easily import it if they so desire. 
