### PR TITLE
Improve json parse error from fetchSync and fix demo store to handle error states

### DIFF
--- a/.changeset/cool-humans-grow.md
+++ b/.changeset/cool-humans-grow.md
@@ -1,0 +1,23 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Whenever using `fetchSync`, make sure to handle the error state. Though we've made changes to the error thrown by the JSON parser to also tell you that the request failed:
+
+```ts
+function MyComponent() {
+  const response = fetchSync('/api');
+
+  // Make sure the error state is handled!
+  if (!response.ok) {
+    console.error(
+      `Unable to load ${response.url} returned ${response.status}`,
+    );
+    return <div>Error. Please try again</div>;
+  }
+
+  // Check `response.ok` before parsing the response
+  const json = response.json();
+
+  return ...
+```

--- a/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
@@ -28,7 +28,7 @@ export class ResponseSync extends Response {
         throw new Error(
           `Request to ${this.url} failed with ${this.status} and the response body is not parseable.\nMake sure to handle the error state when using fetchSync.`
         );
-      }
+      } else throw e;
     }
   }
 

--- a/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
+++ b/packages/hydrogen/src/foundation/fetchSync/ResponseSync.ts
@@ -1,16 +1,18 @@
 import {parseJSON} from '../../utilities/parse.js';
 import {log} from '../../utilities/log/index.js';
 
-type ResponseSyncInit = [string, ResponseInit];
+type ResponseSyncInit = [string, ResponseInit, string];
 
 export class ResponseSync extends Response {
   bodyUsed = true;
   #text: string;
   #json: any;
+  url: string;
 
   constructor(init: ResponseSyncInit) {
-    super(...init);
+    super(init[0], init[1]);
     this.#text = init[0];
+    this.url = init[2];
   }
 
   // @ts-expect-error Changing inherited types
@@ -19,7 +21,15 @@ export class ResponseSync extends Response {
   }
 
   json() {
-    return (this.#json ??= parseJSON(this.#text));
+    try {
+      return (this.#json ??= parseJSON(this.#text));
+    } catch (e: any) {
+      if (!this.ok) {
+        throw new Error(
+          `Request to ${this.url} failed with ${this.status} and the response body is not parseable.\nMake sure to handle the error state when using fetchSync.`
+        );
+      }
+    }
   }
 
   /**
@@ -44,6 +54,7 @@ export class ResponseSync extends Response {
         statusText: response.statusText,
         headers: Array.from(response.headers.entries()),
       },
+      response.url,
     ] as ResponseSyncInit;
   }
 }

--- a/templates/demo-store/src/components/CountrySelector.client.tsx
+++ b/templates/demo-store/src/components/CountrySelector.client.tsx
@@ -107,29 +107,48 @@ export function Countries({
   selectedCountry: Pick<Country, 'isoCode' | 'name'>;
   getClassName: (active: boolean) => string;
 }) {
-  const countries: Country[] = fetchSync('/api/countries').json();
+  const response = fetchSync('/api/countries');
 
-  return (countries || []).map((country) => {
-    const isSelected = country.isoCode === selectedCountry.isoCode;
+  let countries: Country[] | undefined;
 
-    return (
-      <Listbox.Option key={country.isoCode} value={country}>
-        {/* @ts-expect-error @headlessui/react incompatibility with node16 resolution */}
-        {({active}) => (
-          <div
-            className={`text-contrast dark:text-primary ${getClassName(
-              active,
-            )}`}
-          >
-            {country.name}
-            {isSelected ? (
-              <span className="ml-2">
-                <IconCheck />
-              </span>
-            ) : null}
-          </div>
-        )}
-      </Listbox.Option>
+  if (response.ok) {
+    countries = response.json();
+  } else {
+    console.error(
+      `Unable to load available countries ${response.url} returned a ${response.status}`,
     );
-  });
+  }
+
+  return countries ? (
+    countries.map((country) => {
+      const isSelected = country.isoCode === selectedCountry.isoCode;
+
+      return (
+        <Listbox.Option key={country.isoCode} value={country}>
+          {/* @ts-expect-error @headlessui/react incompatibility with node16 resolution */}
+          {({active}) => (
+            <div
+              className={`text-contrast dark:text-primary ${getClassName(
+                active,
+              )}`}
+            >
+              {country.name}
+              {isSelected ? (
+                <span className="ml-2">
+                  <IconCheck />
+                </span>
+              ) : null}
+            </div>
+          )}
+        </Listbox.Option>
+      );
+    })
+  ) : (
+    <div className="flex justify-center">
+      <div className="mt-4 text-center">
+        <div>Unable to load available countries.</div>
+        <div>Please try again.</div>
+      </div>
+    </div>
+  );
 }

--- a/templates/demo-store/src/components/cart/CartEmpty.client.tsx
+++ b/templates/demo-store/src/components/cart/CartEmpty.client.tsx
@@ -55,7 +55,16 @@ export function CartEmpty({
 }
 
 function TopProducts({onClose}: {onClose?: () => void}) {
-  const products: Product[] = fetchSync('/api/bestSellers').json();
+  const response = fetchSync('/api/bestSellers');
+
+  if (!response.ok) {
+    console.error(
+      `Unable to load top products ${response.url} returned a ${response.status}`,
+    );
+    return null;
+  }
+
+  const products: Product[] = response.json();
 
   if (products.length === 0) {
     return <Text format>No products found.</Text>;


### PR DESCRIPTION

### Description

Whenever using `fetchSync`, make sure to handle the error state. Though we've made changes to the error thrown by the JSON parser to also tell you that the request failed:

```ts
function MyComponent() {
  const response = fetchSync('/api');

  // Make sure the error state is handled!
  if (!response.ok) {
    console.error(
      `Unable to load ${response.url} returned ${response.status}`,
    );
    return <div>Error. Please try again</div>;
  }

  // Check `response.ok` before parsing the response
  const json = response.json();

  return ...
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
