### PR TITLE
Add overall request outcome to default logging implementation

### DIFF
--- a/.changeset/orange-spoons-cover.md
+++ b/.changeset/orange-spoons-cover.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-We changed the default logging behavior to include the overal request outcome, either `ok` or an `error`. This is necessary because a streamed request might start with a 200 HTTP response code, and during the process of stream rendering an error is encountered.
+We changed the default logging behavior to include the overall request outcome, either `ok` or an `error`. This is necessary because a streamed request might start with a 200 HTTP response code, and during the process of stream rendering an error is encountered.

--- a/.changeset/orange-spoons-cover.md
+++ b/.changeset/orange-spoons-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+We changed the default logging behavior to include the overal request outcome, either `ok` or an `error`. This is necessary because a streamed request might start with a 200 HTTP response code, and during the process of stream rendering an error is encountered.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -283,10 +283,19 @@ async function processRequest(
 
   if (isRSCRequest) {
     const buffered = await bufferReadableStream(rsc.readable.getReader());
-    postRequestTasks('rsc', 200, request, response);
+    const rscDidError = !!rsc.didError();
+    postRequestTasks(
+      'rsc',
+      rscDidError ? 500 : 200,
+      request,
+      response,
+      rscDidError
+    );
 
-    response.headers.set('cache-control', response.cacheControlHeader);
-    cacheResponse(response, request, [buffered], revalidate);
+    if (rscDidError) {
+      response.headers.set('cache-control', response.cacheControlHeader);
+      cacheResponse(response, request, [buffered], revalidate);
+    }
 
     return new Response(buffered, {
       headers: response.headers,
@@ -533,7 +542,13 @@ async function runSSR({
         // Last SSR write might be pending, delay closing the writable one tick
         setTimeout(() => {
           writable.close();
-          postRequestTasks('str', responseOptions.status, request, response);
+          postRequestTasks(
+            'str',
+            responseOptions.status,
+            request,
+            response,
+            !!didError()
+          );
           response.status = responseOptions.status;
           cacheResponse(response, request, savedChunks, revalidate);
         }, 0);
@@ -541,7 +556,13 @@ async function runSSR({
     } else {
       // Redirects do not write body
       writable.close();
-      postRequestTasks('str', responseOptions.status, request, response);
+      postRequestTasks(
+        'str',
+        responseOptions.status,
+        request,
+        response,
+        !!didError()
+      );
     }
 
     if (response.canStream()) {
@@ -601,7 +622,13 @@ async function runSSR({
           !revalidate &&
           (response.canStream() || nodeResponse.writableEnded)
         ) {
-          postRequestTasks('str', nodeResponse.statusCode, request, response);
+          postRequestTasks(
+            'str',
+            nodeResponse.statusCode,
+            request,
+            response,
+            !!didError()
+          );
           return;
         }
 
@@ -630,8 +657,15 @@ async function runSSR({
 
           if (!error) {
             html = assembleHtml({ssrHtml, rscPayload, request, template});
-            postRequestTasks('ssr', nodeResponse.statusCode, request, response);
           }
+
+          postRequestTasks(
+            'ssr',
+            nodeResponse.statusCode,
+            request,
+            response,
+            !!didError()
+          );
 
           if (!nodeResponse.writableEnded) {
             nodeResponse.write(html);
@@ -798,9 +832,10 @@ function postRequestTasks(
   type: RenderType,
   status: number,
   request: HydrogenRequest,
-  response: HydrogenResponse
+  response: HydrogenResponse,
+  didError: boolean
 ) {
-  logServerResponse(type, request, status);
+  logServerResponse(type, request, status, didError);
   logCacheControlHeaders(type, request, response);
   logQueryTimings(type, request);
   request.savePreloadQueries();

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -282,7 +282,8 @@ export async function renderApiRoute(
     logServerResponse(
       'api',
       request as HydrogenRequest,
-      (response as Response).status ?? 200
+      (response as Response).status ?? 200,
+      false
     );
   }
 

--- a/packages/hydrogen/src/utilities/log/__tests__/log.vitest.ts
+++ b/packages/hydrogen/src/utilities/log/__tests__/log.vitest.ts
@@ -100,13 +100,13 @@ describe('log', () => {
       url: 'http://localhost:3000/',
       time: 1000,
     } as HydrogenRequest;
-    logServerResponse('str', request, 500);
+    logServerResponse('str', request, 500, true);
     expect(mockedLogger.debug).toHaveBeenCalled();
     expect(mockedLogger.debug.mock.calls[0][0]).toEqual(request);
     expect(
       stripColors(mockedLogger.debug.mock.calls[0][1])
     ).toMatchInlineSnapshot(
-      '"GET streaming SSR     500 1100.00 ms http://localhost:3000/"'
+      '"GET streaming SSR     500 error 1100.00 ms http://localhost:3000/"'
     );
   });
 
@@ -116,13 +116,29 @@ describe('log', () => {
       url: 'http://localhost:3000/',
       time: 1000,
     } as HydrogenRequest;
-    logServerResponse('str', request, 200);
+    logServerResponse('str', request, 200, false);
     expect(mockedLogger.debug).toHaveBeenCalled();
     expect(mockedLogger.debug.mock.calls[0][0]).toEqual(request);
     expect(
       stripColors(mockedLogger.debug.mock.calls[0][1])
     ).toMatchInlineSnapshot(
-      '"GET streaming SSR     200 1100.00 ms http://localhost:3000/"'
+      '"GET streaming SSR     200 ok    1100.00 ms http://localhost:3000/"'
+    );
+  });
+
+  it('should log 200 server response with error', () => {
+    const request = {
+      method: 'GET',
+      url: 'http://localhost:3000/',
+      time: 1000,
+    } as HydrogenRequest;
+    logServerResponse('str', request, 200, true);
+    expect(mockedLogger.debug).toHaveBeenCalled();
+    expect(mockedLogger.debug.mock.calls[0][0]).toEqual(request);
+    expect(
+      stripColors(mockedLogger.debug.mock.calls[0][1])
+    ).toMatchInlineSnapshot(
+      '"GET streaming SSR     200 error 1100.00 ms http://localhost:3000/"'
     );
   });
 
@@ -132,13 +148,13 @@ describe('log', () => {
       url: 'http://localhost:3000/',
       time: 1000,
     } as HydrogenRequest;
-    logServerResponse('str', request, 301);
+    logServerResponse('str', request, 301, false);
     expect(mockedLogger.debug).toHaveBeenCalled();
     expect(mockedLogger.debug.mock.calls[0][0]).toEqual(request);
     expect(
       stripColors(mockedLogger.debug.mock.calls[0][1])
     ).toMatchInlineSnapshot(
-      '"GET streaming SSR     301 1100.00 ms http://localhost:3000/"'
+      '"GET streaming SSR     301 ok    1100.00 ms http://localhost:3000/"'
     );
   });
 
@@ -148,13 +164,13 @@ describe('log', () => {
       url: 'http://localhost:3000/',
       time: 1000,
     } as HydrogenRequest;
-    logServerResponse('str', request, 404);
+    logServerResponse('str', request, 404, false);
     expect(mockedLogger.debug).toHaveBeenCalled();
     expect(mockedLogger.debug.mock.calls[0][0]).toEqual(request);
     expect(
       stripColors(mockedLogger.debug.mock.calls[0][1])
     ).toMatchInlineSnapshot(
-      '"GET streaming SSR     404 1100.00 ms http://localhost:3000/"'
+      '"GET streaming SSR     404 error 1100.00 ms http://localhost:3000/"'
     );
   });
 

--- a/packages/hydrogen/src/utilities/log/log.ts
+++ b/packages/hydrogen/src/utilities/log/log.ts
@@ -124,7 +124,8 @@ const SERVER_RESPONSE_MAP: Record<string, string> = {
 export function logServerResponse(
   type: RenderType,
   request: HydrogenRequest,
-  responseStatus: number
+  responseStatus: number,
+  didError: boolean
 ) {
   const log = getLoggerWithContext(request);
   const coloredResponseStatus =
@@ -145,6 +146,8 @@ export function logServerResponse(
   const url = parseUrl(type, request.url);
 
   log.debug(
-    `${request.method} ${styledType} ${coloredResponseStatus} ${paddedTiming} ${url}`
+    `${request.method} ${styledType} ${coloredResponseStatus} ${
+      didError || responseStatus >= 400 ? red('error') : green('ok   ')
+    } ${paddedTiming} ${url}`
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We changed the default logging behavior to include the overall request outcome, either `ok` or an `error`. This is necessary because a streamed request might start with a 200 HTTP response code, and during the process of stream rendering an error is encountered.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
