### PR TITLE
Fix HMR in CSS Modules

### DIFF
--- a/.changeset/green-brooms-jam.md
+++ b/.changeset/green-brooms-jam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Changing the content of a CSS Module should now trigger HMR instead of a full page refresh when using `global` CSS mode.

--- a/packages/playground/server-components/src/routes/css-modules.server.jsx
+++ b/packages/playground/server-components/src/routes/css-modules.server.jsx
@@ -1,5 +1,6 @@
 import {red} from '../style.module.css';
 import CssModulesClient from '../components/CssModules.client';
+import Counter from '../components/Counter.client';
 
 export default function CssModules() {
   return (
@@ -9,6 +10,8 @@ export default function CssModules() {
         something
       </div>
       <CssModulesClient />
+
+      <Counter />
     </>
   );
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #2092

HMR in CSS is challenging due to RSC. This skips the default Vite HMR and updates the classes in the DOM manually instead by diffing code changes in a CSS Module file.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
