### PR TITLE
Adds dynamic screen height to Tailwind for Cart Drawer

### DIFF
--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -37,7 +37,7 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@headlessui/react": "^1.6.4",
+    "@headlessui/react": "^1.7.0",
     "@shopify/hydrogen": "^1.3.2",
     "clsx": "^1.1.1",
     "graphql-tag": "^2.12.6",

--- a/templates/demo-store/src/components/global/Drawer.client.tsx
+++ b/templates/demo-store/src/components/global/Drawer.client.tsx
@@ -61,7 +61,7 @@ function Drawer({
                 leaveFrom="translate-x-0"
                 leaveTo={offScreen[openFrom]}
               >
-                <Dialog.Panel className="w-screen h-screen max-w-lg text-left align-middle transition-all transform shadow-xl bg-contrast">
+                <Dialog.Panel className="w-screen max-w-lg text-left align-middle transition-all transform shadow-xl h-screen-dynamic bg-contrast">
                   <header
                     className={`sticky top-0 flex items-center px-6 h-nav sm:px-8 md:px-12 ${
                       heading ? 'justify-between' : 'justify-end'

--- a/templates/demo-store/src/styles/index.css
+++ b/templates/demo-store/src/styles/index.css
@@ -16,6 +16,7 @@
   --shop-pay-button--width: 100%; /* Sets the width for the shop-pay-button web component */
   --height-nav: 3rem;
   --screen-height: 100vh;
+  --screen-height-dynamic: 100vh;
 
   @media (min-width: 32em) {
     --height-nav: 4rem;
@@ -27,6 +28,9 @@
   }
   @supports (height: 100svh) {
     --screen-height: 100svh;
+  }
+  @supports (height: 100dvh) {
+    --screen-height-dynamic: 100dvh;
   }
 }
 

--- a/templates/demo-store/tailwind.config.js
+++ b/templates/demo-store/tailwind.config.js
@@ -41,6 +41,7 @@ module.exports = {
         screen: 'var(--screen-height, 100vh)',
         'screen-no-nav':
           'calc(var(--screen-height, 100vh) - var(--height-nav))',
+        'screen-dynamic': 'var(--screen-height-dynamic, 100vh)',
       },
       width: {
         mobileGallery: 'calc(100vw - 3rem)',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,10 +2773,10 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
-"@headlessui/react@^1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.6.4.tgz#c73084e23386bef5fb86cd16da3352c3a844bb4c"
-  integrity sha512-0yqz1scwbFtwljmbbKjXsSGl5ABEYNICVHZnMCWo0UtOZodo2Tpu94uOVgCRjRZ77l2WcTi2S0uidINDvG7lsA==
+"@headlessui/react@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.0.tgz#7e36e6bbc25a24b02011527ae157a000dda88b85"
+  integrity sha512-/nDsijOXRwXVLpUBEiYuWguIBSIN3ZbKyah+KPUiD8bdIKtX1U/k+qLYUEr7NCQnSF2e4w1dr8me42ECuG3cvw==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
@@ -16499,7 +16499,7 @@ unified-message-control@^3.0.0:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
 
-unified@9.2.2, unified@^9.0.0:
+unified@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->
Today the cart drawer uses `svh` when supported, as the height. This means that if the user has scrolled, the cart drawer will not fill the page (see screenshot).

<img width="384" alt="image" src="https://user-images.githubusercontent.com/1060770/189006143-f1258fae-5ced-49c0-a746-4d63318e343b.png">

We still want to keep `svh` as the main way to interact with `h-screen` as it's most often used for full bleed Hero banners (and similar) where you don't want the height to change (too jarring). However specifically on the cart drawer, this _should_ be dynamic, as you can only scroll _within_ the pane when it's open.

This also updates `@headlessui` to 1.7.0 to resolve a bug found in scroll lock: https://github.com/tailwindlabs/headlessui/issues/949

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
