### PR TITLE
Adds selling plan allocations to cart line item

### DIFF
--- a/.changeset/tender-planets-guess.md
+++ b/.changeset/tender-planets-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Adds selling plan allocations to cart line item queries

--- a/packages/hydrogen/src/components/CartProvider/cart-queries.ts
+++ b/packages/hydrogen/src/components/CartProvider/cart-queries.ts
@@ -171,6 +171,56 @@ fragment CartFragment on Cart {
             }
           }
         }
+
+        sellingPlanAllocation {
+          priceAdjustments {
+            compareAtPrice {
+              currencyCode
+              amount
+            }
+            perDeliveryPrice {
+              currencyCode
+              amount
+            }
+            price {
+              currencyCode
+              amount
+            }
+            unitPrice {
+              currencyCode
+              amount
+            }
+          }
+          sellingPlan {
+            id
+            description
+            name
+            options {
+              name
+              value
+            }
+            priceAdjustments {
+              orderCount
+              adjustmentValue {
+                ... on SellingPlanFixedAmountPriceAdjustment {
+                  adjustmentAmount {
+                    currencyCode
+                    amount
+                  }
+                }
+                ... on SellingPlanFixedPriceAdjustment {
+                  price {
+                    currencyCode
+                    amount
+                  }
+                }
+                ... on SellingPlanPercentagePriceAdjustment {
+                  adjustmentPercentage
+                }
+              }
+            }
+            recurringDeliveries
+        }
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16384,7 +16384,7 @@ unified-message-control@^3.0.0:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
 
-unified@^9.0.0:
+unified@9.2.2, unified@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
### Description

Currently, the AddToCart button and CartProvider handles subscriptions properly, and can be used to add subscriptions to a hydrogen app. However, cart line items are missing the appropriate queries for selling plans. This leaves users of the framework no out of the box solution to obtain the data needed to create cart level components for managing the plan of a line item within the cart. 


### Additional context

- `docs/components/product-variant/productoptionsprovider.md`: Queries were picked from this document, line 175.
- https://shopify.dev/api/storefront/2022-10/objects/CartLine <- Cart line object GQL docs
- https://shopify.dev/api/storefront/2022-10/objects/SellingPlanAllocation <- SellingPlanAllocation GQL docs

Queries were checked against the above documentation, but more eyes is great.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
