### PR TITLE
Remove useless npms in demo store

### DIFF
--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -38,14 +38,12 @@
   "prettier": "@shopify/prettier-config",
   "dependencies": {
     "@headlessui/react": "^1.6.4",
-    "@heroicons/react": "^1.0.6",
     "@shopify/hydrogen": "^1.3.0",
     "clsx": "^1.1.1",
     "graphql-tag": "^2.12.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-use": "^17.4.0",
-    "title": "^3.4.4",
     "typographic-base": "^1.0.4"
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I think npms are not used in demo store.


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)