### PR TITLE
Logging fixes and improvements

### DIFF
--- a/.changeset/good-kings-pretend.md
+++ b/.changeset/good-kings-pretend.md
@@ -1,0 +1,16 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improvements and fixes to hydrogen logging:
+
+1. API Routes are now passed a reference to the logger bound to the current request:
+
+```ts
+export async function api(request, {log}) {
+  log.warn("Here's a warning!");
+  return new Request('Hello World');
+}
+```
+
+2. If you define a custom logging implementation within your Hydrogen config, we'll now warn you when your logging implementation itself errors.

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -6,6 +6,7 @@ import {
 import {matchPath} from './matchPath.js';
 import {
   getLoggerWithContext,
+  Logger,
   logServerResponse,
 } from '../utilities/log/index.js';
 import type {HydrogenRequest} from '../foundation/HydrogenRequest/HydrogenRequest.server.js';
@@ -24,6 +25,7 @@ let memoizedRawRoutes: ImportGlobEagerOutput = {};
 
 type RouteParams = Record<string, string>;
 export type RequestOptions = {
+  log: Logger;
   params: RouteParams;
   queryShop: <T>(args: QueryShopArgs) => Promise<UseShopQueryResponse<T>>;
   session: SessionApi | null;
@@ -212,6 +214,7 @@ export async function renderApiRoute(
 
   try {
     response = await route.resource(request, {
+      log,
       params: route.params,
       queryShop: queryShopBuilder(hydrogenConfig.shopify, request),
       hydrogenConfig,

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -66,7 +66,14 @@ function doLog(
   try {
     const maybePromise = currentLogger[method](request, ...args);
     if (maybePromise instanceof Promise) {
-      request?.ctx?.runtime?.waitUntil?.(maybePromise);
+      request?.ctx?.runtime?.waitUntil?.(
+        maybePromise.catch((e) => {
+          const message = e instanceof Error ? e.stack : e;
+          defaultLogger.error(
+            `Promise error from the custom logging implementation for logger.${method} failed:\n${message}`
+          );
+        })
+      );
     }
   } catch (e) {
     const message = e instanceof Error ? e.stack : e;

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -63,9 +63,16 @@ function doLog(
   request: Partial<HydrogenRequest>,
   ...args: any[]
 ) {
-  const maybePromise = currentLogger[method](request, ...args);
-  if (maybePromise instanceof Promise) {
-    request?.ctx?.runtime?.waitUntil?.(maybePromise);
+  try {
+    const maybePromise = currentLogger[method](request, ...args);
+    if (maybePromise instanceof Promise) {
+      request?.ctx?.runtime?.waitUntil?.(maybePromise);
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.stack : e;
+    defaultLogger.error(
+      `The custom logging implementation for logger.${method} failed:\n${message}`
+    );
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Improvements and fixes to hydrogen logging:

1. API Routes are now passed a reference to the logger bound to the current request:

```ts
export async function api(request, {log}) {
  log.warn("Here's a warning!");
  return new Request('Hello World');
}
```

2. If you define a custom logging implementation within your Hydrogen config, we'll now warn you when your logging implementation itself errors.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
