### PR TITLE
refactor (client: BrowserRouter) url hash changes should not emit querySelector error

### DIFF
--- a/.changeset/empty-moles-work.md
+++ b/.changeset/empty-moles-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Prevent unhandled errors when `location.hash` is not a valid element selector for scrolling.

--- a/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
+++ b/packages/hydrogen/src/foundation/Router/BrowserRouter.client.tsx
@@ -177,7 +177,12 @@ function useScrollRestoration({
 
     // If there is a location hash, scroll to it
     if (location.hash) {
-      const element = document.querySelector(location.hash);
+      let element;
+      try {
+        element = document.querySelector(location.hash);
+      } catch (err) {
+        // Do nothing, hash may not be a valid selector
+      }
       if (element) {
         element.scrollIntoView();
         onFinishNavigating();


### PR DESCRIPTION
### Description

<!-- Insert your description here and provide info about what issue this PR is solving -->
Adds a `try/catch` around the `BrowserRouter` hash change that assumes the location.hash is a valid querySelector. 

When you add a url hash that is an invalid querySelector (ex: `example.com/#/video/12`) the you'll see a halting error

```
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#video/12' is not a valid selector.
```

<img width="711" alt="Screen Shot 2022-10-04 at 11 38 13 AM" src="https://user-images.githubusercontent.com/468002/193899111-893743cf-6c19-4661-bce9-4b3058201222.png">

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
