### PR TITLE
[CartProviderV2] `cartFragment` prop,`data` props cart initialization and small fixes

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/CartActions.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartActions.client.tsx
@@ -60,13 +60,13 @@ import {useCartFetch} from './hooks.client.js';
  */
 export function useCartActions({
   numCartLines,
-  cartFragment = defaultCartFragment,
+  cartFragment,
   countryCode = CountryCode.Us,
 }: {
   /**  Maximum number of cart lines to fetch. Defaults to 250 cart lines. */
   numCartLines?: number;
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
-  cartFragment?: string;
+  cartFragment: string;
   /** The ISO country code for i18n. */
   countryCode?: CountryCode;
 }) {
@@ -250,104 +250,3 @@ export function useCartActions({
     ]
   );
 }
-
-export const defaultCartFragment = `
-fragment CartFragment on Cart {
-  id
-  checkoutUrl
-  totalQuantity
-  buyerIdentity {
-    countryCode
-    customer {
-      id
-      email
-      firstName
-      lastName
-      displayName
-    }
-    email
-    phone
-  }
-  lines(first: $numCartLines) {
-    edges {
-      node {
-        id
-        quantity
-        attributes {
-          key
-          value
-        }
-        cost {
-          totalAmount {
-            amount
-            currencyCode
-          }
-          compareAtAmountPerQuantity {
-            amount
-            currencyCode
-          }
-        }
-        merchandise {
-          ... on ProductVariant {
-            id
-            availableForSale
-            compareAtPriceV2 {
-              ...MoneyFragment
-            }
-            priceV2 {
-              ...MoneyFragment
-            }
-            requiresShipping
-            title
-            image {
-              ...ImageFragment
-            }
-            product {
-              handle
-              title
-            }
-            selectedOptions {
-              name
-              value
-            }
-          }
-        }
-      }
-    }
-  }
-  cost {
-    subtotalAmount {
-      ...MoneyFragment
-    }
-    totalAmount {
-      ...MoneyFragment
-    }
-    totalDutyAmount {
-      ...MoneyFragment
-    }
-    totalTaxAmount {
-      ...MoneyFragment
-    }
-  }
-  note
-  attributes {
-    key
-    value
-  }
-  discountCodes {
-    code
-  }
-}
-
-fragment MoneyFragment on MoneyV2 {
-  currencyCode
-  amount
-}
-fragment ImageFragment on Image {
-  id
-  url
-  altText
-  width
-  height
-}
-`;

--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -113,6 +113,7 @@ export function CartProviderV2({
   const [cartState, cartSend] = useCartAPIStateMachine({
     numCartLines,
     cartFragment,
+    countryCode,
     onCartActionEntry(context, event) {
       switch (event.type) {
         case 'CART_CREATE':

--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -115,23 +115,27 @@ export function CartProviderV2({
     cartFragment,
     countryCode,
     onCartActionEntry(context, event) {
-      switch (event.type) {
-        case 'CART_CREATE':
-          return onCreate?.();
-        case 'CARTLINE_ADD':
-          return onLineAdd?.();
-        case 'CARTLINE_REMOVE':
-          return onLineRemove?.();
-        case 'CARTLINE_UPDATE':
-          return onLineUpdate?.();
-        case 'NOTE_UPDATE':
-          return onNoteUpdate?.();
-        case 'BUYER_IDENTITY_UPDATE':
-          return onBuyerIdentityUpdate?.();
-        case 'CART_ATTRIBUTES_UPDATE':
-          return onAttributesUpdate?.();
-        case 'DISCOUNT_CODES_UPDATE':
-          return onDiscountCodesUpdate?.();
+      try {
+        switch (event.type) {
+          case 'CART_CREATE':
+            return onCreate?.();
+          case 'CARTLINE_ADD':
+            return onLineAdd?.();
+          case 'CARTLINE_REMOVE':
+            return onLineRemove?.();
+          case 'CARTLINE_UPDATE':
+            return onLineUpdate?.();
+          case 'NOTE_UPDATE':
+            return onNoteUpdate?.();
+          case 'BUYER_IDENTITY_UPDATE':
+            return onBuyerIdentityUpdate?.();
+          case 'CART_ATTRIBUTES_UPDATE':
+            return onAttributesUpdate?.();
+          case 'DISCOUNT_CODES_UPDATE':
+            return onDiscountCodesUpdate?.();
+        }
+      } catch (error) {
+        console.error('Cart entry action failed', error);
       }
     },
     onCartActionOptimisticUI(context, event) {
@@ -175,34 +179,38 @@ export function CartProviderV2({
     },
     onCartActionComplete(context, event) {
       const cartActionEvent = event.payload.cartActionEvent;
-      switch (event.type) {
-        case 'RESOLVE':
-          switch (cartActionEvent.type) {
-            case 'CART_CREATE':
-              publishCreateAnalytics(context, cartActionEvent);
-              return onCreateComplete?.();
-            case 'CARTLINE_ADD':
-              publishLineAddAnalytics(context, cartActionEvent);
-              return onLineAddComplete?.();
-            case 'CARTLINE_REMOVE':
-              publishLineRemoveAnalytics(context, cartActionEvent);
-              return onLineRemoveComplete?.();
-            case 'CARTLINE_UPDATE':
-              publishLineUpdateAnalytics(context, cartActionEvent);
-              return onLineUpdateComplete?.();
-            case 'NOTE_UPDATE':
-              return onNoteUpdateComplete?.();
-            case 'BUYER_IDENTITY_UPDATE':
-              if (countryCodeNotUpdated(context, cartActionEvent)) {
-                customerOverridesCountryCode.current = true;
-              }
-              return onBuyerIdentityUpdateComplete?.();
-            case 'CART_ATTRIBUTES_UPDATE':
-              return onAttributesUpdateComplete?.();
-            case 'DISCOUNT_CODES_UPDATE':
-              publishDiscountCodesUpdateAnalytics(context, cartActionEvent);
-              return onDiscountCodesUpdateComplete?.();
-          }
+      try {
+        switch (event.type) {
+          case 'RESOLVE':
+            switch (cartActionEvent.type) {
+              case 'CART_CREATE':
+                publishCreateAnalytics(context, cartActionEvent);
+                return onCreateComplete?.();
+              case 'CARTLINE_ADD':
+                publishLineAddAnalytics(context, cartActionEvent);
+                return onLineAddComplete?.();
+              case 'CARTLINE_REMOVE':
+                publishLineRemoveAnalytics(context, cartActionEvent);
+                return onLineRemoveComplete?.();
+              case 'CARTLINE_UPDATE':
+                publishLineUpdateAnalytics(context, cartActionEvent);
+                return onLineUpdateComplete?.();
+              case 'NOTE_UPDATE':
+                return onNoteUpdateComplete?.();
+              case 'BUYER_IDENTITY_UPDATE':
+                if (countryCodeNotUpdated(context, cartActionEvent)) {
+                  customerOverridesCountryCode.current = true;
+                }
+                return onBuyerIdentityUpdateComplete?.();
+              case 'CART_ATTRIBUTES_UPDATE':
+                return onAttributesUpdateComplete?.();
+              case 'DISCOUNT_CODES_UPDATE':
+                publishDiscountCodesUpdateAnalytics(context, cartActionEvent);
+                return onDiscountCodesUpdateComplete?.();
+            }
+        }
+      } catch (error) {
+        console.error('onCartActionComplete failed', error);
       }
     },
   });

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -50,8 +50,33 @@ describe('<CartProviderV2 />', () => {
     vi.spyOn(window.localStorage, 'getItem').mockReturnValue('');
   });
 
+  describe('`data` prop', () => {
+    it('uses the `data` prop if provided to initialize the cart. Taking precedence over localStorage', async () => {
+      const cartFetchSpy = vi.fn(async () => ({
+        data: {cart: cartMock},
+      }));
+      vi.spyOn(window.localStorage, 'getItem').mockReturnValue('cart-id');
+
+      mockUseCartActions.mockReturnValue({
+        cartFetch: cartFetchSpy,
+      });
+
+      const {result} = renderHook(() => useCart(), {
+        wrapper: ShopifyCartProvider({
+          data: cartMock,
+        }),
+      });
+
+      expect(cartFetchSpy).not.toBeCalled();
+      expect(result.current).toMatchObject({
+        status: 'idle',
+        ...cartFromGraphQL(cartMock),
+      });
+    });
+  });
+
   describe('local storage', () => {
-    it('fetches the cart with the cart id in local storage when initializing the app', async () => {
+    it('fetches the cart with the cart id in local storage when initializing the app if no `data` prop was given', async () => {
       const cartFetchSpy = vi.fn(async () => ({
         data: {cart: cartMock},
       }));

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -1154,7 +1154,8 @@ describe('<CartProviderV2 />', () => {
       // wait till idle
       await act(async () => {});
 
-      expect(cartCreateSpy).toBeCalledTimes(1);
+      // our setup function also is called once to create
+      expect(cartCreateSpy).toBeCalledTimes(2);
       expect(result.current).toMatchObject({
         status: 'idle',
         ...cartFromGraphQL(cartMock),

--- a/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
+++ b/packages/hydrogen/src/components/CartProvider/tests/CartProviderV2.vitest.tsx
@@ -1108,6 +1108,58 @@ describe('<CartProviderV2 />', () => {
         );
       });
     });
+
+    it('deletes local storage on complete', async () => {
+      const cartLineAddSpy = vi.fn(async () => ({
+        data: {cartLinesAdd: {cart: null}},
+      }));
+
+      const spy = vi.spyOn(window.localStorage, 'removeItem');
+
+      const result = await useCartWithInitializedCart({
+        cartLineAdd: cartLineAddSpy,
+      });
+
+      act(() => {
+        result.current.linesAdd([
+          {
+            merchandiseId: '123',
+          },
+        ]);
+      });
+
+      // wait till idle
+      await act(async () => {});
+
+      expect(spy).toHaveBeenCalledWith(CART_ID_STORAGE_KEY);
+    });
+  });
+
+  describe('creates cart', async () => {
+    it('resolves', async () => {
+      const cartCreateSpy = vi.fn(async () => ({
+        data: {cartCreate: {cart: cartMock}},
+      }));
+
+      const result = await useCartWithInitializedCart({
+        cartCreate: cartCreateSpy,
+      });
+
+      act(() => {
+        result.current.cartCreate({});
+      });
+
+      expect(result.current.status).toEqual('creating');
+
+      // wait till idle
+      await act(async () => {});
+
+      expect(cartCreateSpy).toBeCalledTimes(1);
+      expect(result.current).toMatchObject({
+        status: 'idle',
+        ...cartFromGraphQL(cartMock),
+      });
+    });
   });
 
   describe('error', () => {

--- a/packages/hydrogen/src/components/CartProvider/types.ts
+++ b/packages/hydrogen/src/components/CartProvider/types.ts
@@ -110,6 +110,13 @@ export type CartCreateEvent = {
   payload: CartInput;
 };
 
+export type CartSetEvent = {
+  type: 'CART_SET';
+  payload: {
+    cart: CartFragmentFragment;
+  };
+};
+
 export type CartLineAddEvent = {
   type: 'CARTLINE_ADD';
   payload: {
@@ -162,6 +169,7 @@ export type DiscountCodesUpdateEvent = {
 export type CartMachineActionEvent =
   | CartFetchEvent
   | CartCreateEvent
+  | CartSetEvent
   | CartLineAddEvent
   | CartLineRemoveEvent
   | CartLineUpdateEvent

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -79,6 +79,15 @@ const INITIALIZING_CART_EVENTS: StateMachine.Machine<
   CART_CREATE: {
     target: 'cartCreating',
   },
+  CART_SET: {
+    target: 'idle',
+    actions: [
+      assign({
+        rawCartResult: (_, event) => event.payload.cart,
+        cart: (_, event) => cartFromGraphQL(event.payload.cart),
+      }),
+    ],
+  },
 };
 
 const UPDATING_CART_EVENTS: StateMachine.Machine<

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -174,11 +174,10 @@ export function useCartAPIStateMachine({
     context: CartMachineContext,
     event: CartMachineFetchResultEvent
   ) => void;
-  /** A callback that is invoked after a Cart API completes. */
   /** An object with fields that correspond to the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart). */
   data?: CartFragmentFragment;
   /** A fragment used to query the Storefront API's [Cart object](https://shopify.dev/api/storefront/latest/objects/cart) for all queries and mutations. A default value is used if no argument is provided. */
-  cartFragment?: string;
+  cartFragment: string;
   /** The ISO country code for i18n. */
   countryCode?: CountryCode;
 }) {

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -136,10 +136,10 @@ const cartMachine = createMachine<
       on: INITIALIZING_CART_EVENTS,
     },
     idle: {
-      on: UPDATING_CART_EVENTS,
+      on: {...INITIALIZING_CART_EVENTS, ...UPDATING_CART_EVENTS},
     },
     error: {
-      on: UPDATING_CART_EVENTS,
+      on: {...INITIALIZING_CART_EVENTS, ...UPDATING_CART_EVENTS},
     },
     cartFetching: invokeCart('cartFetchAction', {
       errorTarget: 'initializationError',


### PR DESCRIPTION
#1947 <- the big chunk of this should be ready. QA pending.

### Contains
- `cartFragment` prop for fetching specific attributes of the cart instead of our default fragment
- `data` props for initializing the cart
-  Send country context in API requests, I was missing this prop.
-  Allow create, fetch, set cart actions when in the `idle` state just like `CartProvider`
-  Catch errors when executing custom callbacks from the user (resiliency).

