### PR TITLE
Deprecate Oxygen.env in favor of Hydrogen.env

### DIFF
--- a/.changeset/dry-rabbits-tell.md
+++ b/.changeset/dry-rabbits-tell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+`Oxygen.env` is now deprecated in favor of `Hydrogen.env`. Access environment variables within your server components on `Hydrogen.env`. We hope this will make more sense when deploying to non-Oxygen environments.

--- a/.github/deployments/cloudflare/worker.js
+++ b/.github/deployments/cloudflare/worker.js
@@ -42,6 +42,11 @@ async function handleEvent(event) {
       globalThis.Oxygen = {};
     }
 
+    // TODO: Switch to module syntax and transfer args to Hydrogen.env
+    if (!globalThis.Hydrogen) {
+      globalThis.Hydrogen = {};
+    }
+
     return await handleRequest(event.request, {
       indexTemplate,
       cache: caches.default,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -347,9 +347,6 @@ You can deploy your Hydrogen storefront to Cloudflare Workers, a serverless appl
 
 If you're deploying to a non-Oxygen runtime, then this is a necessary step to avoid rate-limiting in production. [Learn more](https://shopify.dev/custom-storefronts/hydrogen/framework/environment-variables#use-storefront-api-server-tokens) about why it's required.
 
-> Note:
-> In the following example, environment variables are stored in `Oxygen.env`. If you're not deploying to Oxygen, then you can choose a different storage location.
-
 1. Create a [delegate access token](https://shopify.dev/apps/auth/oauth/delegate-access-tokens) for the Storefront API.
 
 1. [Store the token](https://vitejs.dev/guide/env-and-mode.html#env-files) in a private environment variable called `PRIVATE_STOREFRONT_API_TOKEN`.
@@ -361,9 +358,7 @@ If you're deploying to a non-Oxygen runtime, then this is a necessary step to av
     ```tsx
     export default defineConfig({
       privateStorefrontToken:
-      /* In this example, the environment variable is stored in `Oxygen.env`.
-         If you're not deploying to Oxygen, then you can choose a different storage location.*/
-        Oxygen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
+        Hydrogen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
     });
     ```
 
@@ -375,9 +370,7 @@ If you're deploying to a non-Oxygen runtime, then this is a necessary step to av
 
     ```tsx
     export default defineConfig({
-      /* In this example, the environment variable is stored in `Oxygen.env`.
-         Because you're not deploying to Oxygen, you can choose a different storage location.*/
-      storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID
+      storefrontId: Hydrogen?.env?.PUBLIC_STOREFRONT_ID
     });
     ```
 

--- a/docs/framework/analytics.md
+++ b/docs/framework/analytics.md
@@ -330,9 +330,7 @@ To send analytics data from the server-side, complete the following steps:
 
     ```tsx
     export default defineConfig({
-      /* In this example, the environment variable is stored in `Oxygen.env`.
-         Because you're not deploying to Oxygen, you can choose a different storage location.*/
-      storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID
+      storefrontId: Hydrogen?.env?.PUBLIC_STOREFRONT_ID
     });
     ```
 

--- a/docs/framework/environment-variables.md
+++ b/docs/framework/environment-variables.md
@@ -4,7 +4,7 @@ title: Environment variables
 description: Learn how to store sensitive information in your Hydrogen project.
 ---
 
-Environment variables allow you to load different values in your app depending on the running environment. This guide describes how to store environment variables in your Hydrogen project.
+Environment variables enable you to load different values in your app depending on the running environment. This guide describes how to store environment variables in your Hydrogen project.
 
 ## How environment variables work
 
@@ -22,7 +22,7 @@ MY_SECRET_API_TOKEN="topsecret"
 
 Environment variables are available within server components with the global object `Hydrogen.env`:
 
-{% codeblock file, filename: 'Component.server.jsx' %}
+{% codeblock file, filename: 'component.server.jsx' %}
 
 ```js
 export default ServerComponent() {
@@ -33,9 +33,9 @@ export default ServerComponent() {
 
 {% endcodeblock %}
 
-Environment variables are unavailable within client components. If you need to access an environment variable within a client component, pass the variable as a prop from a server component to the client component:
+Environment variables aren't available in client components. To access an environment variable within a client component, pass the variable as a prop from a server component to the client component. The following is an example:
 
-{% codeblock file, filename: 'Component.server.jsx' %}
+{% codeblock file, filename: 'component.server.jsx' %}
 
 ```js
 export default ServerComponent() {
@@ -46,7 +46,8 @@ export default ServerComponent() {
 
 {% endcodeblock %}
 
-Note: Make sure that you *never* pass secret environment variables to client components.
+> Caution: 
+> Never pass secret environment variables to client components.
 
 ### Files for specific environments
 

--- a/docs/framework/environment-variables.md
+++ b/docs/framework/environment-variables.md
@@ -47,7 +47,7 @@ export default ServerComponent() {
 {% endcodeblock %}
 
 > Caution: 
-> Never pass secret environment variables to client components.
+> Never pass secret environment variables to client components. Secret tokens, like `PRIVATE_STOREFRONT_API_TOKEN`, are private, and introduce security vulnerabilities if passed to client components.
 
 ### Files for specific environments
 

--- a/docs/framework/hydrogen-config.md
+++ b/docs/framework/hydrogen-config.md
@@ -10,9 +10,6 @@ This guide describes Hydrogen's configuration properties and how to change the l
 
 ## Example configuration
 
-> Note:
-> In the following example, environment variables are stored in `Oxygen.env`. If you're not deploying to Oxygen, then you can choose a different storage location.
-
 The Hydrogen configuration file contains information that's needed at runtime for routing, connecting to the Storefront API, and many other options. The following example shows a basic Hydrogen configuration file:
 
 {% codeblock file, filename: 'hydrogen.config.ts' %}
@@ -29,11 +26,11 @@ export default defineConfig({
     /* The domain of your Shopify store */
     storeDomain: '{shop_domain}.myshopify.com',
     /* Your app's public Storefront API access token. Authenticates browser and client requests. */
-    storefrontToken: Oxygen?.env?.PUBLIC_STOREFRONT_API_TOKEN,
+    storefrontToken: Hydrogen?.env?.PUBLIC_STOREFRONT_API_TOKEN,
     /* Your app's private Storefront API server (delegate access) token. Authenticates server requests. */
-    privateStorefrontToken: Oxygen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
+    privateStorefrontToken: Hydrogen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
     /* The unique ID for the storefront. This prop is required on non-Oxygen runtimes to avoid breaking the analytics dashboard in the Shopify admin.*/
-    storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
+    storefrontId: Hydrogen?.env?.PUBLIC_STOREFRONT_ID,
     /* The Storefront API version that your app uses */
     storefrontApiVersion: '2022-07',
   },

--- a/examples/multipass/src/routes/account/login/multipass/[token].server.tsx
+++ b/examples/multipass/src/routes/account/login/multipass/[token].server.tsx
@@ -40,7 +40,7 @@ export async function api(
 
   // create a multipassify instance
   const multipassify = new Multipassify(
-    Oxygen.env.SHOPIFY_STORE_MULTIPASS_SECRET
+    Hydrogen.env.SHOPIFY_STORE_MULTIPASS_SECRET
   );
 
   try {

--- a/examples/multipass/src/routes/account/login/multipass/index.server.tsx
+++ b/examples/multipass/src/routes/account/login/multipass/index.server.tsx
@@ -11,7 +11,7 @@ import type {
 
 declare global {
   // eslint-disable-next-line no-var
-  var Oxygen: {env: any; [key: string]: any};
+  var Hydrogen: {env: any; [key: string]: any};
 }
 
 const CUSTOMER_INFO_QUERY = gql`
@@ -85,8 +85,7 @@ export async function api(
     if (!customer && !customerAccessToken) {
       return handleLoggedOutResponse({
         return_to: body?.return_to ?? null,
-        // @ts-ignore
-        checkoutDomain: Oxygen.env.SHOPIFY_CHECKOUT_DOMAIN,
+        checkoutDomain: Hydrogen.env.SHOPIFY_CHECKOUT_DOMAIN,
       });
     }
 
@@ -108,8 +107,7 @@ export async function api(
     try {
       // generate a multipass url and token
       const multipassify = new Multipassify(
-        // @ts-ignore
-        Oxygen.env.SHOPIFY_STORE_MULTIPASS_SECRET
+        Hydrogen.env.SHOPIFY_STORE_MULTIPASS_SECRET
       );
 
       const customerInfo: CustomerInfoType = {
@@ -122,8 +120,7 @@ export async function api(
       // Generating a token for customer
       const data = multipassify.generate(
         customerInfo,
-        // @ts-ignore
-        Oxygen.env.SHOPIFY_STORE_DOMAIN,
+        Hydrogen.env.SHOPIFY_STORE_DOMAIN,
         request
       );
 

--- a/examples/partytown-gtm/hydrogen.config.js
+++ b/examples/partytown-gtm/hydrogen.config.js
@@ -4,8 +4,8 @@ export default defineConfig({
   shopify: () => ({
     defaultLanguageCode: 'EN',
     defaultCountryCode: 'GB',
-    storeDomain: Oxygen.env.SHOPIFY_STORE_DOMAIN,
-    storefrontToken: Oxygen.env.SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN,
+    storeDomain: Hydrogen.env.SHOPIFY_STORE_DOMAIN,
+    storefrontToken: Hydrogen.env.SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN,
     storefrontApiVersion: '2022-07',
   }),
 });

--- a/examples/partytown-gtm/src/components/GTM.server.jsx
+++ b/examples/partytown-gtm/src/components/GTM.server.jsx
@@ -1,6 +1,6 @@
 export function GTM() {
-  const GTM_ID = Oxygen?.env?.GTM_ID;
-  const GA4_ID = Oxygen?.env?.GA4_ID;
+  const GTM_ID = Hydrogen?.env?.GTM_ID;
+  const GA4_ID = Hydrogen?.env?.GA4_ID;
 
   return (
     <>

--- a/packages/hydrogen/src/foundation/Analytics/connectors/Shopify/ShopifyAnalytics.server.tsx
+++ b/packages/hydrogen/src/foundation/Analytics/connectors/Shopify/ShopifyAnalytics.server.tsx
@@ -34,7 +34,7 @@ export function ShopifyAnalytics({cookieDomain}: {cookieDomain?: string}) {
     shopify: {
       shopId: id,
       currency: currencyCode,
-      storefrontId: globalThis.Oxygen?.env?.SHOPIFY_STOREFRONT_ID || '0',
+      storefrontId: globalThis.Hydrogen?.env?.SHOPIFY_STOREFRONT_ID || '0',
       acceptedLanguage:
         request.headers.get('Accept-Language')?.replace(/-.*/, '') || 'en',
       isPersistentCookie: !!cookies[SHOPIFY_S] || !!cookies[SHOPIFY_Y],

--- a/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.server.tsx
+++ b/packages/hydrogen/src/foundation/ShopifyProvider/ShopifyProvider.server.tsx
@@ -14,7 +14,7 @@ import {
   useRequestCacheData,
   useServerRequest,
 } from '../ServerRequestProvider/index.js';
-import {getOxygenVariable} from '../../utilities/storefrontApi.js';
+import {getEnvironmentVariable} from '../../utilities/storefrontApi.js';
 import {SHOPIFY_STOREFRONT_ID_VARIABLE} from '../../constants.js';
 import {getLocale} from '../../utilities/locale/index.js';
 
@@ -33,7 +33,7 @@ function makeShopifyContext(shopifyConfig: ShopifyConfig): {
 } {
   const countryCode = shopifyConfig.defaultCountryCode ?? DEFAULT_COUNTRY;
   const languageCode = shopifyConfig.defaultLanguageCode ?? DEFAULT_LANGUAGE;
-  const storefrontId = getOxygenVariable(SHOPIFY_STOREFRONT_ID_VARIABLE);
+  const storefrontId = getEnvironmentVariable(SHOPIFY_STOREFRONT_ID_VARIABLE);
 
   const shopifyProviderServerValue = {
     defaultCountryCode: countryCode.toUpperCase() as `${CountryCode}`,

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-middleware.ts
@@ -28,7 +28,7 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
         return await server.transformIndexHtml(url, indexHtml);
       }
 
-      await polyfillOxygenEnv(server.config);
+      await polyfillHydrogenEnv(server.config);
 
       // The default vite middleware rewrites the URL `/graphqil` to `/index.html`
       // By running this middleware first, we avoid that.
@@ -81,11 +81,13 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
 
 declare global {
   // eslint-disable-next-line no-var
-  var Oxygen: {env: any; [key: string]: any};
+  var Hydrogen: {env: any; [key: string]: any};
 }
 
-async function polyfillOxygenEnv(config: ResolvedConfig) {
+async function polyfillHydrogenEnv(config: ResolvedConfig) {
   const env = await loadEnv(config.mode, config.root, '');
 
+  globalThis.Hydrogen = {env};
+  /* @ts-ignore */
   globalThis.Oxygen = {env};
 }

--- a/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-hydrogen-virtual-files.ts
@@ -143,7 +143,7 @@ export default (pluginOptions: HydrogenVitePluginOptions) => {
     transform(code, id) {
       if (id === resolvedConfigPath) {
         const s = new MagicString(code);
-        // Wrap in function to avoid evaluating `Oxygen.env`
+        // Wrap in function to avoid evaluating `Hydrogen.env`
         // in the config until we have polyfilled it properly.
         s.replace(/export\s+default\s+(\w+)\s*\(/g, (all, m1) =>
           all.replace(m1, `() => ${m1}`)

--- a/packages/hydrogen/src/platforms/node.ts
+++ b/packages/hydrogen/src/platforms/node.ts
@@ -24,6 +24,7 @@ export async function createServer({
 }: CreateServerOptions = {}) {
   // @ts-ignore
   globalThis.Oxygen = {env: process.env};
+  globalThis.Hydrogen = {env: process.env};
 
   const app = connect();
 

--- a/packages/hydrogen/src/platforms/worker-event.ts
+++ b/packages/hydrogen/src/platforms/worker-event.ts
@@ -9,5 +9,11 @@ interface FetchEvent extends Event {
 
 // @ts-ignore
 addEventListener('fetch', (event: FetchEvent) =>
-  event.respondWith(moduleEntry.fetch(event.request, globalThis, event))
+  event.respondWith(
+    moduleEntry.fetch(
+      event.request,
+      globalThis as unknown as Record<string, string>,
+      event
+    )
+  )
 );

--- a/packages/hydrogen/src/platforms/worker.ts
+++ b/packages/hydrogen/src/platforms/worker.ts
@@ -5,18 +5,15 @@ import {
   assetBasePath,
 } from './virtual.js';
 
-declare global {
-  // eslint-disable-next-line no-var
-  var globalThis: {
-    Oxygen: {env: any};
-    [key: string]: any;
-  };
+declare namespace globalThis {
+  let Oxygen: {env: Record<string, string>};
+  let Hydrogen: {env: Record<string, string>};
 }
 
 export default {
   async fetch(
     request: Request,
-    env: unknown,
+    env: Record<string, string>,
     context: {waitUntil: (promise: Promise<any>) => void}
   ) {
     // Proxy assets to the CDN. This should be removed
@@ -24,6 +21,10 @@ export default {
     const url = new URL(request.url);
     if (assetBasePath && isAsset(url.pathname)) {
       return fetch(request.url.replace(url.origin, assetBasePath), request);
+    }
+
+    if (!globalThis.Hydrogen) {
+      globalThis.Hydrogen = {env};
     }
 
     if (!globalThis.Oxygen) {

--- a/packages/hydrogen/src/utilities/storefrontApi.ts
+++ b/packages/hydrogen/src/utilities/storefrontApi.ts
@@ -1,4 +1,4 @@
-/* global Oxygen */
+/* global Hydrogen */
 import {
   OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE,
   STOREFRONT_API_SECRET_TOKEN_HEADER,
@@ -27,7 +27,7 @@ export function getStorefrontApiRequestHeaders({
 
   if (!privateStorefrontToken && !secretTokenWarned) {
     secretTokenWarned = true;
-    privateStorefrontToken = getOxygenVariable(
+    privateStorefrontToken = getEnvironmentVariable(
       OXYGEN_SECRET_TOKEN_ENVIRONMENT_VARIABLE
     );
 
@@ -44,7 +44,7 @@ export function getStorefrontApiRequestHeaders({
 
   if (!storefrontId && !storefrontIdWarned) {
     storefrontIdWarned = true;
-    storefrontId = getOxygenVariable(SHOPIFY_STOREFRONT_ID_VARIABLE);
+    storefrontId = getEnvironmentVariable(SHOPIFY_STOREFRONT_ID_VARIABLE);
 
     if (!storefrontId && !__HYDROGEN_DEV__) {
       log.warn(
@@ -77,6 +77,6 @@ export function getStorefrontApiRequestHeaders({
   return headers;
 }
 
-export function getOxygenVariable(key: string): any {
-  return typeof Oxygen !== 'undefined' ? Oxygen?.env?.[key] : null;
+export function getEnvironmentVariable(key: string): any {
+  return typeof Hydrogen !== 'undefined' ? Hydrogen?.env?.[key] : null;
 }

--- a/packages/playground/server-components/hydrogen.config.js
+++ b/packages/playground/server-components/hydrogen.config.js
@@ -1,3 +1,4 @@
+/* global Hydrogen */
 import {defineConfig, CookieSessionStorage} from '@shopify/hydrogen/config';
 
 export default defineConfig({
@@ -6,9 +7,7 @@ export default defineConfig({
     defaultCountryCode: 'us',
     storeDomain: 'hydrogen-preview.myshopify.com',
     storefrontToken: '3b580e70970c4528da70c98e097c2fa0',
-    // This should not throw with undefined Oxygen
-    // eslint-disable-next-line no-undef
-    storefrontApiVersion: Oxygen.env.FAKE_VAR || '2022-07',
+    storefrontApiVersion: Hydrogen.env.FAKE_VAR || '2022-07',
   },
   session: CookieSessionStorage('__session', {
     expires: new Date(1749343178614),

--- a/packages/playground/server-components/src/components/ClientEnv.client.jsx
+++ b/packages/playground/server-components/src/components/ClientEnv.client.jsx
@@ -3,8 +3,8 @@ export default function Env() {
   try {
     // This is replaced with a string at build time
     publicVariable = import.meta.env.PUBLIC_VARIABLE;
-    // This one crashes because Oxygen is not defined in browser
-    privateVariable = import.meta.env.SSR ? '' : Oxygen.env.PRIVATE_VARIABLE;
+    // This one crashes because Hydrogen is not defined in browser
+    privateVariable = import.meta.env.SSR ? '' : Hydrogen.env.PRIVATE_VARIABLE;
   } catch (error) {}
 
   return (

--- a/packages/playground/server-components/src/routes/env.server.jsx
+++ b/packages/playground/server-components/src/routes/env.server.jsx
@@ -7,7 +7,7 @@ export default function Env() {
 
       <div className="secrets-server">
         <div>PUBLIC_VARIABLE:{import.meta.env.PUBLIC_VARIABLE || ''}|</div>
-        <div>PRIVATE_VARIABLE:{Oxygen.env.PRIVATE_VARIABLE || ''}|</div>
+        <div>PRIVATE_VARIABLE:{Hydrogen.env.PRIVATE_VARIABLE || ''}|</div>
       </div>
 
       <div className="secrets-client">

--- a/packages/playground/test-utils/worker-entry.js
+++ b/packages/playground/test-utils/worker-entry.js
@@ -5,8 +5,8 @@ import {
   indexTemplate,
 } from '@shopify/hydrogen/platforms';
 
-// Mock Oxygen global
-globalThis.Oxygen = {env: globalThis};
+// Mock Hydrogen global
+globalThis.Hydrogen = {env: globalThis};
 
 async function handleAsset(url, event) {
   const response = await getAssetFromKV(event, {});

--- a/templates/demo-store/hydrogen.config.ts
+++ b/templates/demo-store/hydrogen.config.ts
@@ -6,16 +6,16 @@ export default defineConfig({
     defaultLanguageCode: 'EN',
     storeDomain:
       // @ts-ignore
-      Oxygen?.env?.PUBLIC_STORE_DOMAIN || 'hydrogen-preview.myshopify.com',
+      Hydrogen?.env?.PUBLIC_STORE_DOMAIN || 'hydrogen-preview.myshopify.com',
     storefrontToken:
       // @ts-ignore
-      Oxygen?.env?.PUBLIC_STOREFRONT_API_TOKEN ||
+      Hydrogen?.env?.PUBLIC_STOREFRONT_API_TOKEN ||
       '3b580e70970c4528da70c98e097c2fa0',
     privateStorefrontToken:
       // @ts-ignore
-      Oxygen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
+      Hydrogen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
     // @ts-ignore
-    storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
+    storefrontId: Hydrogen?.env?.PUBLIC_STOREFRONT_ID,
     storefrontApiVersion: '2022-07',
   },
   session: CookieSessionStorage('__session', {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`Oxygen.env` is now deprecated in favor of `Hydrogen.env`. Access environment variables within your server components on `Hydrogen.env`. We hope this will make more sense when deploying to non-Oxygen environments.

### Additional context

Part of https://github.com/Shopify/hydrogen/issues/1879

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
