### PR TITLE
Fixed dev-mode Hydrogen builds to properly show `PUBLIC_` prefixed environment variables

### DIFF
--- a/.changeset/late-buses-film.md
+++ b/.changeset/late-buses-film.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fixed dev-mode Hydrogen builds to properly show `PUBLIC_` prefixed environment variables

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -87,15 +87,5 @@ declare global {
 async function polyfillOxygenEnv(config: ResolvedConfig) {
   const env = await loadEnv(config.mode, config.root, '');
 
-  const publicPrefixes = Array.isArray(config.envPrefix)
-    ? config.envPrefix
-    : [config.envPrefix || ''];
-
-  for (const key of Object.keys(env)) {
-    if (publicPrefixes.some((prefix) => key.startsWith(prefix))) {
-      delete env[key];
-    }
-  }
-
   globalThis.Oxygen = {env};
 }


### PR DESCRIPTION
Fixed dev-mode Hydrogen builds to properly show `PUBLIC_` prefixed environment variables