### PR TITLE
Refactor `ProductProvider` test

### DIFF
--- a/packages/hydrogen-ui/src/ProductProvider.test.tsx
+++ b/packages/hydrogen-ui/src/ProductProvider.test.tsx
@@ -84,7 +84,7 @@ describe('<ProductProvider />', () => {
     await user.click(screen.getByRole('button', {name: 'White'}));
 
     expect(
-      await screen.findByText(JSON.stringify({Color: 'White', Size: 'Small'}))
+      screen.getByText(JSON.stringify({Color: 'White', Size: 'Small'}))
     ).toBeInTheDocument();
   });
 
@@ -245,16 +245,16 @@ describe('<ProductProvider />', () => {
       </ProductProvider>
     );
 
-    expect(screen.getAllByRole('button', {name: 'White'}).length).toBe(1);
+    expect(screen.getByRole('button', {name: 'White'})).toBeInTheDocument();
     expect(
-      screen.queryAllByRole('button', {name: 'White (out of stock)'}).length
-    ).toBe(0);
+      screen.queryByRole('button', {name: 'White (out of stock)'})
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', {name: 'Large'}));
 
     expect(
-      screen.queryAllByRole('button', {name: 'White (out of stock)'}).length
-    ).toBe(1);
+      screen.queryByRole('button', {name: 'White (out of stock)'})
+    ).toBeInTheDocument();
   });
 
   it('supports selecting a selling plan', async () => {
@@ -296,12 +296,12 @@ describe('<ProductProvider />', () => {
             );
           })}
           {selectedSellingPlan ? (
-            <div id="selectedSellingPlan">
+            <div data-testid="selectedSellingPlan">
               {JSON.stringify(selectedSellingPlan)}
             </div>
           ) : null}
           {selectedSellingPlanAllocation ? (
-            <div id="selectedSellingPlanAllocation">
+            <div data-testid="selectedSellingPlanAllocation">
               {JSON.stringify(selectedSellingPlanAllocation)}
             </div>
           ) : null}
@@ -314,7 +314,7 @@ describe('<ProductProvider />', () => {
       sellingPlanGroups: SELLING_PLAN_GROUPS_CONNECTION,
     });
 
-    const {container} = render(
+    render(
       <ProductProvider
         data={prod}
         initialVariantId={VARIANTS_WITH_SELLING_PLANS.nodes?.[0]?.id}
@@ -323,18 +323,23 @@ describe('<ProductProvider />', () => {
       </ProductProvider>
     );
 
-    expect(container.querySelectorAll('#selectedSellingPlan').length).toBe(0);
+    expect(screen.queryByTestId('selectedSellingPlan')).not.toBeInTheDocument();
     expect(
-      container.querySelectorAll('#selectedSellingPlanAllocation').length
-    ).toBe(0);
+      screen.queryByTestId('selectedSellingPlanAllocation')
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', {name: 'Deliver every week'}));
 
-    expect(
-      container.querySelector('#selectedSellingPlan')
-    ).not.toBeEmptyDOMElement();
-    expect(
-      container.querySelector('#selectedSellingPlanAllocation')
-    ).not.toBeEmptyDOMElement();
+    const selectedSellingPlanElement = screen.getByTestId(
+      'selectedSellingPlan'
+    );
+    const selectedSellingPlanAllocationElement = screen.getByTestId(
+      'selectedSellingPlanAllocation'
+    );
+
+    expect(selectedSellingPlanElement).toBeInTheDocument();
+    expect(selectedSellingPlanElement).not.toBeEmptyDOMElement();
+    expect(selectedSellingPlanAllocationElement).toBeInTheDocument();
+    expect(selectedSellingPlanAllocationElement).not.toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->

As discussed in https://github.com/Shopify/hydrogen/pull/2156, this PR includes a few small changes in `ProductProvider` test.

* Changes queries for elements presence
* Refactors usage of `querySelectorAll` on `container` to `getByTestId` query

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
