### PR TITLE
Fix sitemap when a product is missing a featured image

### DIFF
--- a/.changeset/fresh-dancers-mate.md
+++ b/.changeset/fresh-dancers-mate.md
@@ -1,0 +1,5 @@
+---
+'create-hydrogen-app': patch
+---
+
+The `sitemap.xml` was crashing when a product didn't contain `featuredImage` in the API data. To replicate the fix in your app, have a look at the latest version of the [`sitemap.xml.server.ts` in our demo store](https://github.com/Shopify/hydrogen/blob/v1.x-2022-07/templates/demo-store/src/routes/sitemap.xml.server.ts).

--- a/templates/demo-store/src/routes/sitemap.xml.server.ts
+++ b/templates/demo-store/src/routes/sitemap.xml.server.ts
@@ -62,7 +62,7 @@ function shopSitemap(data: SitemapQueryData, baseUrl: string) {
         changeFreq: 'daily',
       };
 
-      if (product.featuredImage!.url) {
+      if (product.featuredImage?.url) {
         finalObject.image = {
           url: product.featuredImage!.url,
         };
@@ -74,9 +74,9 @@ function shopSitemap(data: SitemapQueryData, baseUrl: string) {
         if (product.featuredImage!.altText) {
           finalObject.image.caption = product.featuredImage!.altText;
         }
-
-        return finalObject;
       }
+
+      return finalObject;
     });
 
   const collectionsData = flattenConnection(data.collections)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`product.featuredImage` can be null in certain conditions. Also, we were returning `undefined` if `product.featuredImage.url` was falsy.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
