### PR TITLE
Add useDelay utility hook

### DIFF
--- a/.changeset/blue-parents-tease.md
+++ b/.changeset/blue-parents-tease.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add the `useDelay` hook for artificial delays when rendering server components. This is useful to debug timing issues or building suspense boundary fallback UI. See the [`useDelay` documentation](https://shopify.dev/api/hydrogen/hooks/global/usedelay).

--- a/docs/hooks/global/usedelay.md
+++ b/docs/hooks/global/usedelay.md
@@ -1,0 +1,83 @@
+---
+gid: 2efaf024-c436-4d4e-9130-cf0b0c9cb843
+title: delay
+description: Add an artifical within server components
+---
+
+The `useDelay` hook adds an artificial delay within your server components. This is useful to debug timing issues, and to design fallback UI states at suspense boundaries.
+
+> Note:
+> All artificial delays are removed in production mode
+
+## Example code
+
+```tsx
+import {useShopQuery, gql, useDelay} from '@shopify/hydrogen';
+
+export default function Page() {
+  // Force `useShopQuery` to take at least 3 seconds
+  const {data} = useDelay(
+    useShopQuery({
+      query: QUERY,
+      variables: {},
+    }),
+    3000
+  );
+
+  // Add another delay. The component will not finish rendering
+  // and return for another three seconds
+  useDelay('uniqueDelayKey', 3000);
+
+  return <h1>{data.property}</h1>;
+}
+
+const QUERY = gql`/** add your query here **/`;
+```
+
+The `useDelay` hook is especially useful when testing suspense boundary fallbacks:
+
+```tsx
+import {useShopQuery, gql, useDelay} from '@shopify/hydrogen';
+
+export default function Page() {
+  return (
+    <Suspense fallback={<SkeletonPage />}>
+      <PageContent />
+    </Suspense>
+  );
+}
+
+function SkeletonPage() {
+  return <div>Loading...</div>;
+}
+
+function PageContent() {
+  const {data} = useDelay(
+    useShopQuery({
+      query: QUERY,
+      variables: {},
+    }),
+    3000
+  );
+
+  return <div>...</div>;
+}
+```
+
+## Arguments
+
+The `useDelay` hook takes the following arguments:
+
+| Key     | Required | Description                                                    |
+| ------- | -------- | -------------------------------------------------------------- |
+| `delay` | Yes      | A unique string or the result of `useQuery` or `useShopQuery`. |
+| `time`  | Yes      | The amount of time in miliseconds to delay.                    |
+
+## Return value
+
+The `useDelay` hook returns the result of `useShopQuery` or `useQuery` after the specified delay.
+
+## Related hooks
+
+- [`useShopQuery`](https://shopify.dev/api/hydrogen/hooks/global/useshopquery)
+- [`useQuery`](https://shopify.dev/api/hydrogen/hooks/global/usequery)

--- a/docs/hooks/global/usedelay.md
+++ b/docs/hooks/global/usedelay.md
@@ -25,7 +25,7 @@ export default function Page() {
   );
 
   // Add another delay. The component will not finish rendering
-  // and return for another three seconds
+  // and be returned for another three seconds.
   useDelay('uniqueDelayKey', 3000);
 
   return <h1>{data.property}</h1>;
@@ -34,7 +34,7 @@ export default function Page() {
 const QUERY = gql`/** add your query here **/`;
 ```
 
-The `useDelay` hook is especially useful when testing suspense boundary fallbacks:
+The `useDelay` hook is especially useful when testing suspense boundary fallbacks. The following is an example:
 
 ```tsx
 import {useShopQuery, gql, useDelay} from '@shopify/hydrogen';
@@ -70,7 +70,7 @@ The `useDelay` hook takes the following arguments:
 
 | Key     | Required | Description                                                    |
 | ------- | -------- | -------------------------------------------------------------- |
-| `delay` | Yes      | A unique string or the result of `useQuery` or `useShopQuery`. |
+| `delay` | Yes      | A unique string or the result of either `useQuery` or `useShopQuery`. |
 | `time`  | Yes      | The amount of time in miliseconds to delay.                    |
 
 ## Return value

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -82,6 +82,7 @@ export class HydrogenRequest extends Request {
     scopes: Map<string, Record<string, any>>;
     localization?: LocalizationContextValue;
     [key: string]: any;
+    throttledRequests: Record<string, any>;
   };
 
   constructor(input: any);
@@ -116,6 +117,7 @@ export class HydrogenRequest extends Request {
       preloadQueries: new Map(),
       scopes: new Map(),
       flashSession: {},
+      throttledRequests: {},
     };
     this.cookies = this.parseCookies();
   }

--- a/packages/hydrogen/src/hooks/useDelay/useDelay.ts
+++ b/packages/hydrogen/src/hooks/useDelay/useDelay.ts
@@ -1,8 +1,16 @@
 import {useServerRequest} from '../../foundation/ServerRequestProvider/index.js';
 import {wrapPromise} from '../../utilities/index.js';
+import {log} from '../../utilities/log/log.js';
 
-export const useDelay = function (data: any, time: number) {
-  if (!__HYDROGEN_DEV__) return data;
+export const useDelay = function (data: unknown, time: number) {
+  if (!__HYDROGEN_DEV__) {
+    log.warn(
+      new Error(
+        'The `useDelay` hook introduces an artificial delay which should not be used in production!'
+      ).stack
+    );
+    return data;
+  }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const serverRequest = useServerRequest();

--- a/packages/hydrogen/src/hooks/useDelay/useDelay.ts
+++ b/packages/hydrogen/src/hooks/useDelay/useDelay.ts
@@ -6,7 +6,7 @@ export const useDelay = function (data: unknown, time: number) {
   if (!__HYDROGEN_DEV__) {
     log.warn(
       new Error(
-        'The `useDelay` hook introduces an artificial delay which should not be used in production!'
+        'The `useDelay` hook introduces an artificial delay that should not be used in production!'
       ).stack
     );
     return data;

--- a/packages/hydrogen/src/hooks/useDelay/useDelay.ts
+++ b/packages/hydrogen/src/hooks/useDelay/useDelay.ts
@@ -1,0 +1,19 @@
+import {useServerRequest} from '../../foundation/ServerRequestProvider/index.js';
+import {wrapPromise} from '../../utilities/index.js';
+
+export const useDelay = function (data: any, time: number) {
+  if (!__HYDROGEN_DEV__) return data;
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const serverRequest = useServerRequest();
+  const key = JSON.stringify(data);
+
+  if (!serverRequest.ctx.throttledRequests[key]) {
+    serverRequest.ctx.throttledRequests[key] = wrapPromise(
+      new Promise((resolve) => setTimeout(resolve, time))
+    );
+  }
+  serverRequest.ctx.throttledRequests[key].read();
+
+  return data;
+};

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -46,6 +46,7 @@ export {ShopifyAnalytics} from './foundation/Analytics/connectors/Shopify/Shopif
 export {ShopifyAnalyticsConstants} from './foundation/Analytics/connectors/Shopify/const.js';
 export {useSession} from './foundation/useSession/useSession.js';
 export {Cookie} from './foundation/Cookie/Cookie.js';
+export {useDelay} from './hooks/useDelay/useDelay.js';
 
 /**
  * Export server-only CartQuery here instead of `CartProvider.client` to prevent

--- a/yarn.lock
+++ b/yarn.lock
@@ -16677,7 +16677,7 @@ unified-message-control@^3.0.0:
     unist-util-visit "^2.0.0"
     vfile-location "^3.0.0"
 
-unified@^9.0.0:
+unified@9.2.2, unified@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
### Description

Add the `useDelay` hook for artificial delays when rendering server components. This is useful to debug timing issues or building suspense boundary fallback UI:

The `useDelay` hook is especially useful when testing suspense boundary fallbacks:

```tsx
import {useShopQuery, gql, useDelay} from '@shopify/hydrogen';

export default function Page() {
  return (
    <Suspense fallback={<SkeletonPage />}>
      <PageContent />
    </Suspense>
  );
}

function SkeletonPage() {
  return <div>Loading...</div>;
}

function PageContent() {
  const {data} = useDelay(
    useShopQuery({
      query: QUERY,
      variables: {},
    }),
    3000
  );

  return <div>...</div>;
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
