### PR TITLE
[CartProviderV2] Handle `countryCode` and `customerAccessTokens` props

### DIFF
--- a/packages/hydrogen/src/components/CartLineProvider/tests/fixtures.ts
+++ b/packages/hydrogen/src/components/CartLineProvider/tests/fixtures.ts
@@ -1,4 +1,5 @@
 import {CurrencyCode} from '../../../storefront-api-types.js';
+import {CartFragmentFragment} from '../../CartProvider/graphql/CartFragment.js';
 
 export const CART_LINE = {
   attributes: [{key: 'color', value: 'red'}],
@@ -30,3 +31,9 @@ export const CART_LINE = {
     },
   },
 };
+
+export function getCartLineMock(
+  options?: Partial<CartFragmentFragment['lines']['edges'][0]['node']>
+) {
+  return {...CART_LINE, ...options};
+}

--- a/packages/hydrogen/src/components/CartProvider/CartActions.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartActions.client.tsx
@@ -61,11 +61,14 @@ import {useCartFetch} from './hooks.client.js';
 export function useCartActions({
   numCartLines,
   cartFragment = defaultCartFragment,
+  countryCode = CountryCode.Us,
 }: {
   /**  Maximum number of cart lines to fetch. Defaults to 250 cart lines. */
   numCartLines?: number;
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
   cartFragment?: string;
+  /** The ISO country code for i18n. */
+  countryCode?: CountryCode;
 }) {
   const fetchCart = useCartFetch();
 
@@ -76,11 +79,11 @@ export function useCartActions({
         variables: {
           id: cartId,
           numCartLines,
-          country: CountryCode.Us,
+          country: countryCode,
         },
       });
     },
-    [fetchCart, cartFragment, numCartLines]
+    [fetchCart, cartFragment, numCartLines, countryCode]
   );
 
   const cartCreate = useCallback(
@@ -90,11 +93,11 @@ export function useCartActions({
         variables: {
           input: cart,
           numCartLines,
-          country: CountryCode.Us,
+          country: countryCode,
         },
       });
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   const cartLineAdd = useCallback(
@@ -105,11 +108,11 @@ export function useCartActions({
           cartId,
           lines,
           numCartLines,
-          country: CountryCode.Us,
+          country: countryCode,
         },
       });
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   const cartLineUpdate = useCallback(
@@ -121,12 +124,12 @@ export function useCartActions({
             cartId,
             lines,
             numCartLines,
-            country: CountryCode.Us,
+            country: countryCode,
           },
         }
       );
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   const cartLineRemove = useCallback(
@@ -138,12 +141,12 @@ export function useCartActions({
             cartId,
             lines,
             numCartLines,
-            country: CountryCode.Us,
+            country: countryCode,
           },
         }
       );
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   const noteUpdate = useCallback(
@@ -155,12 +158,12 @@ export function useCartActions({
             cartId,
             note,
             numCartLines,
-            country: CountryCode.Us,
+            country: countryCode,
           },
         }
       );
     },
-    [fetchCart, cartFragment, numCartLines]
+    [fetchCart, cartFragment, numCartLines, countryCode]
   );
 
   const buyerIdentityUpdate = useCallback(
@@ -174,11 +177,11 @@ export function useCartActions({
           cartId,
           buyerIdentity,
           numCartLines,
-          country: CountryCode.Us,
+          country: countryCode,
         },
       });
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   const cartAttributesUpdate = useCallback(
@@ -192,11 +195,11 @@ export function useCartActions({
           cartId,
           attributes,
           numCartLines,
-          country: CountryCode.Us,
+          country: countryCode,
         },
       });
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   const discountCodesUpdate = useCallback(
@@ -213,11 +216,11 @@ export function useCartActions({
           cartId,
           discountCodes,
           numCartLines,
-          country: CountryCode.Us,
+          country: countryCode,
         },
       });
     },
-    [cartFragment, fetchCart, numCartLines]
+    [cartFragment, countryCode, fetchCart, numCartLines]
   );
 
   return useMemo(

--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -97,7 +97,19 @@ export function CartProviderV2({
   countryCode?: CountryCode;
 }) {
   if (countryCode) countryCode = countryCode.toUpperCase() as CountryCode;
+  const [prevCountryCode, setPrevCountryCode] = useState(countryCode);
+  const [prevCustomerAccessToken, setPrevCustomerAccessToken] =
+    useState(customerAccessToken);
   const customerOverridesCountryCode = useRef(false);
+
+  if (
+    prevCountryCode !== countryCode ||
+    prevCustomerAccessToken !== customerAccessToken
+  ) {
+    setPrevCountryCode(countryCode);
+    setPrevCustomerAccessToken(customerAccessToken);
+    customerOverridesCountryCode.current = false;
+  }
 
   const {cartFragment: usedCartFragment} = useCartActions({
     numCartLines,
@@ -165,10 +177,6 @@ export function CartProviderV2({
   const [cartReady, setCartReady] = useState(false);
   const cartCompleted = cartState.matches('cartCompleted');
 
-  useEffect(() => {
-    customerOverridesCountryCode.current = false;
-  }, [countryCode, customerAccessToken]);
-
   const countryChanged =
     (cartState.value === 'idle' ||
       cartState.value === 'error' ||
@@ -186,9 +194,8 @@ export function CartProviderV2({
     countryCode,
     customerAccessToken,
     countryChanged,
-    cartSend,
     customerOverridesCountryCode,
-    cartState?.context?.cart?.buyerIdentity?.countryCode,
+    cartSend,
   ]);
 
   // send cart events when ready

--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {CartFragmentFragment} from './graphql/CartFragment.js';
 import {
   AttributeInput,
@@ -6,9 +6,11 @@ import {
   CartInput,
   CartLineInput,
   CartLineUpdateInput,
+  CountryCode,
 } from '../../storefront-api-types.js';
 import {CartContext} from './context.js';
 import {
+  BuyerIdentityUpdateEvent,
   CartCreateEvent,
   CartLineAddEvent,
   CartLineRemoveEvent,
@@ -46,6 +48,8 @@ export function CartProviderV2({
   onDiscountCodesUpdateComplete,
   data: cart,
   cartFragment,
+  customerAccessToken,
+  countryCode = CountryCode.Us,
 }: {
   /** Any `ReactNode` elements. */
   children: React.ReactNode;
@@ -87,10 +91,18 @@ export function CartProviderV2({
   data?: CartFragmentFragment;
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
   cartFragment?: string;
+  /** A customer access token that's accessible on the server if there's a customer login. */
+  customerAccessToken?: CartBuyerIdentityInput['customerAccessToken'];
+  /** The ISO country code for i18n. */
+  countryCode?: CountryCode;
 }) {
+  if (countryCode) countryCode = countryCode.toUpperCase() as CountryCode;
+  const customerOverridesCountryCode = useRef(false);
+
   const {cartFragment: usedCartFragment} = useCartActions({
     numCartLines,
     cartFragment,
+    countryCode,
   });
 
   const [cartState, cartSend] = useCartAPIStateMachine({
@@ -117,38 +129,33 @@ export function CartProviderV2({
       }
     },
     onCartActionComplete(context, event) {
+      const cartActionEvent = event.payload.cartActionEvent;
       switch (event.type) {
         case 'RESOLVE':
-          switch (event.payload.cartActionEvent.type) {
+          switch (cartActionEvent.type) {
             case 'CART_CREATE':
-              publishCreateAnalytics(context, event.payload.cartActionEvent);
+              publishCreateAnalytics(context, cartActionEvent);
               return onCreateComplete?.();
             case 'CARTLINE_ADD':
-              publishLineAddAnalytics(context, event.payload.cartActionEvent);
+              publishLineAddAnalytics(context, cartActionEvent);
               return onLineAddComplete?.();
             case 'CARTLINE_REMOVE':
-              publishLineRemoveAnalytics(
-                context,
-                event.payload.cartActionEvent
-              );
+              publishLineRemoveAnalytics(context, cartActionEvent);
               return onLineRemoveComplete?.();
             case 'CARTLINE_UPDATE':
-              publishLineUpdateAnalytics(
-                context,
-                event.payload.cartActionEvent
-              );
+              publishLineUpdateAnalytics(context, cartActionEvent);
               return onLineUpdateComplete?.();
             case 'NOTE_UPDATE':
               return onNoteUpdateComplete?.();
             case 'BUYER_IDENTITY_UPDATE':
+              if (countryCodeNotUpdated(context, cartActionEvent)) {
+                customerOverridesCountryCode.current = true;
+              }
               return onBuyerIdentityUpdateComplete?.();
             case 'CART_ATTRIBUTES_UPDATE':
               return onAttributesUpdateComplete?.();
             case 'DISCOUNT_CODES_UPDATE':
-              publishDiscountCodesUpdateAnalytics(
-                context,
-                event.payload.cartActionEvent
-              );
+              publishDiscountCodesUpdateAnalytics(context, cartActionEvent);
               return onDiscountCodesUpdateComplete?.();
           }
       }
@@ -157,6 +164,32 @@ export function CartProviderV2({
 
   const [cartReady, setCartReady] = useState(false);
   const cartCompleted = cartState.matches('cartCompleted');
+
+  useEffect(() => {
+    customerOverridesCountryCode.current = false;
+  }, [countryCode, customerAccessToken]);
+
+  const countryChanged =
+    (cartState.value === 'idle' ||
+      cartState.value === 'error' ||
+      cartState.value === 'cartCompleted') &&
+    countryCode !== cartState?.context?.cart?.buyerIdentity?.countryCode &&
+    !cartState.context.errors;
+
+  useEffect(() => {
+    if (!countryChanged || customerOverridesCountryCode.current) return;
+    cartSend({
+      type: 'BUYER_IDENTITY_UPDATE',
+      payload: {buyerIdentity: {countryCode, customerAccessToken}},
+    });
+  }, [
+    countryCode,
+    customerAccessToken,
+    countryChanged,
+    cartSend,
+    customerOverridesCountryCode,
+    cartState?.context?.cart?.buyerIdentity?.countryCode,
+  ]);
 
   // send cart events when ready
   const onCartReadySend = useCallback(
@@ -210,23 +243,48 @@ export function CartProviderV2({
     }
   }, [cartReady, cartSend]);
 
+  const cartCreate = useCallback(
+    (cartInput: CartInput) => {
+      if (countryCode && !cartInput.buyerIdentity?.countryCode) {
+        if (cartInput.buyerIdentity == null) {
+          cartInput.buyerIdentity = {};
+        }
+        cartInput.buyerIdentity.countryCode = countryCode;
+      }
+
+      if (
+        customerAccessToken &&
+        !cartInput.buyerIdentity?.customerAccessToken
+      ) {
+        if (cartInput.buyerIdentity == null) {
+          cartInput.buyerIdentity = {};
+        }
+        cartInput.buyerIdentity.customerAccessToken = customerAccessToken;
+      }
+      onCartReadySend({
+        type: 'CART_CREATE',
+        payload: cartInput,
+      });
+    },
+    [countryCode, customerAccessToken, onCartReadySend]
+  );
+
   const cartContextValue = useMemo<CartWithActions>(() => {
     return {
       ...(cartState?.context?.cart ?? {lines: [], attributes: []}),
       status: transposeStatus(cartState.value),
       error: cartState?.context?.errors,
       totalQuantity: cartState?.context?.cart?.totalQuantity ?? 0,
-      cartCreate(cartInput: CartInput) {
-        onCartReadySend({
-          type: 'CART_CREATE',
-          payload: cartInput,
-        });
-      },
+      cartCreate,
       linesAdd(lines: CartLineInput[]) {
-        onCartReadySend({
-          type: 'CARTLINE_ADD',
-          payload: {lines},
-        });
+        if (cartState?.context?.cart?.id) {
+          onCartReadySend({
+            type: 'CARTLINE_ADD',
+            payload: {lines},
+          });
+        } else {
+          cartCreate({lines});
+        }
       },
       linesRemove(lines: string[]) {
         onCartReadySend({
@@ -279,6 +337,7 @@ export function CartProviderV2({
       cartFragment: usedCartFragment,
     };
   }, [
+    cartCreate,
     cartState?.context?.cart,
     cartState?.context?.errors,
     cartState.value,
@@ -298,11 +357,11 @@ function transposeStatus(
 ): CartWithActions['status'] {
   switch (status) {
     case 'uninitialized':
+    case 'initializationError':
       return 'uninitialized';
     case 'idle':
     case 'cartCompleted':
     case 'error':
-    case 'initializationError':
       return 'idle';
     case 'cartFetching':
       return 'fetching';
@@ -347,6 +406,17 @@ function storageAvailable(type: 'localStorage' | 'sessionStorage') {
       storage.length !== 0
     );
   }
+}
+
+function countryCodeNotUpdated(
+  context: CartMachineContext,
+  event: BuyerIdentityUpdateEvent
+) {
+  return (
+    event.payload.buyerIdentity.countryCode &&
+    context.cart?.buyerIdentity?.countryCode !==
+      event.payload.buyerIdentity.countryCode
+  );
 }
 
 // Cart Analytics

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -3,7 +3,7 @@ import {vi} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import {useCart} from '../../../hooks/useCart/useCart.js';
 import {ShopifyTestProviders} from '../../../utilities/tests/provider-helpers.js';
-import {CART, CART_WITH_LINES, CART_WITH_LINES_FLATTENED} from './fixtures.js';
+import {getCartMock} from './fixtures.js';
 
 const mockUseCartActions = vi.fn();
 
@@ -17,6 +17,7 @@ import {CountryCode} from '../../../storefront-api-types.js';
 import {CART_ID_STORAGE_KEY} from '../constants.js';
 import {ClientAnalytics} from '../../../foundation/Analytics/ClientAnalytics.js';
 import {CartFragmentFragment} from '../graphql/CartFragment.js';
+import {getCartLineMock} from '../../CartLineProvider/tests/fixtures.js';
 
 function ShopifyCartProvider(
   props: Omit<ComponentProps<typeof CartProviderV2>, 'children'> = {}
@@ -30,6 +31,12 @@ function ShopifyCartProvider(
   };
 }
 
+const cartMock = getCartMock({buyerIdentity: {countryCode: CountryCode.Us}});
+const cartMockWithLine = {
+  ...cartMock,
+  lines: {edges: [{node: getCartLineMock()}]},
+};
+
 describe('<CartProviderV2 />', () => {
   beforeEach(() => {
     mockUseCartActions.mockClear();
@@ -39,7 +46,7 @@ describe('<CartProviderV2 />', () => {
   describe('local storage', () => {
     it('fetches the cart with the cart id in local storage when initializing the app', async () => {
       const cartFetchSpy = vi.fn(async () => ({
-        data: {cart: CART},
+        data: {cart: cartMock},
       }));
       vi.spyOn(window.localStorage, 'getItem').mockReturnValue('cart-id');
 
@@ -58,13 +65,13 @@ describe('<CartProviderV2 />', () => {
       expect(cartFetchSpy).toBeCalledWith('cart-id');
       expect(result.current).toMatchObject({
         status: 'idle',
-        ...cartFromGraphQL(CART),
+        ...cartFromGraphQL(cartMock),
       });
     });
 
     it('does not fetch cart if cart id is not in local storage', async () => {
       const cartFetchSpy = vi.fn(async () => ({
-        data: {cart: CART},
+        data: {cart: cartMock},
       }));
       vi.spyOn(window.localStorage, 'getItem').mockReturnValue('');
 
@@ -127,7 +134,7 @@ describe('<CartProviderV2 />', () => {
   describe('uninitialized cart after local storage init', () => {
     it('creates a cart when creating a cart', async () => {
       const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
+        data: {cartCreate: {cart: cartMock}},
       }));
       mockUseCartActions.mockReturnValue({
         cartCreate: cartCreateSpy,
@@ -151,13 +158,13 @@ describe('<CartProviderV2 />', () => {
 
       expect(result.current).toMatchObject({
         status: 'idle',
-        ...cartFromGraphQL(CART),
+        ...cartFromGraphQL(cartMock),
       });
     });
 
     it('runs the onCartCreate and onCartCreateComplete callbacks when creating a cart', async () => {
       const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
+        data: {cartCreate: {cart: cartMock}},
       }));
 
       const onCartCreateSpy = vi.fn();
@@ -188,7 +195,7 @@ describe('<CartProviderV2 />', () => {
 
     it('sends analytics event after creating a cart', async () => {
       const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART_WITH_LINES}},
+        data: {cartCreate: {cart: cartMockWithLine}},
       }));
 
       const ClientAnalyticsSpy = vi.spyOn(ClientAnalytics, 'publish');
@@ -204,7 +211,7 @@ describe('<CartProviderV2 />', () => {
       const cartInput = {
         lines: [
           {
-            merchandiseId: CART_WITH_LINES.lines.edges[0].node.merchandise.id,
+            merchandiseId: cartMockWithLine.lines.edges[0].node.merchandise.id,
           },
         ],
       };
@@ -221,7 +228,7 @@ describe('<CartProviderV2 />', () => {
         true,
         {
           addedCartLines: cartInput.lines,
-          cart: CART_WITH_LINES,
+          cart: cartMockWithLine,
           prevCart: null,
         }
       );
@@ -229,7 +236,7 @@ describe('<CartProviderV2 />', () => {
 
     it('creates a cart when adding a cart line', async () => {
       const cartCreateSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
+        data: {cartCreate: {cart: cartMock}},
       }));
       mockUseCartActions.mockReturnValue({
         cartCreate: cartCreateSpy,
@@ -255,7 +262,7 @@ describe('<CartProviderV2 />', () => {
 
       expect(result.current).toMatchObject({
         status: 'idle',
-        ...cartFromGraphQL(CART),
+        ...cartFromGraphQL(cartMock),
       });
     });
 
@@ -302,7 +309,7 @@ describe('<CartProviderV2 />', () => {
       }));
 
       const cartCreateResolveSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
+        data: {cartCreate: {cart: cartMock}},
       }));
 
       mockUseCartActions.mockReturnValue({
@@ -352,7 +359,7 @@ describe('<CartProviderV2 />', () => {
 
       expect(result.current).toMatchObject({
         status: 'idle',
-        ...cartFromGraphQL(CART),
+        ...cartFromGraphQL(cartMock),
       });
     });
   });
@@ -361,7 +368,7 @@ describe('<CartProviderV2 />', () => {
     describe('adds cart line', async () => {
       it('resolves', async () => {
         const cartLineAddSpy = vi.fn(async () => ({
-          data: {cartLinesAdd: {cart: CART}},
+          data: {cartLinesAdd: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -384,7 +391,7 @@ describe('<CartProviderV2 />', () => {
         expect(cartLineAddSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -415,7 +422,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onLineAdd and onLineAddComplete callbacks', async () => {
         const cartLineAddSpy = vi.fn(async () => ({
-          data: {cartLinesAdd: {cart: CART}},
+          data: {cartLinesAdd: {cart: cartMock}},
         }));
 
         const onLineAddSpy = vi.fn();
@@ -449,7 +456,7 @@ describe('<CartProviderV2 />', () => {
 
       it('send analytics event after adding a cart line', async () => {
         const cartLineAddSpy = vi.fn(async () => ({
-          data: {cartLinesAdd: {cart: CART_WITH_LINES}},
+          data: {cartLinesAdd: {cart: cartMockWithLine}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -473,8 +480,8 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             addedCartLines: cartLinesInput,
-            cart: CART_WITH_LINES,
-            prevCart: cartFromGraphQL(CART),
+            cart: cartMockWithLine,
+            prevCart: cartFromGraphQL(cartMock),
           }
         );
       });
@@ -483,7 +490,7 @@ describe('<CartProviderV2 />', () => {
     describe('updates cartline', async () => {
       it('resolves', async () => {
         const cartLineUpdateSpy = vi.fn(async () => ({
-          data: {cartLinesUpdate: {cart: CART}},
+          data: {cartLinesUpdate: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -507,7 +514,7 @@ describe('<CartProviderV2 />', () => {
         expect(cartLineUpdateSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -539,7 +546,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onLineUpdate and onLineUpdateComplete callbacks', async () => {
         const cartLineUpdateSpy = vi.fn(async () => ({
-          data: {cartLinesUpdate: {cart: CART}},
+          data: {cartLinesUpdate: {cart: cartMock}},
         }));
 
         const onLineUpdateSpy = vi.fn();
@@ -575,7 +582,7 @@ describe('<CartProviderV2 />', () => {
 
       it('send analytics event after updating a cart line', async () => {
         const cartLineUpdateSpy = vi.fn(async () => ({
-          data: {cartLinesUpdate: {cart: CART_WITH_LINES}},
+          data: {cartLinesUpdate: {cart: cartMockWithLine}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -599,9 +606,9 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             updatedCartLines: cartLinesInput,
-            cart: CART_WITH_LINES,
-            prevCart: cartFromGraphQL(CART),
-            oldCart: cartFromGraphQL(CART),
+            cart: cartMockWithLine,
+            prevCart: cartFromGraphQL(cartMock),
+            oldCart: cartFromGraphQL(cartMock),
           }
         );
       });
@@ -610,7 +617,7 @@ describe('<CartProviderV2 />', () => {
     describe('removes cartline', async () => {
       it('resolves', async () => {
         const cartLineRemoveSpy = vi.fn(async () => ({
-          data: {cartLinesRemove: {cart: CART}},
+          data: {cartLinesRemove: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -629,7 +636,7 @@ describe('<CartProviderV2 />', () => {
         expect(cartLineRemoveSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -655,7 +662,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onLineRemove and onLineRemoveComplete callbacks', async () => {
         const cartLineRemoveSpy = vi.fn(async () => ({
-          data: {cartLinesRemove: {cart: CART}},
+          data: {cartLinesRemove: {cart: cartMock}},
         }));
 
         const onLineRemoveSpy = vi.fn();
@@ -686,11 +693,11 @@ describe('<CartProviderV2 />', () => {
 
       it('send analytics event after removing a cart line', async () => {
         const cartCreateSpy = vi.fn(async () => ({
-          data: {cartCreate: {cart: CART_WITH_LINES}},
+          data: {cartCreate: {cart: cartMockWithLine}},
         }));
 
         const cartLineRemoveSpy = vi.fn(async () => ({
-          data: {cartLinesRemove: {cart: CART}},
+          data: {cartLinesRemove: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -715,8 +722,8 @@ describe('<CartProviderV2 />', () => {
           true,
           {
             removedCartLines: cartLineIds,
-            cart: CART,
-            prevCart: cartFromGraphQL(CART_WITH_LINES),
+            cart: cartMock,
+            prevCart: cartFromGraphQL(cartMockWithLine),
           }
         );
       });
@@ -725,7 +732,7 @@ describe('<CartProviderV2 />', () => {
     describe('note update', async () => {
       it('resolves', async () => {
         const noteUpdateSpy = vi.fn(async () => ({
-          data: {cartNoteUpdate: {cart: CART}},
+          data: {cartNoteUpdate: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -744,7 +751,7 @@ describe('<CartProviderV2 />', () => {
         expect(noteUpdateSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -770,7 +777,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onNoteUpdate and onNoteUpdateComplete callbacks', async () => {
         const noteUpdateSpy = vi.fn(async () => ({
-          data: {cartNoteUpdate: {cart: CART}},
+          data: {cartNoteUpdate: {cart: cartMock}},
         }));
 
         const onNoteUpdateSpy = vi.fn();
@@ -803,7 +810,7 @@ describe('<CartProviderV2 />', () => {
     describe('buyer identity update', async () => {
       it('resolves', async () => {
         const buyerIdentityUpdateSpy = vi.fn(async () => ({
-          data: {cartBuyerIdentityUpdate: {cart: CART}},
+          data: {cartBuyerIdentityUpdate: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -822,7 +829,7 @@ describe('<CartProviderV2 />', () => {
         expect(buyerIdentityUpdateSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -848,7 +855,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onBuyerIdentityUpdate and onBuyerIdentityUpdateComplete callbacks', async () => {
         const buyerIdentityUpdateSpy = vi.fn(async () => ({
-          data: {cartBuyerIdentityUpdate: {cart: CART}},
+          data: {cartBuyerIdentityUpdate: {cart: cartMock}},
         }));
 
         const onBuyerIdentityUpdateSpy = vi.fn();
@@ -881,7 +888,7 @@ describe('<CartProviderV2 />', () => {
     describe('cart attributes update', async () => {
       it('resolves', async () => {
         const cartAttributesUpdateSpy = vi.fn(async () => ({
-          data: {cartAttributesUpdate: {cart: CART}},
+          data: {cartAttributesUpdate: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -900,7 +907,7 @@ describe('<CartProviderV2 />', () => {
         expect(cartAttributesUpdateSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -926,7 +933,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onAttributesUpdate and onAttributesUpdateComplete callbacks', async () => {
         const cartAttributesUpdateSpy = vi.fn(async () => ({
-          data: {cartAttributesUpdate: {cart: CART}},
+          data: {cartAttributesUpdate: {cart: cartMock}},
         }));
 
         const onCartAttributesUpdateSpy = vi.fn();
@@ -959,7 +966,7 @@ describe('<CartProviderV2 />', () => {
     describe('discount update', async () => {
       it('resolves', async () => {
         const discountCodesUpdateSpy = vi.fn(async () => ({
-          data: {cartDiscountCodesUpdate: {cart: CART}},
+          data: {cartDiscountCodesUpdate: {cart: cartMock}},
         }));
 
         const result = await useCartWithInitializedCart({
@@ -978,7 +985,7 @@ describe('<CartProviderV2 />', () => {
         expect(discountCodesUpdateSpy).toBeCalledTimes(1);
         expect(result.current).toMatchObject({
           status: 'idle',
-          ...cartFromGraphQL(CART),
+          ...cartFromGraphQL(cartMock),
         });
       });
 
@@ -1005,7 +1012,7 @@ describe('<CartProviderV2 />', () => {
 
       it('runs onDiscountCodesUpdate and onDiscountCodesUpdateComplete callbacks', async () => {
         const discountCodesUpdateSpy = vi.fn(async () => ({
-          data: {cartDiscountCodesUpdate: {cart: CART}},
+          data: {cartDiscountCodesUpdate: {cart: cartMock}},
         }));
 
         const onDiscountUpdateSpy = vi.fn();
@@ -1037,7 +1044,7 @@ describe('<CartProviderV2 />', () => {
       it('sends analytics event on discount codes update', async () => {
         const discountCodes = ['DiscountCode'];
         const cartWithDiscountCode: CartFragmentFragment = {
-          ...CART,
+          ...cartMock,
           discountCodes: [{code: discountCodes[0], applicable: true}],
         };
         const discountCodesUpdateSpy = vi.fn(async () => ({
@@ -1064,7 +1071,7 @@ describe('<CartProviderV2 />', () => {
           {
             updatedDiscountCodes: discountCodes,
             cart: cartWithDiscountCode,
-            prevCart: cartFromGraphQL(CART),
+            prevCart: cartFromGraphQL(cartMock),
           }
         );
       });
@@ -1079,7 +1086,7 @@ describe('<CartProviderV2 />', () => {
       }));
 
       const cartCreateResolveSpy = vi.fn(async () => ({
-        data: {cartCreate: {cart: CART}},
+        data: {cartCreate: {cart: cartMock}},
       }));
 
       mockUseCartActions.mockReturnValue({
@@ -1122,7 +1129,7 @@ describe('<CartProviderV2 />', () => {
     it('creates a cart with countryCode from props', async () => {
       const mockCountryCode = CountryCode.Ca;
       const cartWithCountry = {
-        ...CART,
+        ...cartMock,
         buyerIdentity: {countryCode: mockCountryCode},
       };
       const cartCreateSpy = vi.fn(async () => ({
@@ -1151,7 +1158,7 @@ describe('<CartProviderV2 />', () => {
       const mockCountryCode = CountryCode.Ca;
       const mockCountryCodeServerProps = CountryCode.Us;
       const cartWithCountry = {
-        ...CART,
+        ...cartMock,
         buyerIdentity: {countryCode: mockCountryCode},
       };
       const cartCreateSpy = vi.fn(async () => ({
@@ -1159,7 +1166,7 @@ describe('<CartProviderV2 />', () => {
       }));
 
       const buyerIdentityUpdateSpy = vi.fn(async () => ({
-        data: {cartBuyerIdentityUpdate: {cart: CART}},
+        data: {cartBuyerIdentityUpdate: {cart: cartMock}},
       }));
 
       mockUseCartActions.mockReturnValue({
@@ -1185,7 +1192,7 @@ describe('<CartProviderV2 />', () => {
 
       // Our current cart provider tries to always change the country code back.
       // @TODO: is this the behaviour we want?
-      expect(buyerIdentityUpdateSpy).toHaveBeenCalledWith(CART.id, {
+      expect(buyerIdentityUpdateSpy).toHaveBeenCalledWith(cartMock.id, {
         countryCode: mockCountryCodeServerProps,
       });
     });
@@ -1199,7 +1206,7 @@ describe('<CartProviderV2 />', () => {
       const mockCountryCode = CountryCode.Ca;
       const mockCountryCodeServerProps = CountryCode.Us;
       const cartWithCountryCa = {
-        ...CART,
+        ...cartMock,
         buyerIdentity: {countryCode: mockCountryCode},
       };
 
@@ -1230,7 +1237,7 @@ describe('<CartProviderV2 />', () => {
       // Our current cart provider tries to always change the country code
       // it stops once it fails
       expect(buyerIdentityUpdateSpy).toHaveBeenCalledTimes(1);
-      expect(buyerIdentityUpdateSpy).toHaveBeenCalledWith(CART.id, {
+      expect(buyerIdentityUpdateSpy).toHaveBeenCalledWith(cartMock.id, {
         countryCode: mockCountryCodeServerProps,
       });
     });
@@ -1240,7 +1247,7 @@ describe('<CartProviderV2 />', () => {
     it('creates a cart with customerAccessToken from props', async () => {
       const mockCustomerAccessToken = 'access token test';
       const cartWithCustomer = {
-        ...CART,
+        ...cartMock,
         buyerIdentity: {
           countryCode: CountryCode.Us,
           customer: {email: 'test@test.com'},
@@ -1277,7 +1284,7 @@ describe('<CartProviderV2 />', () => {
       const mockPropsAccessToken = 'server token test';
       const mockCustomerAccessToken = 'access token test';
       const cartWithCustomer = {
-        ...CART,
+        ...cartMock,
         buyerIdentity: {
           countryCode: CountryCode.Us,
           customer: {email: 'test@test.com'},
@@ -1324,7 +1331,7 @@ async function useCartWithInitializedCart(
   > = {}
 ) {
   const cartCreateSpy = vi.fn(async () => ({
-    data: {cartCreate: {cart: CART}},
+    data: {cartCreate: {cart: cartMock}},
   }));
 
   mockUseCartActions.mockReturnValue({

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -1216,7 +1216,9 @@ describe('<CartProviderV2 />', () => {
         buyerIdentityUpdate: buyerIdentityUpdateSpy,
       });
       const {result} = renderHook(() => useCart(), {
-        wrapper: ShopifyCartProvider({countryCode: mockCountryCodeServerProps}),
+        wrapper: ShopifyCartProvider({
+          countryCode: mockCountryCodeServerProps,
+        }),
       });
 
       act(() => {

--- a/packages/hydrogen/src/components/CartProvider/tests/fixtures.ts
+++ b/packages/hydrogen/src/components/CartProvider/tests/fixtures.ts
@@ -3,12 +3,15 @@ import {getPrice} from '../../../utilities/tests/price.js';
 import {flattenConnection} from '../../../utilities/index.js';
 import type {CartWithActions} from '../types.js';
 import {defaultCartFragment} from '../cart-queries.js';
+import {CountryCode} from '../../../storefront-api-types.js';
 
 export const CART = {
   id: 'abc',
   checkoutUrl: 'https://shopify.com/checkout',
   attributes: [],
-  buyerIdentity: {},
+  buyerIdentity: {
+    countryCode: CountryCode.Us,
+  },
   discountCodes: [],
   totalQuantity: 0,
   cost: {

--- a/packages/hydrogen/src/components/CartProvider/tests/fixtures.ts
+++ b/packages/hydrogen/src/components/CartProvider/tests/fixtures.ts
@@ -3,15 +3,13 @@ import {getPrice} from '../../../utilities/tests/price.js';
 import {flattenConnection} from '../../../utilities/index.js';
 import type {CartWithActions} from '../types.js';
 import {defaultCartFragment} from '../cart-queries.js';
-import {CountryCode} from '../../../storefront-api-types.js';
+import {CartFragmentFragment} from '../graphql/CartFragment.js';
 
 export const CART = {
   id: 'abc',
   checkoutUrl: 'https://shopify.com/checkout',
   attributes: [],
-  buyerIdentity: {
-    countryCode: CountryCode.Us,
-  },
+  buyerIdentity: {},
   discountCodes: [],
   totalQuantity: 0,
   cost: {
@@ -22,6 +20,10 @@ export const CART = {
   },
   lines: {edges: []},
 };
+
+export function getCartMock(options?: Partial<CartFragmentFragment>) {
+  return {...CART, ...options};
+}
 
 export const CART_WITH_LINES = {
   ...CART,


### PR DESCRIPTION
Part of: https://github.com/Shopify/hydrogen/issues/1947
Solves the looping that happens in: https://github.com/Shopify/hydrogen/issues/1677

### Description
This PR copies over the handling of country changes plus fixed the issue when country cannot be changed because of a customer account.

Vitest were added.

