### PR TITLE
Fix inconsistent template .gitignore/_gitignore files

### DIFF
--- a/scripts/compile-template-for-dist.mjs
+++ b/scripts/compile-template-for-dist.mjs
@@ -15,8 +15,9 @@ import fs from 'fs-extra';
 function copyDir(srcDir, destDir) {
   fs.mkdirSync(destDir, {recursive: true});
   for (const file of fs.readdirSync(srcDir)) {
+    const newFile = file.startsWith('_') ? '.' + file.substring(1) : file;
     const srcFile = resolve(srcDir, file);
-    const destFile = resolve(destDir, file);
+    const destFile = resolve(destDir, newFile);
     copy(srcFile, destFile);
   }
 }

--- a/scripts/compile-template-for-dist.mjs
+++ b/scripts/compile-template-for-dist.mjs
@@ -15,7 +15,7 @@ import fs from 'fs-extra';
 function copyDir(srcDir, destDir) {
   fs.mkdirSync(destDir, {recursive: true});
   for (const file of fs.readdirSync(srcDir)) {
-    const newFile = file.startsWith('_') ? '.' + file.substring(1) : file;
+    const newFile = file.startsWith('_') ? `.${file.substring(1)}` : file;
     const srcFile = resolve(srcDir, file);
     const destFile = resolve(destDir, newFile);
     copy(srcFile, destFile);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds a step to rename the `_gitignore` files in JS templates before pushing them to the `dist` folder. This should resolve cases where these were '_gitignore' files were ending up in the final compiled templates.

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
