### PR TITLE
Improve Cart initialization with data props

### DIFF
--- a/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProviderV2.client.tsx
@@ -112,6 +112,7 @@ export function CartProviderV2({
 
   const [cartState, cartSend] = useCartAPIStateMachine({
     numCartLines,
+    data: cart,
     cartFragment,
     countryCode,
     onCartActionEntry(context, event) {
@@ -232,9 +233,7 @@ export function CartProviderV2({
    */
   useEffect(() => {
     if (!cartReady.current) {
-      if (cart) {
-        cartSend({type: 'CART_SET', payload: {cart}});
-      } else if (storageAvailable('localStorage')) {
+      if (!cart && storageAvailable('localStorage')) {
         try {
           const cartId = window.localStorage.getItem(CART_ID_STORAGE_KEY);
           if (cartId) {

--- a/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/useCartAPIStateMachine.client.tsx
@@ -118,44 +118,49 @@ const UPDATING_CART_EVENTS: StateMachine.Machine<
   },
 };
 
-const cartMachine = createMachine<
-  CartMachineContext,
-  CartMachineEvent,
-  CartMachineTypeState
->({
-  id: 'Cart',
-  initial: 'uninitialized',
-  states: {
-    uninitialized: {
-      on: INITIALIZING_CART_EVENTS,
+function createCartMachine(initialCart?: CartFragmentFragment) {
+  return createMachine<
+    CartMachineContext,
+    CartMachineEvent,
+    CartMachineTypeState
+  >({
+    id: 'Cart',
+    initial: initialCart ? 'idle' : 'uninitialized',
+    context: {
+      cart: initialCart && cartFromGraphQL(initialCart),
     },
-    cartCompleted: {
-      on: INITIALIZING_CART_EVENTS,
+    states: {
+      uninitialized: {
+        on: INITIALIZING_CART_EVENTS,
+      },
+      cartCompleted: {
+        on: INITIALIZING_CART_EVENTS,
+      },
+      initializationError: {
+        on: INITIALIZING_CART_EVENTS,
+      },
+      idle: {
+        on: {...INITIALIZING_CART_EVENTS, ...UPDATING_CART_EVENTS},
+      },
+      error: {
+        on: {...INITIALIZING_CART_EVENTS, ...UPDATING_CART_EVENTS},
+      },
+      cartFetching: invokeCart('cartFetchAction', {
+        errorTarget: 'initializationError',
+      }),
+      cartCreating: invokeCart('cartCreateAction', {
+        errorTarget: 'initializationError',
+      }),
+      cartLineRemoving: invokeCart('cartLineRemoveAction'),
+      cartLineUpdating: invokeCart('cartLineUpdateAction'),
+      cartLineAdding: invokeCart('cartLineAddAction'),
+      noteUpdating: invokeCart('noteUpdateAction'),
+      buyerIdentityUpdating: invokeCart('buyerIdentityUpdateAction'),
+      cartAttributesUpdating: invokeCart('cartAttributesUpdateAction'),
+      discountCodesUpdating: invokeCart('discountCodesUpdateAction'),
     },
-    initializationError: {
-      on: INITIALIZING_CART_EVENTS,
-    },
-    idle: {
-      on: {...INITIALIZING_CART_EVENTS, ...UPDATING_CART_EVENTS},
-    },
-    error: {
-      on: {...INITIALIZING_CART_EVENTS, ...UPDATING_CART_EVENTS},
-    },
-    cartFetching: invokeCart('cartFetchAction', {
-      errorTarget: 'initializationError',
-    }),
-    cartCreating: invokeCart('cartCreateAction', {
-      errorTarget: 'initializationError',
-    }),
-    cartLineRemoving: invokeCart('cartLineRemoveAction'),
-    cartLineUpdating: invokeCart('cartLineUpdateAction'),
-    cartLineAdding: invokeCart('cartLineAddAction'),
-    noteUpdating: invokeCart('noteUpdateAction'),
-    buyerIdentityUpdating: invokeCart('buyerIdentityUpdateAction'),
-    cartAttributesUpdating: invokeCart('cartAttributesUpdateAction'),
-    discountCodesUpdating: invokeCart('discountCodesUpdateAction'),
-  },
-});
+  });
+}
 
 export function useCartAPIStateMachine({
   numCartLines,
@@ -205,6 +210,8 @@ export function useCartAPIStateMachine({
     cartFragment,
     countryCode,
   });
+
+  const cartMachine = useMemo(() => createCartMachine(cart), [cart]);
 
   const [state, send, service] = useMachine(cartMachine, {
     actions: {


### PR DESCRIPTION
#1947 Improvements

### Description
Improve the initialization of the cart state machine

### Additional context
When using `CartProvider` with the `data` props:
Originally I used the `SET` action when initializing the state machine. This made a cart always start on an uninitialized state which had the side-effect of adding a full react render cycle.

Now I use `useMemo` and to keep the same state machine given a `data` prop.
