### PR TITLE
Enable streaming in RSC responses

### DIFF
--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -282,7 +282,6 @@ async function processRequest(
   const rsc = runRSC({App, state, log, request, response});
 
   if (isRSCRequest) {
-    response.headers.set('cache-control', response.cacheControlHeader);
     const {headers} = response;
     const [rscReadableForResponse, rscReadableForCache] = rsc.readable.tee();
 
@@ -291,6 +290,7 @@ async function processRequest(
       __HYDROGEN_WORKER__ ? undefined : (chunk) => nodeResponse!.write(chunk)
     ).then((buffered) => {
       if (!__HYDROGEN_WORKER__) nodeResponse!.end();
+      response.headers.set('cache-control', response.cacheControlHeader);
       return cacheResponse(response, request, [buffered], revalidate);
     });
 

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -213,7 +213,7 @@ export default async function testCases({
     expect(body).toContain('>footer!<');
   });
 
-  it('buffers the RSC response', async () => {
+  it('streams the RSC response', async () => {
     const response = await fetch(
       getServerUrl() +
         `${RSC_PATHNAME}?state=` +
@@ -229,7 +229,7 @@ export default async function testCases({
       streamedChunks.push(chunk.toString());
     }
 
-    expect(streamedChunks.length).toBe(1);
+    expect(streamedChunks.length).toBeGreaterThan(1); // Streamed more than 1 chunk
 
     const body = streamedChunks.join('');
     expect(body).toContain('S1:"react.suspense"');


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

@blittle @wizardlyhel This still keeps the full page cache at the edge. Do you think we can enable streaming like this?

Edit: Ahh, i think this is breaking the Form component somehow, and maybe other things 🤯 

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
