### PR TITLE
[CartProviderV2] Load cart from local storage

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -1,6 +1,4 @@
-import React, {useMemo} from 'react';
-import {useMachine} from '@xstate/react/fsm';
-import {createMachine, assign, StateMachine} from '@xstate/fsm';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {CartFragmentFragment} from './graphql/CartFragment.js';
 import {
   AttributeInput,
@@ -11,141 +9,14 @@ import {
 } from '../../storefront-api-types.js';
 import {CartContext} from './context.js';
 import {
-  Cart,
-  CartWithActions,
-  CartMachineContext,
   CartMachineEvent,
   CartMachineTypeState,
+  CartWithActions,
 } from './types.js';
-import {flattenConnection} from '../../utilities/flattenConnection/index.js';
 import {CartNoteUpdateMutationVariables} from './graphql/CartNoteUpdateMutation.js';
 import {useCartActions} from './CartActions.client.js';
-
-function invokeCart(
-  actions: [string],
-  options?: {resolveTarget?: string; errorTarget?: string}
-): StateMachine.Config<CartMachineContext, CartMachineEvent>['states']['on'] {
-  return {
-    entry: actions,
-    on: {
-      RESOLVE: {
-        target: options?.resolveTarget || 'idle',
-        actions: [
-          assign({
-            cart: (_, event) => event?.payload?.cart,
-            errors: (_, event) => undefined,
-          }),
-        ],
-      },
-      ERROR: {
-        target: options?.errorTarget || 'error',
-        actions: assign({
-          errors: (_, event) => event?.payload?.errors,
-        }),
-      },
-    },
-  };
-}
-
-const cartMachine = createMachine<
-  CartMachineContext,
-  CartMachineEvent,
-  CartMachineTypeState
->({
-  id: 'Cart',
-  initial: 'uninitialized',
-  states: {
-    uninitialized: {
-      on: {
-        CART_FETCH: {
-          target: 'cartFetching',
-        },
-        CART_CREATE: {
-          target: 'cartCreating',
-        },
-        CARTLINE_ADD: {
-          target: 'cartCreating',
-        },
-      },
-    },
-    initializationError: {
-      on: {
-        CART_FETCH: {
-          target: 'cartFetching',
-        },
-        CART_CREATE: {
-          target: 'cartCreating',
-        },
-        CARTLINE_ADD: {
-          target: 'cartCreating',
-        },
-      },
-    },
-    idle: {
-      on: {
-        CARTLINE_ADD: {
-          target: 'cartLineAdding',
-        },
-        CARTLINE_UPDATE: {
-          target: 'cartLineUpdating',
-        },
-        CARTLINE_REMOVE: {
-          target: 'cartLineRemoving',
-        },
-        NOTE_UPDATE: {
-          target: 'noteUpdating',
-        },
-        BUYER_IDENTITY_UPDATE: {
-          target: 'buyerIdentityUpdating',
-        },
-        CART_ATTRIBUTES_UPDATE: {
-          target: 'cartAttributesUpdating',
-        },
-        DISCOUNT_CODES_UPDATE: {
-          target: 'discountCodesUpdating',
-        },
-      },
-    },
-    error: {
-      on: {
-        CARTLINE_ADD: {
-          target: 'cartLineAdding',
-        },
-        CARTLINE_UPDATE: {
-          target: 'cartLineUpdating',
-        },
-        CARTLINE_REMOVE: {
-          target: 'cartLineRemoving',
-        },
-        NOTE_UPDATE: {
-          target: 'noteUpdating',
-        },
-        BUYER_IDENTITY_UPDATE: {
-          target: 'buyerIdentityUpdating',
-        },
-        CART_ATTRIBUTES_UPDATE: {
-          target: 'cartAttributesUpdating',
-        },
-        DISCOUNT_CODES_UPDATE: {
-          target: 'discountCodesUpdating',
-        },
-      },
-    },
-    cartFetching: invokeCart(['cartFetchAction'], {
-      errorTarget: 'initializationError',
-    }),
-    cartCreating: invokeCart(['cartCreateAction'], {
-      errorTarget: 'initializationError',
-    }),
-    cartLineRemoving: invokeCart(['cartLineRemoveAction']),
-    cartLineUpdating: invokeCart(['cartLineUpdateAction']),
-    cartLineAdding: invokeCart(['cartLineAddAction']),
-    noteUpdating: invokeCart(['noteUpdateAction']),
-    buyerIdentityUpdating: invokeCart(['buyerIdentityUpdateAction']),
-    cartAttributesUpdating: invokeCart(['cartAttributesUpdateAction']),
-    discountCodesUpdating: invokeCart(['discountCodesUpdateAction']),
-  },
-});
+import {useCartAPIStateMachine} from './useCartAPIStateMachine.client.js';
+import {CART_ID_STORAGE_KEY} from './constants.js';
 
 export function CartProviderV2({
   children,
@@ -162,173 +33,78 @@ export function CartProviderV2({
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
   cartFragment?: string;
 }) {
-  const {
-    cartFetch,
-    cartCreate,
-    cartLineAdd,
-    cartLineUpdate,
-    cartLineRemove,
-    noteUpdate,
-    buyerIdentityUpdate,
-    cartAttributesUpdate,
-    discountCodesUpdate,
-    cartFragment: usedCartFragment,
-  } = useCartActions({
+  const {cartFragment: usedCartFragment} = useCartActions({
     numCartLines,
     cartFragment,
   });
 
-  const [state, send] = useMachine(cartMachine, {
-    actions: {
-      cartFetchAction: (_, event) => {
-        if (event.type !== 'CART_FETCH') return;
-        cartFetch(event?.payload?.cartId).then((res) => {
-          if (res?.errors || !res?.data?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data.cart)},
-          });
-        });
-      },
-      cartCreateAction: (_, event) => {
-        if (event.type !== 'CART_CREATE' && event.type !== 'CARTLINE_ADD')
-          return;
-
-        cartCreate(event?.payload).then((res) => {
-          if (res?.errors || !res.data?.cartCreate?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartCreate.cart)},
-          });
-        });
-      },
-      cartLineAddAction: (context, event) => {
-        if (event.type !== 'CARTLINE_ADD' || !context?.cart?.id) return;
-
-        cartLineAdd(context.cart.id, event.payload.lines).then((res) => {
-          if (res?.errors || !res.data?.cartLinesAdd?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartLinesAdd.cart)},
-          });
-        });
-      },
-      cartLineUpdateAction: (context, event) => {
-        if (event.type !== 'CARTLINE_UPDATE' || !context?.cart?.id) return;
-        cartLineUpdate(context.cart.id, event.payload.lines).then((res) => {
-          if (res?.errors || !res.data?.cartLinesUpdate?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartLinesUpdate.cart)},
-          });
-        });
-      },
-      cartLineRemoveAction: (context, event) => {
-        if (event.type !== 'CARTLINE_REMOVE' || !context?.cart?.id) return;
-        cartLineRemove(context.cart.id, event.payload.lines).then((res) => {
-          if (res?.errors || !res.data?.cartLinesRemove?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartLinesRemove.cart)},
-          });
-        });
-      },
-      noteUpdateAction: (context, event) => {
-        if (event.type !== 'NOTE_UPDATE' || !context?.cart?.id) return;
-        noteUpdate(context.cart.id, event.payload.note).then((res) => {
-          if (res?.errors || !res.data?.cartNoteUpdate?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartNoteUpdate.cart)},
-          });
-        });
-      },
-      buyerIdentityUpdateAction: (context, event) => {
-        if (event.type !== 'BUYER_IDENTITY_UPDATE' || !context?.cart?.id)
-          return;
-        buyerIdentityUpdate(context.cart.id, event.payload.buyerIdentity).then(
-          (res) => {
-            if (res?.errors || !res.data?.cartBuyerIdentityUpdate?.cart) {
-              return send({type: 'ERROR', payload: {errors: res?.errors}});
-            }
-            send({
-              type: 'RESOLVE',
-              payload: {
-                cart: cartFromGraphQL(res.data?.cartBuyerIdentityUpdate.cart),
-              },
-            });
-          }
-        );
-      },
-      cartAttributesUpdateAction: (context, event) => {
-        if (event.type !== 'CART_ATTRIBUTES_UPDATE' || !context?.cart?.id)
-          return;
-        cartAttributesUpdate(context.cart.id, event.payload.attributes).then(
-          (res) => {
-            if (res?.errors || !res.data?.cartAttributesUpdate?.cart) {
-              return send({type: 'ERROR', payload: {errors: res?.errors}});
-            }
-            send({
-              type: 'RESOLVE',
-              payload: {
-                cart: cartFromGraphQL(res.data?.cartAttributesUpdate.cart),
-              },
-            });
-          }
-        );
-      },
-      discountCodesUpdateAction: (context, event) => {
-        if (event.type !== 'DISCOUNT_CODES_UPDATE' || !context?.cart?.id)
-          return;
-        discountCodesUpdate(context.cart.id, event.payload.discountCodes).then(
-          (res) => {
-            if (res?.errors || !res.data?.cartDiscountCodesUpdate?.cart) {
-              return send({type: 'ERROR', payload: {errors: res?.errors}});
-            }
-            send({
-              type: 'RESOLVE',
-              payload: {
-                cart: cartFromGraphQL(res.data?.cartDiscountCodesUpdate.cart),
-              },
-            });
-          }
-        );
-      },
-    },
+  const [cartState, cartSend] = useCartAPIStateMachine({
+    numCartLines,
+    cartFragment,
   });
+
+  const [cartReady, setCartReady] = useState(false);
+
+  // send cart events when ready
+  const onCartReadySend = useCallback(
+    (cartEvent: CartMachineEvent) => {
+      if (!cartReady) {
+        return console.warn("Cart isn't ready yet");
+      }
+      cartSend(cartEvent);
+    },
+    [cartReady, cartSend]
+  );
+
+  // save cart id to local storage
+  useEffect(() => {
+    if (cartState?.context?.cart?.id) {
+      try {
+        window.localStorage.setItem(
+          CART_ID_STORAGE_KEY,
+          cartState.context.cart?.id
+        );
+      } catch (error) {
+        console.warn('Failed to save cartId to localStorage', error);
+      }
+    }
+  }, [cartState?.context?.cart?.id]);
+
+  // fetch cart from local storage if cart id present and set cart as ready for use
+  useEffect(() => {
+    if (cartReady) return;
+    try {
+      const cartId = window.localStorage.getItem(CART_ID_STORAGE_KEY);
+      if (cartId) {
+        cartSend({type: 'CART_FETCH', payload: {cartId}});
+      }
+    } catch (error) {
+      console.warn('error fetching cartId');
+      console.warn(error);
+    }
+    setCartReady(true);
+  }, [cartReady, cartSend]);
 
   const cartContextValue = useMemo<CartWithActions>(() => {
     return {
-      ...(state?.context?.cart ?? {lines: [], attributes: []}),
-      status: tempTransposeStatus(state.value),
-      error: state?.context?.errors,
-      totalQuantity: state?.context?.cart?.totalQuantity ?? 0,
+      ...(cartState?.context?.cart ?? {lines: [], attributes: []}),
+      status: tempTransposeStatus(cartState.value),
+      error: cartState?.context?.errors,
+      totalQuantity: cartState?.context?.cart?.totalQuantity ?? 0,
       cartCreate(cartInput: CartInput) {
-        send({
+        onCartReadySend({
           type: 'CART_CREATE',
           payload: cartInput,
         });
       },
       linesAdd(lines: CartLineInput[]) {
-        send({
+        onCartReadySend({
           type: 'CARTLINE_ADD',
           payload: {lines},
         });
       },
       linesRemove(lines: string[]) {
-        send({
+        onCartReadySend({
           type: 'CARTLINE_REMOVE',
           payload: {
             lines,
@@ -336,7 +112,7 @@ export function CartProviderV2({
         });
       },
       linesUpdate(lines: CartLineUpdateInput[]) {
-        send({
+        onCartReadySend({
           type: 'CARTLINE_UPDATE',
           payload: {
             lines,
@@ -344,7 +120,7 @@ export function CartProviderV2({
         });
       },
       noteUpdate(note: CartNoteUpdateMutationVariables['note']) {
-        send({
+        onCartReadySend({
           type: 'NOTE_UPDATE',
           payload: {
             note,
@@ -352,7 +128,7 @@ export function CartProviderV2({
         });
       },
       buyerIdentityUpdate(buyerIdentity: CartBuyerIdentityInput) {
-        send({
+        onCartReadySend({
           type: 'BUYER_IDENTITY_UPDATE',
           payload: {
             buyerIdentity,
@@ -360,7 +136,7 @@ export function CartProviderV2({
         });
       },
       cartAttributesUpdate(attributes: AttributeInput[]) {
-        send({
+        onCartReadySend({
           type: 'CART_ATTRIBUTES_UPDATE',
           payload: {
             attributes,
@@ -368,7 +144,7 @@ export function CartProviderV2({
         });
       },
       discountCodesUpdate(discountCodes: string[]) {
-        send({
+        onCartReadySend({
           type: 'DISCOUNT_CODES_UPDATE',
           payload: {
             discountCodes,
@@ -377,7 +153,13 @@ export function CartProviderV2({
       },
       cartFragment: usedCartFragment,
     };
-  }, [usedCartFragment, send, state.context, state.value]);
+  }, [
+    cartState?.context?.cart,
+    cartState?.context?.errors,
+    cartState.value,
+    onCartReadySend,
+    usedCartFragment,
+  ]);
 
   return (
     <CartContext.Provider value={cartContextValue}>
@@ -409,13 +191,4 @@ function tempTransposeStatus(
     case 'discountCodesUpdating':
       return 'updating';
   }
-}
-
-export function cartFromGraphQL(cart: CartFragmentFragment): Cart {
-  return {
-    ...cart,
-    // @ts-expect-error While the cart still uses fragments, there will be a TS error here until we remove those fragments and get the type in-line
-    lines: flattenConnection(cart.lines),
-    note: cart.note ?? undefined,
-  };
 }

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -14,6 +14,7 @@ vi.mock('../CartActions.client.js', () => ({
 import {CartProviderV2} from '../CartProviderV2.client.js';
 import {cartFromGraphQL} from '../useCartAPIStateMachine.client.js';
 import {CountryCode} from '../../../storefront-api-types.js';
+import {CART_ID_STORAGE_KEY} from '../constants.js';
 
 function ShopifyCartProvider({children}) {
   return (
@@ -29,8 +30,8 @@ describe('<CartProviderV2 />', () => {
     vi.spyOn(window.localStorage, 'getItem').mockReturnValue('');
   });
 
-  describe('attempt initializing cart from local storage', () => {
-    it('fetches cart from cart id in local storage', async () => {
+  describe('local storage', () => {
+    it('fetches the cart with the cart id in local storage when initializing the app', async () => {
       const cartFetchSpy = vi.fn(async () => ({
         data: {cart: CART},
       }));
@@ -79,10 +80,46 @@ describe('<CartProviderV2 />', () => {
         lines: expect.arrayContaining([]),
       });
     });
+
+    it('saves cart id on cart creation', async () => {
+      vi.spyOn(window.localStorage, 'getItem').mockReturnValue('');
+      const spy = vi.spyOn(window.localStorage, 'setItem');
+
+      const result = await useCartWithInitializedCart();
+
+      expect(spy).toBeCalledWith(CART_ID_STORAGE_KEY, result.current.id);
+    });
+
+    it('deletes cart id on cart completion', async () => {
+      const cartFetchSpy = vi.fn(async () => ({
+        data: {cart: null},
+      }));
+      vi.spyOn(window.localStorage, 'getItem').mockReturnValue('cart-id');
+
+      const spy = vi.spyOn(window.localStorage, 'removeItem');
+
+      mockUseCartActions.mockReturnValue({
+        cartFetch: cartFetchSpy,
+      });
+
+      const {result} = renderHook(() => useCart(), {
+        wrapper: ShopifyCartProvider,
+      });
+
+      await act(async () => {});
+
+      expect(cartFetchSpy).toBeCalledWith('cart-id');
+      expect(result.current).toMatchObject({
+        status: 'idle',
+        lines: [],
+      });
+
+      expect(spy).toBeCalledWith(CART_ID_STORAGE_KEY);
+    });
   });
 
-  describe('uninitialized cart after local storage initialization', () => {
-    it('creates a cart when creating a cart line', async () => {
+  describe('uninitialized cart after local storage init', () => {
+    it('creates a cart when creating a cart', async () => {
       const cartCreateSpy = vi.fn(async () => ({
         data: {cartCreate: {cart: CART}},
       }));
@@ -142,40 +179,6 @@ describe('<CartProviderV2 />', () => {
         status: 'idle',
         ...cartFromGraphQL(CART),
       });
-    });
-
-    it('creates a cart when creating a cart line', async () => {
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
-      mockUseCartActions.mockReturnValue({
-        cartCreate: cartCreateSpy,
-      });
-
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
-
-      expect(result.current.status).toBe('uninitialized');
-
-      act(() => {
-        result.current.cartCreate({});
-      });
-
-      expect(result.current.status).toBe('creating');
-
-      await act(async () => {});
-
-      expect(cartCreateSpy).toBeCalledTimes(1);
-
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
-      });
-    });
-
-    it.skip('fetches a cart when fetching a cart', async () => {
-      // @TODO: new useCart
     });
 
     it('shows inializationError status when an error happens', async () => {
@@ -277,314 +280,353 @@ describe('<CartProviderV2 />', () => {
   });
 
   describe('idle', () => {
-    it('adds cartline', async () => {
-      const cartLineAddSpy = vi.fn(async () => ({
-        data: {cartLineAdd: {cart: {}}},
-      }));
+    describe('adds cart line', async () => {
+      it('resolves', async () => {
+        const cartLineAddSpy = vi.fn(async () => ({
+          data: {cartLinesAdd: {cart: CART}},
+        }));
 
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
+        const result = await useCartWithInitializedCart({
+          cartLineAdd: cartLineAddSpy,
+        });
 
-      mockUseCartActions.mockReturnValue({
-        cartLineAdd: cartLineAddSpy,
-        cartCreate: cartCreateSpy,
+        act(() => {
+          result.current.linesAdd([
+            {
+              merchandiseId: '123',
+            },
+          ]);
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(cartLineAddSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
+      it('deletes local storage on complete', async () => {
+        const cartLineAddSpy = vi.fn(async () => ({
+          data: {cartLinesAdd: {cart: null}},
+        }));
 
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
 
-      // add cart line
-      act(() => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
+        const result = await useCartWithInitializedCart({
+          cartLineAdd: cartLineAddSpy,
+        });
 
-      expect(result.current.status).toEqual('updating');
+        act(() => {
+          result.current.linesAdd([
+            {
+              merchandiseId: '123',
+            },
+          ]);
+        });
 
-      // wait till idle
-      await act(async () => {});
+        // wait till idle
+        await act(async () => {});
 
-      expect(cartLineAddSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
-      });
-    });
-
-    it('updates cartline', async () => {
-      const cartLineUpdateSpy = vi.fn(async () => ({
-        data: {cartLineUpdate: {cart: CART}},
-      }));
-
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
-
-      mockUseCartActions.mockReturnValue({
-        cartLineUpdate: cartLineUpdateSpy,
-        cartCreate: cartCreateSpy,
-      });
-
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
-
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
-
-      act(() => {
-        result.current.linesUpdate([
-          {
-            id: '123',
-            merchandiseId: '123',
-          },
-        ]);
-      });
-
-      expect(result.current.status).toEqual('updating');
-
-      // wait till idle
-      await act(async () => {});
-
-      expect(cartLineUpdateSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
       });
     });
 
-    it('removes cartline', async () => {
-      const cartLineRemoveSpy = vi.fn(async () => ({
-        data: {cartLineRemove: {cart: CART}},
-      }));
+    describe('updates cartline', async () => {
+      it('resolves', async () => {
+        const cartLineUpdateSpy = vi.fn(async () => ({
+          data: {cartLinesUpdate: {cart: CART}},
+        }));
 
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
+        const result = await useCartWithInitializedCart({
+          cartLineUpdate: cartLineUpdateSpy,
+        });
 
-      mockUseCartActions.mockReturnValue({
-        cartLineRemove: cartLineRemoveSpy,
-        cartCreate: cartCreateSpy,
+        act(() => {
+          result.current.linesUpdate([
+            {
+              id: '123',
+              merchandiseId: '123',
+            },
+          ]);
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(cartLineUpdateSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
+      it('deletes local storage on complete', async () => {
+        const cartLineUpdateSpy = vi.fn(async () => ({
+          data: {cartLinesUpdate: {cart: null}},
+        }));
 
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
 
-      act(() => {
-        result.current.linesRemove(['123']);
-      });
+        const result = await useCartWithInitializedCart({
+          cartLineUpdate: cartLineUpdateSpy,
+        });
 
-      expect(result.current.status).toEqual('updating');
+        act(() => {
+          result.current.linesUpdate([
+            {
+              id: '123',
+              merchandiseId: '123',
+            },
+          ]);
+        });
 
-      // wait till idle
-      await act(async () => {});
+        // wait till idle
+        await act(async () => {});
 
-      expect(cartLineRemoveSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
-      });
-    });
-
-    it('note update', async () => {
-      const noteUpdateSpy = vi.fn(async () => ({
-        data: {noteUpdate: {cart: CART}},
-      }));
-
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
-
-      mockUseCartActions.mockReturnValue({
-        noteUpdate: noteUpdateSpy,
-        cartCreate: cartCreateSpy,
-      });
-
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
-
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
-
-      act(() => {
-        result.current.noteUpdate('test note');
-      });
-
-      expect(result.current.status).toEqual('updating');
-
-      // wait till idle
-      await act(async () => {});
-
-      expect(noteUpdateSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
       });
     });
 
-    it('buyer identity update', async () => {
-      const buyerIdentityUpdateSpy = vi.fn(async () => ({
-        data: {buyerIdentityUpdate: {cart: CART}},
-      }));
+    describe('removes cartline', async () => {
+      it('resolves', async () => {
+        const cartLineRemoveSpy = vi.fn(async () => ({
+          data: {cartLinesRemove: {cart: CART}},
+        }));
 
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
+        const result = await useCartWithInitializedCart({
+          cartLineRemove: cartLineRemoveSpy,
+        });
 
-      mockUseCartActions.mockReturnValue({
-        buyerIdentityUpdate: buyerIdentityUpdateSpy,
-        cartCreate: cartCreateSpy,
+        act(() => {
+          result.current.linesRemove(['123']);
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(cartLineRemoveSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
+      it('deletes local storage on complete', async () => {
+        const cartLineRemoveSpy = vi.fn(async () => ({
+          data: {cartLinesRemove: {cart: null}},
+        }));
 
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
 
-      act(() => {
-        result.current.buyerIdentityUpdate({countryCode: CountryCode.Us});
-      });
+        const result = await useCartWithInitializedCart({
+          cartLineRemove: cartLineRemoveSpy,
+        });
 
-      expect(result.current.status).toEqual('updating');
+        act(() => {
+          result.current.linesRemove(['123']);
+        });
 
-      // wait till idle
-      await act(async () => {});
-
-      expect(buyerIdentityUpdateSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
-      });
-    });
-
-    it('cart attributes update', async () => {
-      const cartAttributesUpdateSpy = vi.fn(async () => ({
-        data: {cartAttributesUpdate: {cart: CART}},
-      }));
-
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
-
-      mockUseCartActions.mockReturnValue({
-        cartAttributesUpdate: cartAttributesUpdateSpy,
-        cartCreate: cartCreateSpy,
-      });
-
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
-      });
-
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
-      });
-
-      act(() => {
-        result.current.cartAttributesUpdate([{key: 'key', value: 'value'}]);
-      });
-
-      expect(result.current.status).toEqual('updating');
-
-      // wait till idle
-      await act(async () => {});
-
-      expect(cartAttributesUpdateSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
+        // wait till idle
+        await act(async () => {});
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
       });
     });
 
-    it('discount update', async () => {
-      const discountCodesUpdateSpy = vi.fn(async () => ({
-        data: {discountCodesUpdate: {cart: CART}},
-      }));
+    describe('note update', async () => {
+      it('resolves', async () => {
+        const noteUpdateSpy = vi.fn(async () => ({
+          data: {cartNoteUpdate: {cart: CART}},
+        }));
 
-      const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
-      }));
+        const result = await useCartWithInitializedCart({
+          noteUpdate: noteUpdateSpy,
+        });
 
-      mockUseCartActions.mockReturnValue({
-        discountCodesUpdate: discountCodesUpdateSpy,
-        cartCreate: cartCreateSpy,
+        act(() => {
+          result.current.noteUpdate('test note');
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(noteUpdateSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider,
+      it('deletes local storage on complete', async () => {
+        const noteUpdateSpy = vi.fn(async () => ({
+          data: {cartNoteUpdate: {cart: null}},
+        }));
+
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
+
+        const result = await useCartWithInitializedCart({
+          noteUpdate: noteUpdateSpy,
+        });
+
+        act(() => {
+          result.current.noteUpdate('test note');
+        });
+
+        // wait till idle
+        await act(async () => {});
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
+      });
+    });
+
+    describe('buyer identity update', async () => {
+      it('resolves', async () => {
+        const buyerIdentityUpdateSpy = vi.fn(async () => ({
+          data: {cartBuyerIdentityUpdate: {cart: CART}},
+        }));
+
+        const result = await useCartWithInitializedCart({
+          buyerIdentityUpdate: buyerIdentityUpdateSpy,
+        });
+
+        act(() => {
+          result.current.buyerIdentityUpdate({countryCode: CountryCode.Us});
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(buyerIdentityUpdateSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      // creates a cart and wait till idle
-      await act(async () => {
-        result.current.linesAdd([
-          {
-            merchandiseId: '123',
-          },
-        ]);
+      it('deletes local storage on complete', async () => {
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
+
+        const buyerIdentityUpdateSpy = vi.fn(async () => ({
+          data: {cartBuyerIdentityUpdate: {cart: null}},
+        }));
+
+        const result = await useCartWithInitializedCart({
+          buyerIdentityUpdate: buyerIdentityUpdateSpy,
+        });
+
+        act(() => {
+          result.current.buyerIdentityUpdate({countryCode: CountryCode.Us});
+        });
+
+        // wait till idle
+        await act(async () => {});
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
+      });
+    });
+
+    describe('cart attributes update', async () => {
+      it('resolves', async () => {
+        const cartAttributesUpdateSpy = vi.fn(async () => ({
+          data: {cartAttributesUpdate: {cart: CART}},
+        }));
+
+        const result = await useCartWithInitializedCart({
+          cartAttributesUpdate: cartAttributesUpdateSpy,
+        });
+
+        act(() => {
+          result.current.cartAttributesUpdate([{key: 'key', value: 'value'}]);
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(cartAttributesUpdateSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      act(() => {
-        result.current.discountCodesUpdate(['DiscountCode']);
+      it('deletes local storage on complete', async () => {
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
+
+        const cartAttributesUpdateSpy = vi.fn(async () => ({
+          data: {cartAttributesUpdate: {cart: null}},
+        }));
+
+        const result = await useCartWithInitializedCart({
+          cartAttributesUpdate: cartAttributesUpdateSpy,
+        });
+
+        act(() => {
+          result.current.cartAttributesUpdate([{key: 'key', value: 'value'}]);
+        });
+
+        // wait till idle
+        await act(async () => {});
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
+      });
+    });
+
+    describe('discount update', async () => {
+      it('resolves', async () => {
+        const discountCodesUpdateSpy = vi.fn(async () => ({
+          data: {cartDiscountCodesUpdate: {cart: CART}},
+        }));
+
+        const result = await useCartWithInitializedCart({
+          discountCodesUpdate: discountCodesUpdateSpy,
+        });
+
+        act(() => {
+          result.current.discountCodesUpdate(['DiscountCode']);
+        });
+
+        expect(result.current.status).toEqual('updating');
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(discountCodesUpdateSpy).toBeCalledTimes(1);
+        expect(result.current).toMatchObject({
+          status: 'idle',
+          ...cartFromGraphQL(CART),
+        });
       });
 
-      expect(result.current.status).toEqual('updating');
+      it('deletes local storage on complete', async () => {
+        const spy = vi.spyOn(window.localStorage, 'removeItem');
 
-      // wait till idle
-      await act(async () => {});
+        const discountCodesUpdateSpy = vi.fn(async () => ({
+          data: {cartDiscountCodesUpdate: {cart: null}},
+        }));
 
-      expect(discountCodesUpdateSpy).toBeCalledTimes(1);
-      expect(result.current).toMatchObject({
-        status: 'idle',
-        ...cartFromGraphQL(CART),
+        const result = await useCartWithInitializedCart({
+          discountCodesUpdate: discountCodesUpdateSpy,
+        });
+
+        act(() => {
+          result.current.discountCodesUpdate(['DiscountCode']);
+        });
+
+        // wait till idle
+        await act(async () => {});
+
+        expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
       });
     });
   });
@@ -636,3 +678,30 @@ describe('<CartProviderV2 />', () => {
     });
   });
 });
+
+async function useCartWithInitializedCart(cartActionsMocks = {}) {
+  const cartCreateSpy = vi.fn(async () => ({
+    data: {cartCreate: {cart: CART}},
+  }));
+
+  mockUseCartActions.mockReturnValue({
+    cartCreate: cartCreateSpy,
+    ...cartActionsMocks,
+  });
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const {result} = renderHook(() => useCart(), {
+    wrapper: ShopifyCartProvider,
+  });
+
+  // creates a cart and wait till idle
+  await act(async () => {
+    result.current.linesAdd([
+      {
+        merchandiseId: '123',
+      },
+    ]);
+  });
+
+  return result;
+}

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -165,6 +165,7 @@ export type CartMachineEvent =
   | BuyerIdentityUpdateEvent
   | CartAttributesUpdateEvent
   | DiscountCodesUpdateEvent
+  | {type: 'CART_COMPLETED'}
   | {type: 'RESOLVE'; payload: {cart: Cart}}
   | {type: 'ERROR'; payload: {errors: any}};
 
@@ -178,6 +179,13 @@ export type CartMachineTypeState =
     }
   | {
       value: 'initializationError';
+      context: CartMachineContext & {
+        cart: undefined;
+        errors: any;
+      };
+    }
+  | {
+      value: 'cartCompleted';
       context: CartMachineContext & {
         cart: undefined;
         errors: any;

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -1,0 +1,308 @@
+import {useMachine} from '@xstate/react/fsm';
+import {createMachine, assign, StateMachine} from '@xstate/fsm';
+import {CartFragmentFragment} from './graphql/CartFragment.js';
+import {
+  Cart,
+  CartMachineContext,
+  CartMachineEvent,
+  CartMachineTypeState,
+} from './types.js';
+import {flattenConnection} from '../../utilities/flattenConnection/index.js';
+import {useCartActions} from './CartActions.client.js';
+import {useMemo} from 'react';
+
+function invokeCart(
+  actions: [string],
+  options?: {resolveTarget?: string; errorTarget?: string}
+): StateMachine.Config<CartMachineContext, CartMachineEvent>['states']['on'] {
+  return {
+    entry: actions,
+    on: {
+      RESOLVE: {
+        target: options?.resolveTarget || 'idle',
+        actions: [
+          assign({
+            cart: (_, event) => event?.payload?.cart,
+            errors: (_, event) => undefined,
+          }),
+        ],
+      },
+      ERROR: {
+        target: options?.errorTarget || 'error',
+        actions: assign({
+          errors: (_, event) => event?.payload?.errors,
+        }),
+      },
+    },
+  };
+}
+
+const cartMachine = createMachine<
+  CartMachineContext,
+  CartMachineEvent,
+  CartMachineTypeState
+>({
+  id: 'Cart',
+  initial: 'uninitialized',
+  states: {
+    uninitialized: {
+      on: {
+        CART_FETCH: {
+          target: 'cartFetching',
+        },
+        CART_CREATE: {
+          target: 'cartCreating',
+        },
+        CARTLINE_ADD: {
+          target: 'cartCreating',
+        },
+      },
+    },
+    initializationError: {
+      on: {
+        CART_FETCH: {
+          target: 'cartFetching',
+        },
+        CART_CREATE: {
+          target: 'cartCreating',
+        },
+        CARTLINE_ADD: {
+          target: 'cartCreating',
+        },
+      },
+    },
+    idle: {
+      on: {
+        CARTLINE_ADD: {
+          target: 'cartLineAdding',
+        },
+        CARTLINE_UPDATE: {
+          target: 'cartLineUpdating',
+        },
+        CARTLINE_REMOVE: {
+          target: 'cartLineRemoving',
+        },
+        NOTE_UPDATE: {
+          target: 'noteUpdating',
+        },
+        BUYER_IDENTITY_UPDATE: {
+          target: 'buyerIdentityUpdating',
+        },
+        CART_ATTRIBUTES_UPDATE: {
+          target: 'cartAttributesUpdating',
+        },
+        DISCOUNT_CODES_UPDATE: {
+          target: 'discountCodesUpdating',
+        },
+      },
+    },
+    error: {
+      on: {
+        CARTLINE_ADD: {
+          target: 'cartLineAdding',
+        },
+        CARTLINE_UPDATE: {
+          target: 'cartLineUpdating',
+        },
+        CARTLINE_REMOVE: {
+          target: 'cartLineRemoving',
+        },
+        NOTE_UPDATE: {
+          target: 'noteUpdating',
+        },
+        BUYER_IDENTITY_UPDATE: {
+          target: 'buyerIdentityUpdating',
+        },
+        CART_ATTRIBUTES_UPDATE: {
+          target: 'cartAttributesUpdating',
+        },
+        DISCOUNT_CODES_UPDATE: {
+          target: 'discountCodesUpdating',
+        },
+      },
+    },
+    cartFetching: invokeCart(['cartFetchAction'], {
+      errorTarget: 'initializationError',
+    }),
+    cartCreating: invokeCart(['cartCreateAction'], {
+      errorTarget: 'initializationError',
+    }),
+    cartLineRemoving: invokeCart(['cartLineRemoveAction']),
+    cartLineUpdating: invokeCart(['cartLineUpdateAction']),
+    cartLineAdding: invokeCart(['cartLineAddAction']),
+    noteUpdating: invokeCart(['noteUpdateAction']),
+    buyerIdentityUpdating: invokeCart(['buyerIdentityUpdateAction']),
+    cartAttributesUpdating: invokeCart(['cartAttributesUpdateAction']),
+    discountCodesUpdating: invokeCart(['discountCodesUpdateAction']),
+  },
+});
+
+export function useCartAPIStateMachine({
+  numCartLines,
+  data: cart,
+  cartFragment,
+}: {
+  /**  Maximum number of cart lines to fetch. Defaults to 250 cart lines. */
+  numCartLines?: number;
+  /** An object with fields that correspond to the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart). */
+  data?: CartFragmentFragment;
+  /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
+  cartFragment?: string;
+}) {
+  const {
+    cartFetch,
+    cartCreate,
+    cartLineAdd,
+    cartLineUpdate,
+    cartLineRemove,
+    noteUpdate,
+    buyerIdentityUpdate,
+    cartAttributesUpdate,
+    discountCodesUpdate,
+  } = useCartActions({
+    numCartLines,
+    cartFragment,
+  });
+
+  const [state, send, service] = useMachine(cartMachine, {
+    actions: {
+      cartFetchAction: (_, event) => {
+        if (event.type !== 'CART_FETCH') return;
+        cartFetch(event?.payload?.cartId).then((res) => {
+          if (res?.errors || !res?.data?.cart) {
+            return send({type: 'ERROR', payload: {errors: res?.errors}});
+          }
+          send({
+            type: 'RESOLVE',
+            payload: {cart: cartFromGraphQL(res.data.cart)},
+          });
+        });
+      },
+      cartCreateAction: (_, event) => {
+        if (event.type !== 'CART_CREATE' && event.type !== 'CARTLINE_ADD')
+          return;
+
+        cartCreate(event?.payload).then((res) => {
+          if (res?.errors || !res.data?.cartCreate?.cart) {
+            return send({type: 'ERROR', payload: {errors: res?.errors}});
+          }
+          send({
+            type: 'RESOLVE',
+            payload: {cart: cartFromGraphQL(res.data?.cartCreate.cart)},
+          });
+        });
+      },
+      cartLineAddAction: (context, event) => {
+        if (event.type !== 'CARTLINE_ADD' || !context?.cart?.id) return;
+
+        cartLineAdd(context.cart.id, event.payload.lines).then((res) => {
+          if (res?.errors || !res.data?.cartLinesAdd?.cart) {
+            return send({type: 'ERROR', payload: {errors: res?.errors}});
+          }
+          send({
+            type: 'RESOLVE',
+            payload: {cart: cartFromGraphQL(res.data?.cartLinesAdd.cart)},
+          });
+        });
+      },
+      cartLineUpdateAction: (context, event) => {
+        if (event.type !== 'CARTLINE_UPDATE' || !context?.cart?.id) return;
+        cartLineUpdate(context.cart.id, event.payload.lines).then((res) => {
+          if (res?.errors || !res.data?.cartLinesUpdate?.cart) {
+            return send({type: 'ERROR', payload: {errors: res?.errors}});
+          }
+          send({
+            type: 'RESOLVE',
+            payload: {cart: cartFromGraphQL(res.data?.cartLinesUpdate.cart)},
+          });
+        });
+      },
+      cartLineRemoveAction: (context, event) => {
+        if (event.type !== 'CARTLINE_REMOVE' || !context?.cart?.id) return;
+        cartLineRemove(context.cart.id, event.payload.lines).then((res) => {
+          if (res?.errors || !res.data?.cartLinesRemove?.cart) {
+            return send({type: 'ERROR', payload: {errors: res?.errors}});
+          }
+          send({
+            type: 'RESOLVE',
+            payload: {cart: cartFromGraphQL(res.data?.cartLinesRemove.cart)},
+          });
+        });
+      },
+      noteUpdateAction: (context, event) => {
+        if (event.type !== 'NOTE_UPDATE' || !context?.cart?.id) return;
+        noteUpdate(context.cart.id, event.payload.note).then((res) => {
+          if (res?.errors || !res.data?.cartNoteUpdate?.cart) {
+            return send({type: 'ERROR', payload: {errors: res?.errors}});
+          }
+          send({
+            type: 'RESOLVE',
+            payload: {cart: cartFromGraphQL(res.data?.cartNoteUpdate.cart)},
+          });
+        });
+      },
+      buyerIdentityUpdateAction: (context, event) => {
+        if (event.type !== 'BUYER_IDENTITY_UPDATE' || !context?.cart?.id)
+          return;
+        buyerIdentityUpdate(context.cart.id, event.payload.buyerIdentity).then(
+          (res) => {
+            if (res?.errors || !res.data?.cartBuyerIdentityUpdate?.cart) {
+              return send({type: 'ERROR', payload: {errors: res?.errors}});
+            }
+            send({
+              type: 'RESOLVE',
+              payload: {
+                cart: cartFromGraphQL(res.data?.cartBuyerIdentityUpdate.cart),
+              },
+            });
+          }
+        );
+      },
+      cartAttributesUpdateAction: (context, event) => {
+        if (event.type !== 'CART_ATTRIBUTES_UPDATE' || !context?.cart?.id)
+          return;
+        cartAttributesUpdate(context.cart.id, event.payload.attributes).then(
+          (res) => {
+            if (res?.errors || !res.data?.cartAttributesUpdate?.cart) {
+              return send({type: 'ERROR', payload: {errors: res?.errors}});
+            }
+            send({
+              type: 'RESOLVE',
+              payload: {
+                cart: cartFromGraphQL(res.data?.cartAttributesUpdate.cart),
+              },
+            });
+          }
+        );
+      },
+      discountCodesUpdateAction: (context, event) => {
+        if (event.type !== 'DISCOUNT_CODES_UPDATE' || !context?.cart?.id)
+          return;
+        discountCodesUpdate(context.cart.id, event.payload.discountCodes).then(
+          (res) => {
+            if (res?.errors || !res.data?.cartDiscountCodesUpdate?.cart) {
+              return send({type: 'ERROR', payload: {errors: res?.errors}});
+            }
+            send({
+              type: 'RESOLVE',
+              payload: {
+                cart: cartFromGraphQL(res.data?.cartDiscountCodesUpdate.cart),
+              },
+            });
+          }
+        );
+      },
+    },
+  });
+
+  return useMemo(() => [state, send, service] as const, [state, send, service]);
+}
+
+export function cartFromGraphQL(cart: CartFragmentFragment): Cart {
+  return {
+    ...cart,
+    // @ts-expect-error While the cart still uses fragments, there will be a TS error here until we remove those fragments and get the type in-line
+    lines: flattenConnection(cart.lines),
+    note: cart.note ?? undefined,
+  };
+}


### PR DESCRIPTION
### Description
Part of Issue: https://github.com/Shopify/hydrogen/issues/1947
New `CartProviderV2` now loads from local storage. Tested with vitest

### Additional context
I keep the local storage separate from the main state machine, since this seems a very specific initialization we are seeking.
I keep the implementation simple with `useEffect`

### Tophat
https://github.com/Shopify/hydrogen/tree/feat/init-cart-state-tophat
