### PR TITLE
Remove AccountIcon

### DIFF
--- a/templates/demo-store/src/components/elements/Icon.tsx
+++ b/templates/demo-store/src/components/elements/Icon.tsx
@@ -25,19 +25,6 @@ function Icon({
   );
 }
 
-export function AccountIcon(props: IconProps) {
-  return (
-    <Icon {...props}>
-      <title>Accounts</title>
-      <circle cx="20" cy="10.5" r="4.5" strokeWidth="2" />
-      <path
-        d="M20 19C13.4375 19 9.5 20.2857 9.5 28H30.5C30.5 20.2857 26.5625 19 20 19Z"
-        strokeWidth="2"
-      />
-    </Icon>
-  );
-}
-
 export function IconMenu(props: IconProps) {
   return (
     <Icon {...props} stroke={props.stroke || 'currentColor'}>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Remove the icon component **AccountIcon** as it is not used in the demo store. It appears that it was replaced with the icon component **IconAccount**.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
