### PR TITLE
Hydrogen: fix broken links

### DIFF
--- a/docs/framework/authentication.md
+++ b/docs/framework/authentication.md
@@ -56,7 +56,7 @@ Pages that require authentication shouldn't be indexed by bots. For example, bot
 
 ## Next steps
 
-- Learn how to [manage customer accounts](https://shopify.dev/api/examples/customer-accounts) with the Storefront API.
+- Learn how to [manage customer accounts](https://shopify.dev/custom-storefronts/customer-accounts) with the Storefront API.
 - Get familiar with the [file-based routing system](https://shopify.dev/custom-storefronts/hydrogen/framework/routes) that Hydrogen uses.
 - Learn about the Hydrogen framework's built-in support for [session management](https://shopify.dev/custom-storefronts/hydrogen/framework/sessions).
 - Learn how to customize the output of [SEO-related tags](https://shopify.dev/custom-storefronts/hydrogen/framework/seo) in your Hydrogen client and server components.

--- a/docs/framework/internationalization.md
+++ b/docs/framework/internationalization.md
@@ -17,7 +17,7 @@ Hydrogen includes the following components and hooks for localization:
 - **[`useLocalization`](https://shopify.dev/api/hydrogen/hooks/localization/uselocalization)**: A hook that returns the locale, country, and language of the current page.
 
 > Note:
-> Any descendents of `ShopifyProvider` can use the `useLocalization` hook. The `isoCode` of the `country` can be used in the Storefront API's [`@inContext` directive](https://shopify.dev/api/examples/international-pricing) as the `country` value.
+> Any descendants of `ShopifyProvider` can use the `useLocalization` hook. The `isoCode` of the `country` can be used in the Storefront API's [`@inContext` directive](https://shopify.dev/custom-storefronts/internationalization/international-pricing) as the `country` value.
 
 ### Default configuration
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `/api/examples` pages are gone. I've adjusted the links to custom-storefront api examples to go to the correct location

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
