### PR TITLE
Use Custom-Storefront-Request-Group-ID in useShopQuery

### DIFF
--- a/.changeset/thirty-ladybugs-explain.md
+++ b/.changeset/thirty-ladybugs-explain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Requests to SF API will now provide a Custom-Storefront-Group-ID header.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -47,6 +47,7 @@ import {DevTools} from './foundation/DevTools/DevTools.server.js';
 import {getSyncSessionApi} from './foundation/session/session.js';
 import {parseJSON} from './utilities/parse.js';
 import {htmlEncode} from './utilities/index.js';
+import {generateUUID} from './utilities/random.js';
 import {splitCookiesString} from 'set-cookie-parser';
 import {
   deleteItemFromCache,
@@ -108,11 +109,24 @@ export const renderHydrogen = (App: any) => {
     request.ctx.hydrogenConfig = hydrogenConfig;
     request.ctx.buyerIpHeader = buyerIpHeader;
 
+    const platformRequestID = request.headers.get('request-id');
+    if (platformRequestID) {
+      request.ctx.requestGroupID = platformRequestID;
+    } else {
+      request.ctx.requestGroupID = generateUUID();
+    }
+
     setLogger(hydrogenConfig.logger);
     const log = getLoggerWithContext(request);
 
+    const responseHeaders = new Headers(headers);
+    responseHeaders.set(
+      'Custom-Storefront-Request-Group-ID',
+      request.ctx.requestGroupID
+    );
+
     const response = new HydrogenResponse(request.url, null, {
-      headers: headers || {},
+      headers: responseHeaders,
     });
 
     if (request.cookies.get(FORM_REDIRECT_COOKIE)) {

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -16,6 +16,7 @@ import {HelmetData as HeadData} from 'react-helmet-async';
 import {RSC_PATHNAME} from '../../constants.js';
 import type {SessionSyncApi} from '../session/session-types.js';
 import {parseJSON} from '../../utilities/parse.js';
+import {generateUUID} from '../../utilities/random.js';
 
 export type PreloadQueryEntry = {
   key: QueryKey;
@@ -29,15 +30,6 @@ export type RouterContextData = {
   serverProps: Record<string, any>;
   routeParams: Record<string, string>;
 };
-
-let reqCounter = 0; // For debugging
-const generateId =
-  typeof crypto !== 'undefined' &&
-  // @ts-ignore
-  !!crypto.randomUUID
-    ? // @ts-ignore
-      () => crypto.randomUUID() as string
-    : () => `req${++reqCounter}`;
 
 // Stores queries by url or '*'
 const preloadCache: AllPreloadQueries = new Map();
@@ -81,6 +73,7 @@ export class HydrogenRequest extends Request {
     runtime?: RuntimeContext;
     scopes: Map<string, Record<string, any>>;
     localization?: LocalizationContextValue;
+    requestGroupID?: string;
     [key: string]: any;
     throttledRequests: Record<string, any>;
   };
@@ -95,7 +88,7 @@ export class HydrogenRequest extends Request {
     }
 
     this.time = getTime();
-    this.id = generateId();
+    this.id = generateUUID();
     this.normalizedUrl = decodeURIComponent(
       this.isRscRequest() ? normalizeUrl(this.url) : this.url
     );

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -224,6 +224,16 @@ function useCreateShopRequest(body: string) {
   const request = useServerRequest();
   const buyerIp = request.getBuyerIp();
 
+  let headers: Record<string, string> = {
+    'X-SDK-Variant': 'hydrogen',
+    'X-SDK-Version': storefrontApiVersion,
+    'content-type': 'application/json',
+  };
+
+  if (request.ctx.requestGroupID) {
+    headers['Custom-Storefront-Request-Group-ID'] = request.ctx.requestGroupID;
+  }
+
   const extraHeaders = getStorefrontApiRequestHeaders({
     buyerIp,
     publicStorefrontToken: storefrontToken,
@@ -231,18 +241,15 @@ function useCreateShopRequest(body: string) {
     storefrontId,
   });
 
+  headers = {...headers, ...extraHeaders};
+
   return {
     key: [storeDomain, storefrontApiVersion, body],
     url: `https://${storeDomain}/api/${storefrontApiVersion}/graphql.json`,
     requestInit: {
       body,
       method: 'POST',
-      headers: {
-        'X-SDK-Variant': 'hydrogen',
-        'X-SDK-Version': storefrontApiVersion,
-        'content-type': 'application/json',
-        ...extraHeaders,
-      },
+      headers,
     },
   };
 }

--- a/packages/hydrogen/src/utilities/random.ts
+++ b/packages/hydrogen/src/utilities/random.ts
@@ -1,0 +1,10 @@
+/*
+ * Generate a UUID using crypto and fallback to Math.random if crypto is not available.
+ */
+export function generateUUID() {
+  if (typeof crypto !== 'undefined' && !!crypto.randomUUID) {
+    return crypto.randomUUID();
+  } else {
+    return `weak-${Math.random().toString(16).substring(2)}`;
+  }
+}


### PR DESCRIPTION
### Description

Provide a group ID to storefront API requests to enable mapping parts of the RSC request to their underlying storefront API requests.

Use an existing Request-ID as the group ID if provided by the platform.

The Shopify-Storefront-Request-Group-ID header can be provided during a technical support inquiry to aid in the process.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
