### PR TITLE
useQuery and useShopquery: Provide direction on when to use 

### DIFF
--- a/docs/hooks/global/useshopquery.md
+++ b/docs/hooks/global/useshopquery.md
@@ -6,6 +6,9 @@ description: The useShopQuery hook allows you to make server-only GraphQL querie
 
 The `useShopQuery` hook allows you to make server-only GraphQL queries to the Storefront API. It must be a descendent of a `ShopifyProvider` component.
 
+> Note:
+> `queryShop` is the `API` route version of `useShopQuery`. Use [`queryShop`](https://shopify.dev/api/hydrogen/utilities/queryshop) to query the Storefront API within `API` routes.
+
 ## Example code
 
 ```tsx
@@ -69,6 +72,10 @@ The `useShopQuery` returns an object with the following key:
 ## Related components
 
 - [`ShopifyProvider`](https://shopify.dev/api/hydrogen/components/global/shopifyprovider)
+
+## Related utilities
+
+- [`queryShop`](https://shopify.dev/api/hydrogen/utilities/queryshop)
 
 ## Related hooks
 

--- a/docs/utilities/queryshop.md
+++ b/docs/utilities/queryshop.md
@@ -1,10 +1,10 @@
 ---
 gid: 574c35e8-209f-8fv2-b896-b3763d8c060c
 title: queryShop
-description: The queryShop utility is a function that helps you query the Storefront API.
+description: The queryShop utility is a function that helps you query the Storefront API within API routes.
 ---
 
-The `queryShop` utility is a function that helps you query the Storefront API. It's similar to the `useShopQuery` hook, which is available in server components.
+The `queryShop` utility is a function that helps you query the Storefront API within `API` routes. `queryShop` is the `API` route version of [`useShopQuery`](https://shopify.dev/api/hydrogen/hooks/global/useshopquery), which is available in server components.
 
 ## Example code
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/Shopify/shopify-dev/issues/25389

### Additional context

I've followed what I did for [`useLoadScript`](https://shopify.dev/api/hydrogen/hooks/primitive/useloadscript). 

## For reviewers

Do we need to call out anything more specific? For e.g. [we indicate some hooks](https://shopify.dev/api/hydrogen/hooks/primitive/useloadscript) for using `loadScript`. Maybe we could/should provide similar direction for `useShopQuery`, vis-a-vis `queryShop`?

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
