### PR TITLE
[CartProviderV2] Cart actions on entry and on complete callbacks

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -21,6 +21,22 @@ import {CART_ID_STORAGE_KEY} from './constants.js';
 export function CartProviderV2({
   children,
   numCartLines,
+  onCreate,
+  onLineAdd,
+  onLineRemove,
+  onLineUpdate,
+  onNoteUpdate,
+  onBuyerIdentityUpdate,
+  onAttributesUpdate,
+  onDiscountCodesUpdate,
+  onCreateComplete,
+  onLineAddComplete,
+  onLineRemoveComplete,
+  onLineUpdateComplete,
+  onNoteUpdateComplete,
+  onBuyerIdentityUpdateComplete,
+  onAttributesUpdateComplete,
+  onDiscountCodesUpdateComplete,
   data: cart,
   cartFragment,
 }: {
@@ -28,6 +44,38 @@ export function CartProviderV2({
   children: React.ReactNode;
   /**  Maximum number of cart lines to fetch. Defaults to 250 cart lines. */
   numCartLines?: number;
+  /** A callback that is invoked when the process to create a cart begins, but before the cart is created in the Storefront API. */
+  onCreate?: () => void;
+  /** A callback that is invoked when the process to add a line item to the cart begins, but before the line item is added to the Storefront API. */
+  onLineAdd?: () => void;
+  /** A callback that is invoked when the process to remove a line item to the cart begins, but before the line item is removed from the Storefront API. */
+  onLineRemove?: () => void;
+  /** A callback that is invoked when the process to update a line item in the cart begins, but before the line item is updated in the Storefront API. */
+  onLineUpdate?: () => void;
+  /** A callback that is invoked when the process to add or update a note in the cart begins, but before the note is added or updated in the Storefront API. */
+  onNoteUpdate?: () => void;
+  /** A callback that is invoked when the process to update the buyer identity begins, but before the buyer identity is updated in the Storefront API. */
+  onBuyerIdentityUpdate?: () => void;
+  /** A callback that is invoked when the process to update the cart attributes begins, but before the attributes are updated in the Storefront API. */
+  onAttributesUpdate?: () => void;
+  /** A callback that is invoked when the process to update the cart discount codes begins, but before the discount codes are updated in the Storefront API. */
+  onDiscountCodesUpdate?: () => void;
+  /** A callback that is invoked when the process to create a cart completes */
+  onCreateComplete?: () => void;
+  /** A callback that is invoked when the process to add a line item to the cart completes */
+  onLineAddComplete?: () => void;
+  /** A callback that is invoked when the process to remove a line item to the cart completes */
+  onLineRemoveComplete?: () => void;
+  /** A callback that is invoked when the process to update a line item in the cart completes */
+  onLineUpdateComplete?: () => void;
+  /** A callback that is invoked when the process to add or update a note in the cart completes */
+  onNoteUpdateComplete?: () => void;
+  /** A callback that is invoked when the process to update the buyer identity completes */
+  onBuyerIdentityUpdateComplete?: () => void;
+  /** A callback that is invoked when the process to update the cart attributes completes */
+  onAttributesUpdateComplete?: () => void;
+  /** A callback that is invoked when the process to update the cart discount codes completes */
+  onDiscountCodesUpdateComplete?: () => void;
   /** An object with fields that correspond to the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart). */
   data?: CartFragmentFragment;
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
@@ -41,6 +89,49 @@ export function CartProviderV2({
   const [cartState, cartSend] = useCartAPIStateMachine({
     numCartLines,
     cartFragment,
+    onCartActionEntry(context, event) {
+      switch (event.type) {
+        case 'CART_CREATE':
+          return onCreate?.();
+        case 'CARTLINE_ADD':
+          return onLineAdd?.();
+        case 'CARTLINE_REMOVE':
+          return onLineRemove?.();
+        case 'CARTLINE_UPDATE':
+          return onLineUpdate?.();
+        case 'NOTE_UPDATE':
+          return onNoteUpdate?.();
+        case 'BUYER_IDENTITY_UPDATE':
+          return onBuyerIdentityUpdate?.();
+        case 'CART_ATTRIBUTES_UPDATE':
+          return onAttributesUpdate?.();
+        case 'DISCOUNT_CODES_UPDATE':
+          return onDiscountCodesUpdate?.();
+      }
+    },
+    onCartActionComplete(context, event) {
+      switch (event.type) {
+        case 'RESOLVE':
+          switch (event.payload.cartActionEvent.type) {
+            case 'CART_CREATE':
+              return onCreateComplete?.();
+            case 'CARTLINE_ADD':
+              return onLineAddComplete?.();
+            case 'CARTLINE_REMOVE':
+              return onLineRemoveComplete?.();
+            case 'CARTLINE_UPDATE':
+              return onLineUpdateComplete?.();
+            case 'NOTE_UPDATE':
+              return onNoteUpdateComplete?.();
+            case 'BUYER_IDENTITY_UPDATE':
+              return onBuyerIdentityUpdateComplete?.();
+            case 'CART_ATTRIBUTES_UPDATE':
+              return onAttributesUpdateComplete?.();
+            case 'DISCOUNT_CODES_UPDATE':
+              return onDiscountCodesUpdateComplete?.();
+          }
+      }
+    },
   });
 
   const [cartReady, setCartReady] = useState(false);
@@ -101,7 +192,7 @@ export function CartProviderV2({
   const cartContextValue = useMemo<CartWithActions>(() => {
     return {
       ...(cartState?.context?.cart ?? {lines: [], attributes: []}),
-      status: tempTransposeStatus(cartState.value),
+      status: transposeStatus(cartState.value),
       error: cartState?.context?.errors,
       totalQuantity: cartState?.context?.cart?.totalQuantity ?? 0,
       cartCreate(cartInput: CartInput) {
@@ -181,7 +272,7 @@ export function CartProviderV2({
   );
 }
 
-function tempTransposeStatus(
+function transposeStatus(
   status: CartMachineTypeState['value']
 ): CartWithActions['status'] {
   switch (status) {

--- a/packages/hydrogen/src/components/CartProvider/hooks.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/hooks.client.tsx
@@ -63,7 +63,7 @@ export function useCartFetch() {
         .catch((error) => {
           return {
             data: undefined,
-            error: error.toString(),
+            errors: error.toString(),
           };
         });
     },

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -7,6 +7,7 @@ import {
   MutationCartAttributesUpdateArgs,
 } from '../../storefront-api-types.js';
 import {CartFragmentFragment} from './graphql/CartFragment.js';
+import {StateMachine} from '@xstate/fsm';
 
 export type Status = State['status'];
 
@@ -226,3 +227,22 @@ export type CartMachineTypeState =
   | {value: 'buyerIdentityUpdating'; context: CartMachineContext}
   | {value: 'cartAttributesUpdating'; context: CartMachineContext}
   | {value: 'discountCodesUpdating'; context: CartMachineContext};
+
+export type CartMachineAction = StateMachine.ActionFunction<
+  CartMachineContext,
+  CartMachineEvent
+>;
+
+export type CartMachineActions = {
+  cartFetchAction: CartMachineAction;
+  cartCreateAction: CartMachineAction;
+  cartLineRemoveAction: CartMachineAction;
+  cartLineUpdateAction: CartMachineAction;
+  cartLineAddAction: CartMachineAction;
+  noteUpdateAction: CartMachineAction;
+  buyerIdentityUpdateAction: CartMachineAction;
+  cartAttributesUpdateAction: CartMachineAction;
+  discountCodesUpdateAction: CartMachineAction;
+  onCartActionEntry?: CartMachineAction;
+  onCartActionComplete?: CartMachineAction;
+};

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -155,7 +155,7 @@ export type DiscountCodesUpdateEvent = {
   };
 };
 
-export type CartMachineEvent =
+export type CartMachineActionEvent =
   | CartFetchEvent
   | CartCreateEvent
   | CartLineAddEvent
@@ -164,10 +164,22 @@ export type CartMachineEvent =
   | NoteUpdateEvent
   | BuyerIdentityUpdateEvent
   | CartAttributesUpdateEvent
-  | DiscountCodesUpdateEvent
-  | {type: 'CART_COMPLETED'}
-  | {type: 'RESOLVE'; payload: {cart: Cart}}
-  | {type: 'ERROR'; payload: {errors: any}};
+  | DiscountCodesUpdateEvent;
+
+export type CartMachineFetchResultEvent =
+  | {type: 'CART_COMPLETED'; payload: {cartActionEvent: CartMachineActionEvent}}
+  | {
+      type: 'RESOLVE';
+      payload: {cartActionEvent: CartMachineActionEvent; cart: Cart};
+    }
+  | {
+      type: 'ERROR';
+      payload: {cartActionEvent: CartMachineActionEvent; errors: any};
+    };
+
+export type CartMachineEvent =
+  | CartMachineActionEvent
+  | CartMachineFetchResultEvent;
 
 export type CartMachineTypeState =
   | {

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -3,20 +3,28 @@ import {createMachine, assign, StateMachine} from '@xstate/fsm';
 import {CartFragmentFragment} from './graphql/CartFragment.js';
 import {
   Cart,
+  CartMachineActionEvent,
   CartMachineContext,
   CartMachineEvent,
+  CartMachineFetchResultEvent,
   CartMachineTypeState,
 } from './types.js';
 import {flattenConnection} from '../../utilities/flattenConnection/index.js';
 import {useCartActions} from './CartActions.client.js';
 import {useMemo} from 'react';
+import {InitEvent} from '@xstate/fsm/lib/types.js';
 
 function invokeCart(
-  actions: [string],
-  options?: {resolveTarget?: string; errorTarget?: string}
+  action: string,
+  options?: {
+    entryActions?: [string];
+    resolveTarget?: string;
+    errorTarget?: string;
+    exitActions?: [string];
+  }
 ): StateMachine.Config<CartMachineContext, CartMachineEvent>['states']['on'] {
   return {
-    entry: actions,
+    entry: [...(options?.entryActions || []), 'onCartActionEntry', action],
     on: {
       RESOLVE: {
         target: options?.resolveTarget || 'idle',
@@ -41,6 +49,7 @@ function invokeCart(
         }),
       },
     },
+    exit: ['onCartActionComplete', ...(options?.exitActions || [])],
   };
 }
 
@@ -103,29 +112,43 @@ const cartMachine = createMachine<
     error: {
       on: UPDATING_CART_EVENTS,
     },
-    cartFetching: invokeCart(['cartFetchAction'], {
+    cartFetching: invokeCart('cartFetchAction', {
+      errorTarget: 'initializationError',
+      entryActions: ['onFetch'],
+      exitActions: ['onFetchComplete'],
+    }),
+    cartCreating: invokeCart('cartCreateAction', {
       errorTarget: 'initializationError',
     }),
-    cartCreating: invokeCart(['cartCreateAction'], {
-      errorTarget: 'initializationError',
-    }),
-    cartLineRemoving: invokeCart(['cartLineRemoveAction']),
-    cartLineUpdating: invokeCart(['cartLineUpdateAction']),
-    cartLineAdding: invokeCart(['cartLineAddAction']),
-    noteUpdating: invokeCart(['noteUpdateAction']),
-    buyerIdentityUpdating: invokeCart(['buyerIdentityUpdateAction']),
-    cartAttributesUpdating: invokeCart(['cartAttributesUpdateAction']),
-    discountCodesUpdating: invokeCart(['discountCodesUpdateAction']),
+    cartLineRemoving: invokeCart('cartLineRemoveAction'),
+    cartLineUpdating: invokeCart('cartLineUpdateAction'),
+    cartLineAdding: invokeCart('cartLineAddAction'),
+    noteUpdating: invokeCart('noteUpdateAction'),
+    buyerIdentityUpdating: invokeCart('buyerIdentityUpdateAction'),
+    cartAttributesUpdating: invokeCart('cartAttributesUpdateAction'),
+    discountCodesUpdating: invokeCart('discountCodesUpdateAction'),
   },
 });
 
 export function useCartAPIStateMachine({
   numCartLines,
+  onCartActionEntry,
+  onCartActionComplete,
   data: cart,
   cartFragment,
 }: {
   /**  Maximum number of cart lines to fetch. Defaults to 250 cart lines. */
   numCartLines?: number;
+  /** A callback that is invoked just before a Cart API action executes. */
+  onCartActionEntry?: (
+    context: CartMachineContext,
+    event: CartMachineActionEvent
+  ) => void;
+  /** A callback that is invoked after a Cart API completes. */
+  onCartActionComplete?: (
+    context: CartMachineContext,
+    event: CartMachineFetchResultEvent
+  ) => void;
   /** An object with fields that correspond to the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart). */
   data?: CartFragmentFragment;
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
@@ -148,185 +171,147 @@ export function useCartAPIStateMachine({
 
   const [state, send, service] = useMachine(cartMachine, {
     actions: {
-      cartFetchAction: (_, event) => {
+      cartFetchAction: async (_, event): Promise<void> => {
         if (event.type !== 'CART_FETCH') return;
-        cartFetch(event?.payload?.cartId).then((res) => {
-          if (res?.errors) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
 
-          if (!res?.data?.cart) {
-            return send({
-              type: 'CART_COMPLETED',
-            });
-          }
-
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data.cart)},
-          });
-        });
+        const {data, errors} = await cartFetch(event?.payload?.cartId);
+        const resultEvent = eventFromFetchResult(event, data?.cart, errors);
+        send(resultEvent);
       },
-      cartCreateAction: (_, event) => {
+      cartCreateAction: async (_, event): Promise<void> => {
         if (event.type !== 'CART_CREATE' && event.type !== 'CARTLINE_ADD')
           return;
 
-        cartCreate(event?.payload).then((res) => {
-          if (res?.errors || !res.data?.cartCreate?.cart) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
-
-          if (!res?.data?.cartCreate.cart) {
-            return send({
-              type: 'CART_COMPLETED',
-            });
-          }
-
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartCreate.cart)},
-          });
-        });
+        const {data, errors} = await cartCreate(event?.payload);
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartCreate?.cart,
+          errors
+        );
+        send(resultEvent);
       },
-      cartLineAddAction: (context, event) => {
+      cartLineAddAction: async (context, event): Promise<void> => {
         if (event.type !== 'CARTLINE_ADD' || !context?.cart?.id) return;
 
-        cartLineAdd(context.cart.id, event.payload.lines).then((res) => {
-          if (res?.errors) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
+        const {data, errors} = await cartLineAdd(
+          context.cart.id,
+          event.payload.lines
+        );
 
-          if (!res.data?.cartLinesAdd?.cart) {
-            return send({
-              type: 'CART_COMPLETED',
-            });
-          }
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartLinesAdd?.cart,
+          errors
+        );
 
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartLinesAdd.cart)},
-          });
-        });
+        send(resultEvent);
       },
-      cartLineUpdateAction: (context, event) => {
+      cartLineUpdateAction: async (context, event): Promise<void> => {
         if (event.type !== 'CARTLINE_UPDATE' || !context?.cart?.id) return;
-        cartLineUpdate(context.cart.id, event.payload.lines).then((res) => {
-          if (res?.errors) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
+        const {data, errors} = await cartLineUpdate(
+          context.cart.id,
+          event.payload.lines
+        );
 
-          if (!res.data?.cartLinesUpdate?.cart) {
-            return send({
-              type: 'CART_COMPLETED',
-            });
-          }
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartLinesUpdate?.cart,
+          errors
+        );
 
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartLinesUpdate.cart)},
-          });
-        });
+        send(resultEvent);
       },
-      cartLineRemoveAction: (context, event) => {
+      cartLineRemoveAction: async (context, event): Promise<void> => {
         if (event.type !== 'CARTLINE_REMOVE' || !context?.cart?.id) return;
-        cartLineRemove(context.cart.id, event.payload.lines).then((res) => {
-          if (res?.errors) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
+        const {data, errors} = await cartLineRemove(
+          context.cart.id,
+          event.payload.lines
+        );
 
-          if (!res.data?.cartLinesRemove?.cart) {
-            return send('CART_COMPLETED');
-          }
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartLinesRemove?.cart,
+          errors
+        );
 
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartLinesRemove.cart)},
-          });
-        });
+        send(resultEvent);
       },
-      noteUpdateAction: (context, event) => {
+      noteUpdateAction: async (context, event): Promise<void> => {
         if (event.type !== 'NOTE_UPDATE' || !context?.cart?.id) return;
-        noteUpdate(context.cart.id, event.payload.note).then((res) => {
-          if (res?.errors) {
-            return send({type: 'ERROR', payload: {errors: res?.errors}});
-          }
+        const {data, errors} = await noteUpdate(
+          context.cart.id,
+          event.payload.note
+        );
 
-          if (!res.data?.cartNoteUpdate?.cart) {
-            return send('CART_COMPLETED');
-          }
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartNoteUpdate?.cart,
+          errors
+        );
 
-          send({
-            type: 'RESOLVE',
-            payload: {cart: cartFromGraphQL(res.data?.cartNoteUpdate.cart)},
-          });
-        });
+        send(resultEvent);
       },
-      buyerIdentityUpdateAction: (context, event) => {
+      buyerIdentityUpdateAction: async (context, event): Promise<void> => {
         if (event.type !== 'BUYER_IDENTITY_UPDATE' || !context?.cart?.id)
           return;
-        buyerIdentityUpdate(context.cart.id, event.payload.buyerIdentity).then(
-          (res) => {
-            if (res?.errors) {
-              return send({type: 'ERROR', payload: {errors: res?.errors}});
-            }
-
-            if (!res.data?.cartBuyerIdentityUpdate?.cart) {
-              return send('CART_COMPLETED');
-            }
-
-            send({
-              type: 'RESOLVE',
-              payload: {
-                cart: cartFromGraphQL(res.data?.cartBuyerIdentityUpdate.cart),
-              },
-            });
-          }
+        const {data, errors} = await buyerIdentityUpdate(
+          context.cart.id,
+          event.payload.buyerIdentity
         );
+
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartBuyerIdentityUpdate?.cart,
+          errors
+        );
+
+        send(resultEvent);
       },
-      cartAttributesUpdateAction: (context, event) => {
+      cartAttributesUpdateAction: async (context, event): Promise<void> => {
         if (event.type !== 'CART_ATTRIBUTES_UPDATE' || !context?.cart?.id)
           return;
-        cartAttributesUpdate(context.cart.id, event.payload.attributes).then(
-          (res) => {
-            if (res?.errors) {
-              return send({type: 'ERROR', payload: {errors: res?.errors}});
-            }
-
-            if (!res.data?.cartAttributesUpdate?.cart) {
-              return send('CART_COMPLETED');
-            }
-
-            send({
-              type: 'RESOLVE',
-              payload: {
-                cart: cartFromGraphQL(res.data?.cartAttributesUpdate.cart),
-              },
-            });
-          }
+        const {data, errors} = await cartAttributesUpdate(
+          context.cart.id,
+          event.payload.attributes
         );
+
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartAttributesUpdate?.cart,
+          errors
+        );
+
+        send(resultEvent);
       },
-      discountCodesUpdateAction: (context, event) => {
+      discountCodesUpdateAction: async (context, event): Promise<void> => {
         if (event.type !== 'DISCOUNT_CODES_UPDATE' || !context?.cart?.id)
           return;
-        discountCodesUpdate(context.cart.id, event.payload.discountCodes).then(
-          (res) => {
-            if (res?.errors) {
-              return send({type: 'ERROR', payload: {errors: res?.errors}});
-            }
-
-            if (!res.data?.cartDiscountCodesUpdate?.cart) {
-              return send('CART_COMPLETED');
-            }
-
-            send({
-              type: 'RESOLVE',
-              payload: {
-                cart: cartFromGraphQL(res.data?.cartDiscountCodesUpdate.cart),
-              },
-            });
-          }
+        const {data, errors} = await discountCodesUpdate(
+          context.cart.id,
+          event.payload.discountCodes
         );
+        const resultEvent = eventFromFetchResult(
+          event,
+          data?.cartDiscountCodesUpdate?.cart,
+          errors
+        );
+
+        send(resultEvent);
       },
+      ...(onCartActionEntry && {
+        onCartActionEntry: (context, event) => {
+          if (isCartActionEvent(event)) {
+            onCartActionEntry(context, event);
+          }
+        },
+      }),
+      ...(onCartActionComplete && {
+        onCartActionComplete: (context, event) => {
+          if (isCartFetchResultEvent(event)) {
+            onCartActionComplete(context, event);
+          }
+        },
+      }),
     },
   });
 
@@ -340,4 +325,53 @@ export function cartFromGraphQL(cart: CartFragmentFragment): Cart {
     lines: flattenConnection(cart.lines),
     note: cart.note ?? undefined,
   };
+}
+
+function eventFromFetchResult(
+  cartActionEvent: CartMachineActionEvent,
+  cart?: CartFragmentFragment | null,
+  errors?: any
+): CartMachineFetchResultEvent {
+  if (errors) {
+    return {type: 'ERROR', payload: {errors, cartActionEvent}};
+  }
+
+  if (!cart) {
+    return {
+      type: 'CART_COMPLETED',
+      payload: {
+        cartActionEvent,
+      },
+    };
+  }
+
+  return {
+    type: 'RESOLVE',
+    payload: {cart: cartFromGraphQL(cart), cartActionEvent},
+  };
+}
+
+function isCartActionEvent(
+  event: CartMachineEvent | InitEvent
+): event is CartMachineActionEvent {
+  return (
+    event.type === 'CART_CREATE' ||
+    event.type === 'CARTLINE_ADD' ||
+    event.type === 'CARTLINE_UPDATE' ||
+    event.type === 'CARTLINE_REMOVE' ||
+    event.type === 'NOTE_UPDATE' ||
+    event.type === 'BUYER_IDENTITY_UPDATE' ||
+    event.type === 'CART_ATTRIBUTES_UPDATE' ||
+    event.type === 'DISCOUNT_CODES_UPDATE'
+  );
+}
+
+function isCartFetchResultEvent(
+  event: CartMachineEvent | InitEvent
+): event is CartMachineFetchResultEvent {
+  return (
+    event.type === 'RESOLVE' ||
+    event.type === 'ERROR' ||
+    event.type === 'CART_COMPLETED'
+  );
 }


### PR DESCRIPTION
### Description

Adds on entry callbacks `onCreate`, `onLineAdd`, etc. same as our original `CartProvider`
Additionally I created on complete callbacks `onCreateComplete`, `onLineAddComplete`, etc. that execute after the cart action has finished either successfully or with errors

**Bug fix**
Also contains a bug fix were `useCartFetch` was not returning errors

**Not in scope of this PR:**
Still not proposing specific arguments for the entry and complete callbacks. This PR seeks feature parity but opens the possibility for adding these args in a future PR

**Tophatting**
https://github.com/Shopify/hydrogen/pull/new/feat/cart-provider-v2-callbacks-tophat
