### PR TITLE
Fix response when doNotStream is called mid way

### DIFF
--- a/.changeset/tasty-mails-return.md
+++ b/.changeset/tasty-mails-return.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+When a route is rendering, if Hydrogen has already started streaming, it is invalid to call `response.doNotStream()`. Disabling streaming should always happen before any async operation in your route server component. This change fixes Hydrogen to warn if you try to disable streaming after the stream has already begun.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -195,6 +195,8 @@ export const renderHydrogen = (App: any) => {
                 hydrogenConfig,
                 true
               );
+
+              response.markAsSent();
             } catch (e: any) {
               log.error('Cache revalidate error', e);
             }
@@ -208,7 +210,7 @@ export const renderHydrogen = (App: any) => {
       }
     }
 
-    return processRequest(
+    const result = await processRequest(
       handleRequest,
       App,
       url,
@@ -218,6 +220,9 @@ export const renderHydrogen = (App: any) => {
       response,
       hydrogenConfig
     );
+
+    response.markAsSent();
+    return result;
   };
 
   if (__HYDROGEN_WORKER__) return handleRequest;

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -111,7 +111,7 @@ export const renderHydrogen = (App: any) => {
     setLogger(hydrogenConfig.logger);
     const log = getLoggerWithContext(request);
 
-    const response = new HydrogenResponse(null, {
+    const response = new HydrogenResponse(request.url, null, {
       headers: headers || {},
     });
 

--- a/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
@@ -8,17 +8,24 @@ import React from 'react';
 
 export class HydrogenResponse extends Response {
   private wait = false;
+  private sent = false;
   private cacheOptions: CachingStrategy = CacheShort();
 
   public status = 200;
   public statusText = '';
+
+  markAsSent() {
+    this.sent = true;
+  }
 
   /**
    * Buffer the current response until all queries have resolved,
    * and prevent it from streaming back early.
    */
   doNotStream() {
-    this.wait = true;
+    if (!this.sent) {
+      this.wait = true;
+    }
   }
 
   canStream() {

--- a/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
@@ -34,7 +34,7 @@ export class HydrogenResponse extends Response {
       this.wait = true;
     } else {
       log.warn(
-        `response.doNotStream() failed, the stream has already started on: ${this.url}`
+        `response.doNotStream() failed, the stream has already started on: ${this.url}\nDisabling streaming should always be the first thing in your route server component.`
       );
     }
   }

--- a/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenResponse/HydrogenResponse.server.ts
@@ -5,6 +5,7 @@ import {
 import type {CachingStrategy} from '../../types.js';
 import Redirect from '../Redirect/Redirect.client.js';
 import React from 'react';
+import {log} from '../../utilities/log/log.js';
 
 export class HydrogenResponse extends Response {
   private wait = false;
@@ -13,6 +14,12 @@ export class HydrogenResponse extends Response {
 
   public status = 200;
   public statusText = '';
+  public url;
+
+  constructor(url: string, body: any, init: any) {
+    super(body, init);
+    this.url = url;
+  }
 
   markAsSent() {
     this.sent = true;
@@ -25,6 +32,10 @@ export class HydrogenResponse extends Response {
   doNotStream() {
     if (!this.sent) {
       this.wait = true;
+    } else {
+      log.warn(
+        `response.doNotStream() failed, the stream has already started on: ${this.url}`
+      );
     }
   }
 

--- a/packages/playground/server-components/hydrogen.config.js
+++ b/packages/playground/server-components/hydrogen.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
   logger: {
     trace() {},
     debug() {},
+    warn() {},
   },
   serverErrorPage: '/src/500Error.tsx',
 });

--- a/packages/playground/server-components/src/routes/midwaynostream.server.jsx
+++ b/packages/playground/server-components/src/routes/midwaynostream.server.jsx
@@ -1,0 +1,10 @@
+import {useQuery} from '@shopify/hydrogen';
+
+export default function ({response}) {
+  useQuery(
+    'somekey',
+    () => new Promise((resolve) => setTimeout(() => resolve(), 100))
+  );
+  response.doNotStream();
+  return <div>Call doNotStream after stream has already begun</div>;
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -155,6 +155,21 @@ export default async function testCases({
     expect(body).toContain('>footer!<');
   });
 
+  it('streams if server component calls doNotStream after stream has already started', async () => {
+    const response = await fetch(getServerUrl() + '/midwaynostream');
+    const streamedChunks = [];
+
+    // This fetch response is not standard but a node-fetch polyfill.
+    // Therefore, the body is not a ReadableStream but a Node Readable.
+    // @ts-ignore
+    for await (const chunk of response.body) {
+      streamedChunks.push(chunk.toString());
+    }
+
+    const body = streamedChunks.join('');
+    expect(body).toContain('Call doNotStream after stream has already begun');
+  });
+
   it('buffers HTML for bots', async () => {
     const response = await fetch(getServerUrl() + '/stream?_bot');
     const streamedChunks = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -16379,7 +16379,7 @@ unified-message-control@^3.0.0:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
 
-unified@^9.0.0:
+unified@9.2.2, unified@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

>It looks like we have a bug in Hydrogen where, after streaming has already started, if you set response.doNotStream(), everything can get borked.

This prevents changing the streaming behavior once the response is returned.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
