### PR TITLE
Allow overrides for contenttype

### DIFF
--- a/.changeset/cyan-rats-bake.md
+++ b/.changeset/cyan-rats-bake.md
@@ -1,0 +1,12 @@
+---
+'@shopify/hydrogen-ui-alpha': patch
+---
+
+Updated `createStorefrontClient()`:
+
+- Completely remove `storefrontId`
+- Add ability to customize `contentType` on every invocation of `getPublicTokenHeaders()` and `getPrivateTokenHeaders()`
+- Fix and update TypeScript type explanations
+- Update README docs
+
+Also updated the README with additional docs on restarting the GraphQL server in your IDE.

--- a/packages/hydrogen-ui/README.md
+++ b/packages/hydrogen-ui/README.md
@@ -52,6 +52,8 @@ schema: node_modules/@shopify/hydrogen-ui/storefront.schema.json
 
 GraphQL autocompletion and validation will now work in `.graphql` files or in [`gql`](https://github.com/apollographql/graphql-tag) template literals!
 
+If you are having troubles getting it to work, try restarting the GraphQL server in your IDE. For example, in VSCode you can open the [command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette), type `graphql`, and select the option that says `VSCode GraphQL: Manual Restart`.
+
 ## Storefront Client
 
 To make it easier to query the Storefront API, Hydrogen-UI exposes a helper function called `createStorefrontClient()`. The client can take in either the [delegate access token](https://shopify.dev/api/storefront#authentication) as `privateStorefrontToken` - which is ideal for server-side requests to the Storefront API - or take in `publicAccessToken`. For example:
@@ -94,7 +96,21 @@ export async function getServerSideProps() {
 }
 ```
 
-If you're using TypeScript, refer to the [TypeScript](#typescript-types) section on how to improve the typing experience here as well!
+If you're using TypeScript, refer to the [TypeScript](#typescript-types) section on how to improve the typing experience here as well.
+
+### Content Type for the Storefront Client
+
+Note that the storefront client is configured to send the `"content-type": "application/json"` header by default, but you can change this default by doing:
+
+```ts
+createStorefrontClient({contentType: 'graphql', ...})
+```
+
+Alternativetly, each time you get the headers you can customize which `"content-type"` you want, just for that one invocation:
+
+```ts
+getPrivateTokenHeaders({contentType: 'graphql'});
+```
 
 ## TypeScript Types
 

--- a/packages/hydrogen-ui/src/storefront-client.test.ts
+++ b/packages/hydrogen-ui/src/storefront-client.test.ts
@@ -90,15 +90,15 @@ describe(`createStorefrontClient`, () => {
       expect(
         client.getPrivateTokenHeaders({
           privateStorefrontToken: 'newPrivate',
-          storefrontApiVersion: '2000-01',
           buyerIp: '1.1.1.1',
+          contentType: 'graphql',
         })
       ).toEqual({
         'Shopify-Storefront-Buyer-IP': '1.1.1.1',
         'Shopify-Storefront-Private-Token': 'newPrivate',
         'X-SDK-Variant': 'hydrogen-ui',
-        'X-SDK-Version': '2000-01',
-        'content-type': 'application/json',
+        'X-SDK-Version': '2022-07',
+        'content-type': 'application/graphql',
       });
     });
   });
@@ -111,8 +111,8 @@ describe(`createStorefrontClient`, () => {
 
       expect(client.getPublicTokenHeaders()).toEqual({
         'X-Shopify-Storefront-Access-Token': 'publicToken',
-        'X-SDK-Variant': 'hydrogen-ui',
         'X-SDK-Version': '2022-07',
+        'X-SDK-Variant': 'hydrogen-ui',
         'content-type': 'application/json',
       });
     });
@@ -125,13 +125,13 @@ describe(`createStorefrontClient`, () => {
       expect(
         client.getPublicTokenHeaders({
           publicStorefrontToken: 'newPublic',
-          storefrontApiVersion: '2000-01',
+          contentType: 'graphql',
         })
       ).toEqual({
         'X-Shopify-Storefront-Access-Token': 'newPublic',
+        'X-SDK-Version': '2022-07',
         'X-SDK-Variant': 'hydrogen-ui',
-        'X-SDK-Version': '2000-01',
-        'content-type': 'application/json',
+        'content-type': 'application/graphql',
       });
     });
   });


### PR DESCRIPTION
Updated `createStorefrontClient()`:

- Completely remove `storefrontId`
- Add ability to customize `contentType` on every invocation of `getPublicTokenHeaders()` and `getPrivateTokenHeaders()`
- Fix and update TypeScript type explanations
- Update README docs

Also updated the README with additional docs on restarting the GraphQL server in your IDE.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
