### PR TITLE
[CartProviderV2] Add cart analytics to CartProviderV2

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -356,7 +356,7 @@ function publishCreateAnalytics(
 ) {
   ClientAnalytics.publish(ClientAnalytics.eventNames.ADD_TO_CART, true, {
     addedCartLines: event.payload.lines,
-    cart: context.cart,
+    cart: context.rawCartResult,
     prevCart: null,
   });
 }
@@ -367,7 +367,7 @@ function publishLineAddAnalytics(
 ) {
   ClientAnalytics.publish(ClientAnalytics.eventNames.ADD_TO_CART, true, {
     addedCartLines: event.payload.lines,
-    cart: context.cart,
+    cart: context.rawCartResult,
     prevCart: context.prevCart,
   });
 }
@@ -379,7 +379,7 @@ function publishLineUpdateAnalytics(
   ClientAnalytics.publish(ClientAnalytics.eventNames.UPDATE_CART, true, {
     updatedCartLines: event.payload.lines,
     oldCart: context.prevCart,
-    cart: context.cart,
+    cart: context.rawCartResult,
     prevCart: context.prevCart,
   });
 }
@@ -390,7 +390,7 @@ function publishLineRemoveAnalytics(
 ) {
   ClientAnalytics.publish(ClientAnalytics.eventNames.REMOVE_FROM_CART, true, {
     removedCartLines: event.payload.lines,
-    cart: context.cart,
+    cart: context.rawCartResult,
     prevCart: context.prevCart,
   });
 }
@@ -404,7 +404,7 @@ function publishDiscountCodesUpdateAnalytics(
     true,
     {
       updatedDiscountCodes: event.payload.discountCodes,
-      cart: context.cart,
+      cart: context.rawCartResult,
       prevCart: context.prevCart,
     }
   );

--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -121,16 +121,22 @@ export function CartProviderV2({
         case 'RESOLVE':
           switch (event.payload.cartActionEvent.type) {
             case 'CART_CREATE':
-              onCreateAnalytics(context, event.payload.cartActionEvent);
+              publishCreateAnalytics(context, event.payload.cartActionEvent);
               return onCreateComplete?.();
             case 'CARTLINE_ADD':
-              onLineAddAnalytics(context, event.payload.cartActionEvent);
+              publishLineAddAnalytics(context, event.payload.cartActionEvent);
               return onLineAddComplete?.();
             case 'CARTLINE_REMOVE':
-              onLineRemoveAnalytics(context, event.payload.cartActionEvent);
+              publishLineRemoveAnalytics(
+                context,
+                event.payload.cartActionEvent
+              );
               return onLineRemoveComplete?.();
             case 'CARTLINE_UPDATE':
-              onLineUpdateAnalytics(context, event.payload.cartActionEvent);
+              publishLineUpdateAnalytics(
+                context,
+                event.payload.cartActionEvent
+              );
               return onLineUpdateComplete?.();
             case 'NOTE_UPDATE':
               return onNoteUpdateComplete?.();
@@ -139,7 +145,7 @@ export function CartProviderV2({
             case 'CART_ATTRIBUTES_UPDATE':
               return onAttributesUpdateComplete?.();
             case 'DISCOUNT_CODES_UPDATE':
-              onDiscountCodesUpdateAnalytics(
+              publishDiscountCodesUpdateAnalytics(
                 context,
                 event.payload.cartActionEvent
               );
@@ -344,7 +350,7 @@ function storageAvailable(type: 'localStorage' | 'sessionStorage') {
 }
 
 // Cart Analytics
-function onCreateAnalytics(
+function publishCreateAnalytics(
   context: CartMachineContext,
   event: CartCreateEvent
 ) {
@@ -355,7 +361,7 @@ function onCreateAnalytics(
   });
 }
 
-function onLineAddAnalytics(
+function publishLineAddAnalytics(
   context: CartMachineContext,
   event: CartLineAddEvent
 ) {
@@ -366,7 +372,7 @@ function onLineAddAnalytics(
   });
 }
 
-function onLineUpdateAnalytics(
+function publishLineUpdateAnalytics(
   context: CartMachineContext,
   event: CartLineUpdateEvent
 ) {
@@ -378,7 +384,7 @@ function onLineUpdateAnalytics(
   });
 }
 
-function onLineRemoveAnalytics(
+function publishLineRemoveAnalytics(
   context: CartMachineContext,
   event: CartLineRemoveEvent
 ) {
@@ -389,7 +395,7 @@ function onLineRemoveAnalytics(
   });
 }
 
-function onDiscountCodesUpdateAnalytics(
+function publishDiscountCodesUpdateAnalytics(
   context: CartMachineContext,
   event: DiscountCodesUpdateEvent
 ) {

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -221,7 +221,7 @@ describe('<CartProviderV2 />', () => {
         true,
         {
           addedCartLines: cartInput.lines,
-          cart: cartFromGraphQL(CART_WITH_LINES),
+          cart: CART_WITH_LINES,
           prevCart: null,
         }
       );
@@ -475,7 +475,7 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             addedCartLines: cartLinesInput,
-            cart: cartFromGraphQL(CART_WITH_LINES),
+            cart: CART_WITH_LINES,
             prevCart: cartFromGraphQL(CART),
           }
         );
@@ -601,7 +601,7 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             updatedCartLines: cartLinesInput,
-            cart: cartFromGraphQL(CART_WITH_LINES),
+            cart: CART_WITH_LINES,
             prevCart: cartFromGraphQL(CART),
             oldCart: cartFromGraphQL(CART),
           }
@@ -717,7 +717,7 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             removedCartLines: cartLineIds,
-            cart: cartFromGraphQL(CART),
+            cart: CART,
             prevCart: cartFromGraphQL(CART_WITH_LINES),
           }
         );
@@ -1065,7 +1065,7 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             updatedDiscountCodes: discountCodes,
-            cart: cartFromGraphQL(cartWithDiscountCode),
+            cart: cartWithDiscountCode,
             prevCart: cartFromGraphQL(CART),
           }
         );

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -92,6 +92,7 @@ export type CartAction =
 // State Machine types
 export type CartMachineContext = {
   cart?: Cart;
+  prevCart?: Cart;
   errors?: any;
 };
 
@@ -187,6 +188,7 @@ export type CartMachineTypeState =
       value: 'uninitialized';
       context: CartMachineContext & {
         cart: undefined;
+        prevCart: undefined;
         errors?: any;
       };
     }
@@ -194,6 +196,7 @@ export type CartMachineTypeState =
       value: 'initializationError';
       context: CartMachineContext & {
         cart: undefined;
+        prevCart: undefined;
         errors: any;
       };
     }
@@ -201,6 +204,7 @@ export type CartMachineTypeState =
       value: 'cartCompleted';
       context: CartMachineContext & {
         cart: undefined;
+        prevCart?: Cart;
         errors: any;
       };
     }
@@ -208,6 +212,7 @@ export type CartMachineTypeState =
       value: 'idle';
       context: CartMachineContext & {
         cart: Cart;
+        prevCart?: Cart;
         errors?: any;
       };
     }
@@ -215,6 +220,7 @@ export type CartMachineTypeState =
       value: 'error';
       context: CartMachineContext & {
         cart?: Cart;
+        prevCart?: Cart;
         errors: any;
       };
     }

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -83,7 +83,7 @@ export type CartAction =
   | {type: 'buyerIdentityUpdate'}
   | {type: 'cartAttributesUpdate'}
   | {type: 'discountCodesUpdate'}
-  | {type: 'resolve'; cart: Cart}
+  | {type: 'resolve'; cart: Cart; rawCartResult?: CartFragmentFragment}
   | {type: 'reject'; errors: any}
   | {type: 'resetCart'};
 
@@ -92,6 +92,7 @@ export type CartAction =
 // State Machine types
 export type CartMachineContext = {
   cart?: Cart;
+  rawCartResult?: CartFragmentFragment;
   prevCart?: Cart;
   errors?: any;
 };
@@ -172,7 +173,11 @@ export type CartMachineFetchResultEvent =
   | {type: 'CART_COMPLETED'; payload: {cartActionEvent: CartMachineActionEvent}}
   | {
       type: 'RESOLVE';
-      payload: {cartActionEvent: CartMachineActionEvent; cart: Cart};
+      payload: {
+        cartActionEvent: CartMachineActionEvent;
+        cart: Cart;
+        rawCartResult: CartFragmentFragment;
+      };
     }
   | {
       type: 'ERROR';

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -33,6 +33,7 @@ function invokeCart(
           assign({
             prevCart: (context) => context?.cart,
             cart: (_, event) => event?.payload?.cart,
+            rawCartResult: (_, event) => event?.payload?.rawCartResult,
             errors: (_) => undefined,
           }),
         ],
@@ -357,7 +358,11 @@ function eventFromFetchResult(
 
   return {
     type: 'RESOLVE',
-    payload: {cart: cartFromGraphQL(cart), cartActionEvent},
+    payload: {
+      cart: cartFromGraphQL(cart),
+      rawCartResult: cart,
+      cartActionEvent,
+    },
   };
 }
 

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -31,22 +31,25 @@ function invokeCart(
         target: options?.resolveTarget || 'idle',
         actions: [
           assign({
+            prevCart: (context) => context?.cart,
             cart: (_, event) => event?.payload?.cart,
-            errors: (_, event) => undefined,
+            errors: (_) => undefined,
           }),
         ],
       },
       ERROR: {
         target: options?.errorTarget || 'error',
         actions: assign({
+          prevCart: (context) => context?.cart,
           errors: (_, event) => event?.payload?.errors,
         }),
       },
       CART_COMPLETED: {
         target: 'cartCompleted',
         actions: assign({
-          cart: (_, event) => undefined,
-          errors: (_, event) => undefined,
+          prevCart: (_) => undefined,
+          cart: (_) => undefined,
+          errors: (_) => undefined,
         }),
       },
     },


### PR DESCRIPTION
Part of: #1947

### Description
Imported directly from `CartProvider`. Tests added.

### Additional context
I added the `prevCart` to the state management context to be able to access it when sending analytics.

### Feedback on Analytics:
1. Cart analytics in `CartProvider` is sending directly the `CartFragmentFragment` response. I would prefer to send our flattened `Cart` instead. Would this break analytics for users? This would avoid adding the preprocessed version of the Cart to our context. 
2. I also found some analytics events with `cart` as `CartFragmentFragment` and `prevCart` as our own `Cart`. Not sure if this is a bug. 

Left comments.

### Tophatting
https://github.com/Shopify/hydrogen/pull/new/feat/cart-provider-v2-analytics-tophat

