### PR TITLE
Fix platform entry resolution in CI

### DIFF
--- a/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
+++ b/packages/hydrogen/src/framework/plugins/vite-plugin-platform-entry.ts
@@ -68,7 +68,7 @@ export default () => {
       if (
         config.command === 'build' &&
         options?.ssr &&
-        /@shopify\/hydrogen\/.+platforms\/virtual\./.test(normalizePath(id))
+        /\/hydrogen\/.+platforms\/virtual\./.test(normalizePath(id))
       ) {
         const ms = new MagicString(code);
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Our Netlify deployment workflow [is broken](https://github.com/Shopify/hydrogen/actions/runs/3188301092/jobs/5201399762).
Netlify has updated their plugin to use our `@shopify/hydrgen/virtual` entry point. Turns out in this repo, the Netlify build is not accessing `node_modules/@shopify/hydrogen/dist` but `packages/hydrogen/dist`, and this doesn't match some of our internal RegExps.

Trying to make it work here.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
