### PR TITLE
Add Link header to preload stylesheets

### DIFF
--- a/.changeset/gentle-pianos-change.md
+++ b/.changeset/gentle-pianos-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Hydrogen responses now contain a `Link` header to preload stylesheets.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -342,6 +342,7 @@ async function runSSR({
     noScriptTemplate,
     bootstrapModules,
     bootstrapScripts,
+    stylesheets,
   },
 }: RunSsrParams) {
   let ssrDidError: Error | undefined;
@@ -369,6 +370,18 @@ async function runSSR({
       </ServerRequestProvider>
     </Html>
   );
+
+  const newLinkHeader = stylesheets
+    .map((resource) => `<${resource}>; rel=preload; as=style`)
+    .join(', ');
+
+  if (newLinkHeader) {
+    const existingLinkHeader = response.headers.get('Link');
+    response.headers.set(
+      'Link',
+      (existingLinkHeader ? existingLinkHeader + ', ' : '') + newLinkHeader
+    );
+  }
 
   log.trace('start ssr');
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -342,7 +342,7 @@ async function runSSR({
     noScriptTemplate,
     bootstrapModules,
     bootstrapScripts,
-    stylesheets,
+    linkHeader,
   },
 }: RunSsrParams) {
   let ssrDidError: Error | undefined;
@@ -371,15 +371,11 @@ async function runSSR({
     </Html>
   );
 
-  const newLinkHeader = stylesheets
-    .map((resource) => `<${resource}>; rel=preload; as=style`)
-    .join(', ');
-
-  if (newLinkHeader) {
+  if (linkHeader) {
     const existingLinkHeader = response.headers.get('Link');
     response.headers.set(
       'Link',
-      (existingLinkHeader ? existingLinkHeader + ', ' : '') + newLinkHeader
+      existingLinkHeader ? existingLinkHeader + ', ' + linkHeader : linkHeader
     );
   }
 

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -42,7 +42,7 @@ import {
   createFromReadableStream,
   bufferReadableStream,
 } from './streaming.server.js';
-import {stripScriptsFromTemplate} from './utilities/template.js';
+import {getTemplate} from './utilities/template.js';
 import {Analytics} from './foundation/Analytics/Analytics.server.js';
 import {DevTools} from './foundation/DevTools/DevTools.server.js';
 import {getSyncSessionApi} from './foundation/session/session.js';
@@ -293,27 +293,9 @@ async function processRequest(
     request,
     response,
     nodeResponse,
-    template: await getTemplate(indexTemplate, url),
     revalidate,
+    template: await getTemplate(indexTemplate, url),
   });
-}
-
-async function getTemplate(
-  indexTemplate:
-    | string
-    | ((url: string) => Promise<string | {default: string}>),
-  url: URL
-) {
-  let template =
-    typeof indexTemplate === 'function'
-      ? await indexTemplate(url.toString())
-      : indexTemplate;
-
-  if (template && typeof template !== 'string') {
-    template = template.default;
-  }
-
-  return template;
 }
 
 function getApiRoute(url: URL, routes: ResolvedHydrogenRoutes) {
@@ -351,11 +333,16 @@ async function runSSR({
   request,
   response,
   nodeResponse,
-  template,
   nonce,
   dev,
   log,
   revalidate,
+  template: {
+    raw: template,
+    noScriptTemplate,
+    bootstrapModules,
+    bootstrapScripts,
+  },
 }: RunSsrParams) {
   let ssrDidError: Error | undefined;
   const didError = () => rsc.didError() ?? ssrDidError;
@@ -363,9 +350,6 @@ async function runSSR({
   const [rscReadableForFizz, rscReadableForFlight] = rsc.readable.tee();
   const rscResponse = createFromReadableStream(rscReadableForFizz);
   const RscConsumer = () => rscResponse.readRoot();
-
-  const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
-    stripScriptsFromTemplate(template);
 
   const AppSSR = (
     <Html

--- a/packages/hydrogen/src/types.ts
+++ b/packages/hydrogen/src/types.ts
@@ -8,6 +8,7 @@ import type {HydrogenResponse} from './foundation/HydrogenResponse/HydrogenRespo
 import type {Metafield} from './storefront-api-types.js';
 import type {SessionStorageAdapter} from './foundation/session/session-types.js';
 import type {PartialDeep, JsonValue} from 'type-fest';
+import type {TemplateParts} from './utilities/template.js';
 
 export type AssembleHtmlParams = {
   ssrHtml: string;
@@ -25,7 +26,7 @@ export type RunSsrParams = {
   response: HydrogenResponse;
   log: Logger;
   dev?: boolean;
-  template: string;
+  template: TemplateParts;
   nonce?: string;
   nodeResponse?: ServerResponse;
   revalidate?: Boolean;

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -26,3 +26,26 @@ export function stripScriptsFromTemplate(template: string) {
 
   return {noScriptTemplate: template, bootstrapScripts, bootstrapModules};
 }
+
+export async function getTemplate(
+  indexTemplate:
+    | string
+    | ((url: string) => Promise<string | {default: string}>),
+  url: URL
+) {
+  let raw =
+    typeof indexTemplate === 'function'
+      ? await indexTemplate(url.toString())
+      : indexTemplate;
+
+  if (raw && typeof raw !== 'string') {
+    raw = raw.default;
+  }
+
+  return {
+    raw,
+    ...stripScriptsFromTemplate(raw),
+  };
+}
+
+export type TemplateParts = Awaited<ReturnType<typeof getTemplate>>;

--- a/packages/hydrogen/src/utilities/template.ts
+++ b/packages/hydrogen/src/utilities/template.ts
@@ -46,7 +46,7 @@ export async function getTemplate(
   for (const linkTag of raw.match(/\s*<link[^<>]+?>/gim) || []) {
     if (linkTag.includes('rel="stylesheet"')) {
       const href = linkTag.match(/href="([^"]+)"/)?.[1];
-      if (href) stylesheets.push(href.replace(/^https?:/i, ''));
+      if (href) stylesheets.push(encodeURI(href.replace(/^https?:/i, '')));
     }
   }
 

--- a/packages/hydrogen/src/utilities/tests/template.vitest.ts
+++ b/packages/hydrogen/src/utilities/tests/template.vitest.ts
@@ -1,7 +1,7 @@
-import {stripScriptsFromTemplate} from '../template.js';
+import {getTemplate} from '../template.js';
 
-describe('getScriptsFromTemplate', () => {
-  it('identifies scripts and modules in a template', () => {
+describe('getTemplate', () => {
+  it('identifies scripts and modules in a template', async () => {
     const template = `<html><head>
       <script src="/foo.js"></script>
     </head>
@@ -11,7 +11,7 @@ describe('getScriptsFromTemplate', () => {
     </body></html>`;
 
     const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
-      stripScriptsFromTemplate(template);
+      await getTemplate(template);
 
     expect(noScriptTemplate).not.toMatch('<script');
 
@@ -22,7 +22,7 @@ describe('getScriptsFromTemplate', () => {
     expect(bootstrapModules[0]).toBe('/module.js');
   });
 
-  it('identifies scripts and modules in a template even with script tag in head', () => {
+  it('identifies scripts and modules in a template even with script tag in head', async () => {
     const template = `<html><head>
       <script type="module">
         var foo = 'bar';
@@ -34,8 +34,7 @@ describe('getScriptsFromTemplate', () => {
       <script src="/module.js" type="module"></script>
     </body></html>`;
 
-    const {bootstrapScripts, bootstrapModules} =
-      stripScriptsFromTemplate(template);
+    const {bootstrapScripts, bootstrapModules} = await getTemplate(template);
 
     expect(bootstrapScripts).toHaveLength(2);
     expect(bootstrapScripts[0]).toBe('/foo.js');
@@ -44,13 +43,13 @@ describe('getScriptsFromTemplate', () => {
     expect(bootstrapModules[0]).toBe('/module.js');
   });
 
-  it('identifies varying orders of attributes in script tags', () => {
+  it('identifies varying orders of attributes in script tags', async () => {
     const template = `<html><body>
       <script type="module" src="/src/entry-client.tsx"></script>
     </body></html>`;
 
     const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
-      stripScriptsFromTemplate(template);
+      await getTemplate(template);
 
     expect(noScriptTemplate).not.toMatch('<script');
     expect(bootstrapScripts).toHaveLength(0);
@@ -58,18 +57,18 @@ describe('getScriptsFromTemplate', () => {
     expect(bootstrapModules[0]).toBe('/src/entry-client.tsx');
   });
 
-  it('does not crash if no script tags', () => {
+  it('does not crash if no script tags', async () => {
     const template = `<html><body></body></html>`;
 
     const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
-      stripScriptsFromTemplate(template);
+      await getTemplate(template);
 
     expect(noScriptTemplate).not.toMatch('<script');
     expect(bootstrapScripts).toHaveLength(0);
     expect(bootstrapModules).toHaveLength(0);
   });
 
-  it('identifies scripts with line breaks in them', () => {
+  it('identifies scripts with line breaks in them', async () => {
     const template = `<html><head>
       <script src="/foo.js"></script>
     </head>
@@ -80,7 +79,7 @@ describe('getScriptsFromTemplate', () => {
     </body></html>`;
 
     const {noScriptTemplate, bootstrapScripts, bootstrapModules} =
-      stripScriptsFromTemplate(template);
+      await getTemplate(template);
 
     expect(noScriptTemplate).not.toMatch('<script');
 
@@ -89,5 +88,32 @@ describe('getScriptsFromTemplate', () => {
 
     expect(bootstrapModules).toHaveLength(1);
     expect(bootstrapModules[0]).toBe('/module.js');
+  });
+
+  it('finds the stylesheets in a document', async () => {
+    const template = `<html><head>
+      <link rel="stylesheet" href="/assets/1.css">
+      <link rel="stylesheet" wrong="/assets/2.css">
+      <!-- -->
+      <link rel="preconnect" href="/assets/3.css">
+      <script></script>
+      <link rel="stylesheet" href="https://example.com/assets/4.css">
+    </head></html>`;
+
+    const {stylesheets} = await getTemplate(template);
+
+    expect(stylesheets).toHaveLength(2);
+    expect(stylesheets).toEqual(
+      expect.arrayContaining(['/assets/1.css', '//example.com/assets/4.css'])
+    );
+  });
+
+  it('accepts a function', async () => {
+    const {raw} = await getTemplate(
+      (url) => Promise.resolve('my-template:' + url),
+      new URL('https://example.com/')
+    );
+
+    expect(raw).toEqual('my-template:https://example.com/');
   });
 });

--- a/packages/hydrogen/src/utilities/tests/template.vitest.ts
+++ b/packages/hydrogen/src/utilities/tests/template.vitest.ts
@@ -90,26 +90,28 @@ describe('getTemplate', () => {
     expect(bootstrapModules[0]).toBe('/module.js');
   });
 
-  it('finds and encodes the stylesheets in a document', async () => {
+  it('creates a link header from link tags in the document', async () => {
     const template = `<html><head>
       <link rel="stylesheet" href="/assets/1.css">
       <link rel="stylesheet" wrong="/assets/2.css">
       <!-- -->
-      <link rel="preconnect" href="/assets/3.css">
+      <link rel="preconnect" href="https://my-cdn.com">
       <script></script>
-      <link rel="stylesheet" href="https://example.com/assets/4.css">
+      <link rel="stylesheet" href="https://example.com/assets/3.css">
+      <link rel="icon" href="/assets/4.css">
       <link rel="stylesheet" href="/assets/苗条.css">
+      <link rel="preload" href="/myFont.woff2" as="font" type="font/woff2" crossorigin="anonymous">
     </head></html>`;
 
-    const {stylesheets} = await getTemplate(template);
-
-    expect(stylesheets).toHaveLength(3);
-    expect(stylesheets).toEqual(
-      expect.arrayContaining([
-        '/assets/1.css',
-        '//example.com/assets/4.css',
-        '/assets/%E8%8B%97%E6%9D%A1.css',
-      ])
+    const {linkHeader} = await getTemplate(template);
+    expect(linkHeader).toEqual(
+      [
+        '</assets/1.css>; rel=preload; as=style',
+        '<//my-cdn.com>; rel=preconnect',
+        '<//example.com/assets/3.css>; rel=preload; as=style',
+        '</assets/%E8%8B%97%E6%9D%A1.css>; rel=preload; as=style',
+        '</myFont.woff2>; rel=preload; as=font; type=font/woff2; crossorigin=anonymous',
+      ].join(', ')
     );
   });
 

--- a/packages/hydrogen/src/utilities/tests/template.vitest.ts
+++ b/packages/hydrogen/src/utilities/tests/template.vitest.ts
@@ -90,7 +90,7 @@ describe('getTemplate', () => {
     expect(bootstrapModules[0]).toBe('/module.js');
   });
 
-  it('finds the stylesheets in a document', async () => {
+  it('finds and encodes the stylesheets in a document', async () => {
     const template = `<html><head>
       <link rel="stylesheet" href="/assets/1.css">
       <link rel="stylesheet" wrong="/assets/2.css">
@@ -98,13 +98,18 @@ describe('getTemplate', () => {
       <link rel="preconnect" href="/assets/3.css">
       <script></script>
       <link rel="stylesheet" href="https://example.com/assets/4.css">
+      <link rel="stylesheet" href="/assets/苗条.css">
     </head></html>`;
 
     const {stylesheets} = await getTemplate(template);
 
-    expect(stylesheets).toHaveLength(2);
+    expect(stylesheets).toHaveLength(3);
     expect(stylesheets).toEqual(
-      expect.arrayContaining(['/assets/1.css', '//example.com/assets/4.css'])
+      expect.arrayContaining([
+        '/assets/1.css',
+        '//example.com/assets/4.css',
+        '/assets/%E8%8B%97%E6%9D%A1.css',
+      ])
     );
   });
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -367,11 +367,11 @@ export default async function testCases({
           /<\/assets\/style.[\w\d]+.css>; rel=preload; as=style/
         );
 
-        const stylesheets = (html.match(/<link[^<>]+?>/gim) || [])
+        const assets = (html.match(/<link[^<>]+?>/gim) || [])
           .filter((linkTag) => linkTag.includes('rel="stylesheet"'))
           .map((linkTag) => linkTag.match(/href="([^"]+)"/)?.[1] || '');
 
-        for (const asset of stylesheets) {
+        for (const asset of assets) {
           expect(link).toMatch(asset);
         }
       });

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -354,6 +354,28 @@ export default async function testCases({
         new RegExp(`\\.${className}\\s*{\\s*color:\\s*red;?\\s*}`, 'm')
       );
     });
+
+    if (isBuild) {
+      it('preloads stylesheets', async () => {
+        const response = await page.request.get(
+          getServerUrl() + '/css-modules'
+        );
+        const html = await response.text();
+        const {link} = response.headers();
+
+        expect(link).toMatch(
+          /<\/assets\/style.[\w\d]+.css>; rel=preload; as=style/
+        );
+
+        const stylesheets = (html.match(/<link[^<>]+?>/gim) || [])
+          .filter((linkTag) => linkTag.includes('rel="stylesheet"'))
+          .map((linkTag) => linkTag.match(/href="([^"]+)"/)?.[1] || '');
+
+        for (const asset of stylesheets) {
+          expect(link).toMatch(asset);
+        }
+      });
+    }
   });
 
   describe('HMR', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Context: see https://github.com/Shopify/hydrogen/discussions/2068

This adds a [`Link` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) in Hydrogen SSR responses to preload stylesheets. I think this should also enable [Cloudflare's early hints](https://developers.cloudflare.com/cache/about/early-hints/#generating-early-hints).

~~We could also add the `preconnect` links we find in the template. Thoughts?~~ It now adds `preconnect` link tags to the header as well.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
