### PR TITLE
[CartProviderV2] port optimistic UI

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -140,6 +140,45 @@ export function CartProviderV2({
           return onDiscountCodesUpdate?.();
       }
     },
+    onCartActionOptimisticUI(context, event) {
+      if (!context?.cart) return {cart: undefined};
+      switch (event.type) {
+        case 'CARTLINE_REMOVE':
+          return {
+            ...context,
+            lastValidCart: context.cart,
+            cart: {
+              ...context.cart,
+              lines: context?.cart?.lines.filter(
+                ({id}) => !event.payload.lines.includes(id)
+              ),
+            },
+          };
+        case 'CARTLINE_UPDATE':
+          return {
+            ...context,
+            lastValidCart: context.cart,
+            cart: {
+              ...context.cart,
+              lines: context.cart.lines.map((line) => {
+                const updatedLine = event.payload.lines.find(
+                  ({id}) => id === line.id
+                );
+
+                if (updatedLine && updatedLine.quantity) {
+                  return {
+                    ...line,
+                    quantity: updatedLine.quantity,
+                  };
+                }
+
+                return line;
+              }),
+            },
+          };
+      }
+      return {cart: context.cart ? {...context.cart} : undefined};
+    },
     onCartActionComplete(context, event) {
       const cartActionEvent = event.payload.cartActionEvent;
       switch (event.type) {

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -92,6 +92,7 @@ export type CartAction =
 // State Machine types
 export type CartMachineContext = {
   cart?: Cart;
+  lastValidCart?: Cart;
   rawCartResult?: CartFragmentFragment;
   prevCart?: Cart;
   errors?: any;
@@ -193,6 +194,7 @@ export type CartMachineTypeState =
       value: 'uninitialized';
       context: CartMachineContext & {
         cart: undefined;
+        lastValidCart: undefined;
         prevCart: undefined;
         errors?: any;
       };
@@ -201,6 +203,7 @@ export type CartMachineTypeState =
       value: 'initializationError';
       context: CartMachineContext & {
         cart: undefined;
+        lastValidCart: undefined;
         prevCart: undefined;
         errors: any;
       };
@@ -210,6 +213,7 @@ export type CartMachineTypeState =
       context: CartMachineContext & {
         cart: undefined;
         prevCart?: Cart;
+        lastValidCart: undefined;
         errors: any;
       };
     }
@@ -218,6 +222,7 @@ export type CartMachineTypeState =
       context: CartMachineContext & {
         cart: Cart;
         prevCart?: Cart;
+        lastValidCart?: Cart;
         errors?: any;
       };
     }
@@ -226,6 +231,7 @@ export type CartMachineTypeState =
       context: CartMachineContext & {
         cart?: Cart;
         prevCart?: Cart;
+        lastValidCart?: Cart;
         errors: any;
       };
     }
@@ -255,5 +261,9 @@ export type CartMachineActions = {
   cartAttributesUpdateAction: CartMachineAction;
   discountCodesUpdateAction: CartMachineAction;
   onCartActionEntry?: CartMachineAction;
+  onCartActionOptimisticUI?: StateMachine.AssignActionObject<
+    CartMachineContext,
+    CartMachineEvent
+  >;
   onCartActionComplete?: CartMachineAction;
 };


### PR DESCRIPTION
#1947 

### Description
Adding optimistic UI like in `CartProvider`. I added a callback `onCartActionOptimisticUI` for the state machine that allows us to create optimistic UI for any cart action. This means we could decide to expose a custom function for the user or to enable / disable optimistic UI.

I added a `lastValidCart` to our context to revert the `cart` if the API cart action returns an error

Tests were also added.