### PR TITLE
fix(2233): added faker dep

### DIFF
--- a/.changeset/moody-dots-march.md
+++ b/.changeset/moody-dots-march.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': minor
 ---
 
-Removed undeclared dependancy on faker from ShopifyTestProviders
+Added missing dependancy for faker to hydrogen package

--- a/.changeset/moody-dots-march.md
+++ b/.changeset/moody-dots-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Removed undeclared dependancy on faker from ShopifyTestProviders

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -103,6 +103,7 @@
     "babel-loader": "^8.2.2",
     "cpy-cli": "^3.1.0",
     "eslint-plugin-import": "^2.26.0",
+    "faker": "^6.6.6",
     "happy-dom": "^6.0.4",
     "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -103,7 +103,7 @@
     "babel-loader": "^8.2.2",
     "cpy-cli": "^3.1.0",
     "eslint-plugin-import": "^2.26.0",
-    "faker": "^6.6.6",
+    "faker": "^5.5.3",
     "happy-dom": "^6.0.4",
     "mkdirp": "^1.0.4",
     "npm-run-all": "^4.1.5",

--- a/packages/hydrogen/src/utilities/tests/media.ts
+++ b/packages/hydrogen/src/utilities/tests/media.ts
@@ -7,7 +7,6 @@ import {
   MediaHost,
   Model3d,
 } from '../../storefront-api-types.js';
-// eslint-disable-next-line node/no-extraneous-import
 import faker from 'faker';
 import type {PartialDeep} from 'type-fest';
 

--- a/packages/hydrogen/src/utilities/tests/metafields.ts
+++ b/packages/hydrogen/src/utilities/tests/metafields.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-extraneous-import
 import faker from 'faker';
 import type {Metafield} from '../../storefront-api-types.js';
 import type {PartialDeep} from 'type-fest';

--- a/packages/hydrogen/src/utilities/tests/price.ts
+++ b/packages/hydrogen/src/utilities/tests/price.ts
@@ -1,10 +1,9 @@
 // eslint-disable-next-line node/no-extraneous-import
-import faker from 'faker';
 import {CurrencyCode, MoneyV2} from '../../storefront-api-types.js';
 
 export function getPrice(price: Partial<MoneyV2> = {}) {
   return {
     currencyCode: price.currencyCode ?? CurrencyCode.Cad,
-    amount: price.amount ?? faker.finance.amount(),
+    amount: price.amount ?? '9.99',
   };
 }

--- a/packages/hydrogen/src/utilities/tests/price.ts
+++ b/packages/hydrogen/src/utilities/tests/price.ts
@@ -1,9 +1,9 @@
-// eslint-disable-next-line node/no-extraneous-import
+import faker from 'faker';
 import {CurrencyCode, MoneyV2} from '../../storefront-api-types.js';
 
 export function getPrice(price: Partial<MoneyV2> = {}) {
   return {
     currencyCode: price.currencyCode ?? CurrencyCode.Cad,
-    amount: price.amount ?? '9.99',
+    amount: price.amount ?? faker.finance.amount(),
   };
 }

--- a/packages/hydrogen/src/utilities/tests/product.ts
+++ b/packages/hydrogen/src/utilities/tests/product.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-extraneous-import
 import faker from 'faker';
 import {getPrice} from './price.js';
 import {getUnitPriceMeasurement} from './unitPriceMeasurement.js';

--- a/packages/hydrogen/src/utilities/tests/unitPriceMeasurement.ts
+++ b/packages/hydrogen/src/utilities/tests/unitPriceMeasurement.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/no-extraneous-import
 import faker from 'faker';
 import {
   UnitPriceMeasurementMeasuredUnit,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8212,11 +8212,6 @@ faker@^5.5.3:
   resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
   integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
-faker@^6.6.6:
-  version "6.6.6"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-6.6.6.tgz#e9529da0109dca4c7c5dbfeaadbd9234af943033"
-  integrity sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8212,6 +8212,11 @@ faker@^5.5.3:
   resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
   integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
+faker@^6.6.6:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-6.6.6.tgz#e9529da0109dca4c7c5dbfeaadbd9234af943033"
+  integrity sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
[Original Issue](https://github.com/Shopify/hydrogen/issues/2233)
As of Hydrogen 1.5.0 a bug has been introduced to the new ShopifyTestProviders HOC including this in a project via the import
import {ShopifyTestProviders} from '@shopify/hydrogen/testing';

Will cause builds to throw errors such as the one below.
✘ [ERROR] [plugin vite:dep-pre-bundle] Failed to resolve entry for package "faker". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "faker". The package may have incorrect main/module/exports specified in its package.json.

This is because /packages/hydrogen/src/utilities/tests/price.ts includes faker as a dependency in order to create a randomised amount value for the getPrice function.

As this dependency is not declared in /packages/hydrogen/package.json this creates an undeclared dep.

### Additional context

I have resolved the issue by adding faker (using the same version as the rest of the repo) as a dev dependency of the hydrogen package and removing any node/no-extraneous-import rules imposed in the utilities/tests.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
