### PR TITLE
Fix `@shopify/hydrogen/experimental` imports

### DIFF
--- a/.changeset/large-ties-love.md
+++ b/.changeset/large-ties-love.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix imports from `@shopify/hydrogen/experimental` at build time. Previously, importing from this path would end up in unresolved client components.

--- a/packages/hydrogen/CHANGELOG.md
+++ b/packages/hydrogen/CHANGELOG.md
@@ -325,7 +325,7 @@ If your Store is based on the "Demo Store" tempate, and you are using the `test:
   } from '@shopify/hydrogen/platforms';
 
   // Platform entry handler
-  export default function(request) {
+  export default function (request) {
     if (isAsset(new URL(request.url).pathname)) {
       return platformAssetHandler(request);
     }

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -13,10 +13,7 @@
   "main": "dist/esnext/index.js",
   "exports": {
     ".": "./dist/esnext/index.js",
-    "./experimental": {
-      "import": "./dist/esnext/experimental.js",
-      "require": "./dist/node/experimental.js"
-    },
+    "./experimental": "./dist/esnext/experimental.js",
     "./plugin": {
       "import": "./dist/esnext/framework/plugin.js",
       "require": "./dist/node/framework/plugin.js"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1928

This makes tests in https://github.com/Shopify/hydrogen/pull/2194 pass (cc @juanpprieto )

In-app logic such as components and hooks should **always** be imported from the `esnext` build. In fact, we don't even create `dist/node/<in-app-stuff>`.

The RSC plugin at some point runs `require.resolve('@shopify/hydrogen/experimental')` and, since we are running in the CJS version of Vite, it was resolving to `@shopify/hydrogen/dist/node/experimental.js` instead of `@shopify/hydrogen/dist/esnext/experimental.js`. With this change, it always resolves to the latter.

We can't run the ESM version of Vite until we migrate user apps to `type: "module"`.

@frehner Tagging you here because I think this might be interesting for you.


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
