### PR TITLE
Change brand @type to Brand in ProductSeo

### DIFF
--- a/.changeset/silly-buckets-cover.md
+++ b/.changeset/silly-buckets-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Correct brand type in product seo

--- a/packages/hydrogen/src/components/Seo/ProductSeo.client.tsx
+++ b/packages/hydrogen/src/components/Seo/ProductSeo.client.tsx
@@ -31,7 +31,7 @@ export function ProductSeo({
     name: title,
     description,
     brand: {
-      '@type': 'Thing',
+      '@type': 'Brand',
       name: vendor,
     },
     url,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `@type` field on the ProductSeo `brand` field is incorrect. It should be `Brand` instead of Thing.
**Motivation:**
<img width="651" alt="Screen Shot 2022-09-13 at 7 05 39 PM" src="https://user-images.githubusercontent.com/5790877/190024529-342b98db-3087-492d-8230-ac65c066a6a2.png">


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
