### PR TITLE
Remove the browser field in package exports

### DIFF
--- a/.changeset/neat-months-sparkle.md
+++ b/.changeset/neat-months-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-ui-alpha': patch
+---
+
+Fix package exports and remove the `browser` field.

--- a/packages/hydrogen-ui/package.json
+++ b/packages/hydrogen-ui/package.json
@@ -14,11 +14,6 @@
   "type": "module",
   "exports": {
     ".": {
-      "browser": {
-        "development": "./dist/umd/hydrogen-ui.dev.js",
-        "production": "./dist/umd/hydrogen-ui.prod.js",
-        "default": "./dist/umd/hydrogen-ui.prod.js"
-      },
       "module": {
         "types": "./dist/types/index.d.ts",
         "development": "./dist/dev/index.js",
@@ -45,8 +40,9 @@
   },
   "main": "./dist/prod/index.cjs",
   "module": "./dist/prod/index.js",
-  "browser": "./dist/umd/hydrogen-ui.prod.js",
   "types": "./dist/types/index.d.ts",
+  "unpkg": "./dist/umd/hydrogen-ui.prod.js",
+  "jsdelivr": "./dist/umd/hydrogen-ui.prod.js",
   "typesVersions": {
     "*": {
       "/index.js": [


### PR DESCRIPTION
As this field is prioritized by webpack 4/5 and is used to create the bundles, we actually don't want to specify it and let webpack resolve to the "module" condition. See https://github.com/frehner/modern-guide-to-packaging-js-library#consider-setting-the-browser-field for more details.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
