### PR TITLE
For Image, handle it better in prod mode if data is missing

### DIFF
--- a/.changeset/great-hornets-vanish.md
+++ b/.changeset/great-hornets-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-ui-alpha': patch
+---
+
+Update Image to better handle no data sources in production builds

--- a/packages/hydrogen-ui/src/Image.stories.tsx
+++ b/packages/hydrogen-ui/src/Image.stories.tsx
@@ -17,6 +17,7 @@ const Template: Story<{
       url: props['data.url'],
       width: props['data.width'],
       height: props['data.height'],
+      id: 'testing',
     },
     width: props.width,
     height: props.height,

--- a/packages/hydrogen-ui/src/Image.test.tsx
+++ b/packages/hydrogen-ui/src/Image.test.tsx
@@ -318,6 +318,13 @@ describe('<Image />', () => {
     expect(image).not.toHaveAttribute('height');
   });
 
+  it(`throws an error if you don't have data.url`, () => {
+    render(<Image data={{url: ''}} />);
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(console.error).toBeCalled();
+  });
+
   // eslint-disable-next-line jest/expect-expect
   it.skip(`typescript types`, () => {
     // this test is actually just using //@ts-expect-error as the assertion, and don't need to execute in order to have TS validation on them

--- a/packages/hydrogen-ui/src/Image.tsx
+++ b/packages/hydrogen-ui/src/Image.tsx
@@ -71,14 +71,24 @@ export function Image({
   ...rest
 }: ShopifyImageProps) {
   if (!data.url) {
-    throw new Error(`<Image/>: the 'data' prop requires the 'url' property`);
+    const missingUrlError = `<Image/>: the 'data' prop requires the 'url' property. Image: ${
+      data.id ?? 'no ID provided'
+    }`;
+
+    if (__HYDROGEN_DEV__) {
+      throw new Error(missingUrlError);
+    } else {
+      console.error(missingUrlError);
+    }
+
+    return null;
   }
 
   if (__HYDROGEN_DEV__ && !data.altText && !rest.alt) {
     console.warn(
-      `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. ${`Image: ${
+      `<Image/>: the 'data' prop should have the 'altText' property, or the 'alt' prop, and one of them should not be empty. Image: ${
         data.id ?? data.url
-      }`}`
+      }`
     );
   }
 
@@ -94,9 +104,9 @@ export function Image({
 
   if (__HYDROGEN_DEV__ && (!imgElementWidth || !imgElementHeight)) {
     console.warn(
-      `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. ${`Image: ${
+      `<Image/>: the 'data' prop requires either 'width' or 'data.width', and 'height' or 'data.height' properties. Image: ${
         data.id ?? data.url
-      }`}`
+      }`
     );
   }
 
@@ -111,9 +121,9 @@ export function Image({
     });
     if (typeof finalSrc !== 'string' || !finalSrc) {
       throw new Error(
-        `<Image/>: 'loader' did not return a valid string. ${`Image: ${
+        `<Image/>: 'loader' did not return a valid string. Image: ${
           data.id ?? data.url
-        }`}`
+        }`
       );
     }
   }
@@ -170,7 +180,9 @@ function internalImageSrcSet({
 }: InternalShopifySrcSetGeneratorsParams) {
   const hasCustomWidths = widths && Array.isArray(widths);
   if (hasCustomWidths && widths.some((size) => isNaN(size as number))) {
-    throw new Error(`<Image/>: the 'widths' must be an array of numbers`);
+    throw new Error(
+      `<Image/>: the 'widths' must be an array of numbers. Image: ${src}`
+    );
   }
 
   let aspectRatio = 1;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Addresses the feedback provided [here](https://github.com/Shopify/linkpop/issues/4321#issuecomment-1230491548) that `<Image/>` shouldn't throw in prod mode

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
