### PR TITLE
Add useProduct beta doc

### DIFF
--- a/docs/hooks/product-variant/useproduct.md
+++ b/docs/hooks/product-variant/useproduct.md
@@ -1,0 +1,175 @@
+---
+gid: c850ae3e-fafd-11eb-9a03-0242ac130005
+title: useProduct
+description: The useProduct hook returns an object that enables you to keep track of the selected variant and/or selling plan state, as well as callbacks for modifying the state.
+---
+
+> Note:
+> `useProduct` is only available as part of the [Hydrogen UI](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions)
+
+The `useProduct` hook returns an object that enables you to keep track of the
+selected variant and/or selling plan state, as well as callbacks for modifying the state. The `useProduct` hook must be a child of the [`ProductProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productprovider) component.
+
+## Example code
+
+```tsx
+/**
+ * Iterate through a list of variants and allow the customer to select a specific variant.
+ */
+import {useProduct} from '@shopify/hydrogen-react';
+
+export function MyComponent() {
+  const {variants, selectedVariant, setSelectedVariant} = useProduct();
+
+  return (
+    <>
+      <label htmlFor="variants">Select a variant</label>
+      <select
+        id="variants"
+        name="variants"
+        value={selectedVariant?.id}
+        onChange={(e) =>
+          setSelectedVariant(
+            variants.find((variant) => variant.id === e.target.value)
+          )
+        }
+      >
+        {variants.map((variant) => (
+          <option key={variant.id} value={variant.id}>
+            {variant.title}
+          </option>
+        ))}
+      </select>
+    </>
+  );
+}
+```
+
+```tsx
+/**
+ * Support selling plans. You should display a selling plan selector to a user
+ * when a product has selling plans enabled. You need to pass `sellingPlanGroups` to the hook.
+ */
+import {useProduct} from '@shopify/hydrogen-react';
+
+export function MyComponent() {
+  const {
+    selectedSellingPlan,
+    setSelectedSellingPlan,
+    selectedSellingPlanAllocation,
+    sellingPlanGroups,
+  } = useProduct({
+    variants: product.variants,
+    sellingPlanGroups: product.sellingPlanGroups,
+    initialVariantId: product.variants.edges[0].node.id,
+  });
+
+  return (
+    <>
+      {/* Code for your variant selector goes here */}
+
+      {sellingPlanGroups.map((sellingPlanGroup) => (
+        <div key={sellingPlanGroup.id}>
+          <h2>{sellingPlanGroup.name}</h2>
+          <ul>
+            {sellingPlanGroup.sellingPlans.map((sellingPlan) => {
+              return (
+                <li key={sellingPlan.id}>
+                  <button onClick={() => setSelectedSellingPlan(sellingPlan)}>
+                    {sellingPlan.name}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </>
+  );
+}
+```
+
+```tsx
+/**
+ * Use product options.
+ */
+import {useProduct} from '@shopify/hydrogen-react';
+
+export function MyComponent() {
+  const {options, selectedVariant, selectedOptions, setSelectedOption} =
+    useProduct({variants: product.variants});
+
+  return (
+    <>
+      {options.map(({name, values}) => (
+        <fieldset key={name}>
+          <legend>{name}</legend>
+          {values.map((value) => (
+            <label htmlFor={`option[${name}][${value}]`}>
+              <input
+                type="radio"
+                id={`option[${name}][${value}]`}
+                name={`option[${name}]`}
+                checked={selectedOptions[name] === value}
+                onChange={() => setSelectedOption(name, value)}
+              />
+              {value}
+            </label>
+          ))}
+        </fieldset>
+      ))}
+    </>
+  );
+}
+```
+
+### Considerations
+
+- To make sure you have all the data necessary for the `useProduct` hook, refer to the Storefront API's [ProductVariant object](https://shopify.dev/api/storefront/latest/objects/ProductVariant).
+- If your product requires a selling plan, then make sure to display that as required in your user interface. If it doesn't require a selling plan, then you might want to offer a "one-time purchase" option which triggers `setSelectedSellingPlan(null)`.
+- You can use `selectedSellingPlanAllocation` to display the price adjustments for the selected variant when a given selling plan is active.
+- You can manually deselect a variant by calling `setSelectedVariant(null)`.
+
+## Arguments
+
+This hook takes a single object with the following keys:
+
+| Key                | Type                                                         | Description                        |
+| ------------------ | ------------------------------------------------------------ | ---------------------------------- |
+| variants?          | <code>PartialDeep&#60;ProductVariantConnection&#62;</code>   | The product's `VariantConnection`. |
+| sellingPlanGroups? | <code>PartialDeep&#60;SellingPlanGroupConnection&#62;</code> | The product's `SellingPlanGroups`. |
+| initialVariantId?  | <code>ProductVariantType['id']</code>                        | The initially selected variant.    |
+
+## Return value
+
+This hook returns a single object with the following keys:
+
+| Key                             | Description                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------------- |
+| `variants`                      | An array of the variant `nodes` from the `VariantConnection`.                 |
+| `options`                       | An array of the product's options and values.                                 |
+| `selectedVariant`               | The selected variant.                                                         |
+| `setSelectedVariant`            | A callback to set the selected variant to the variant passed as an argument.  |
+| `selectedOptions`               | The current selected options.                                                 |
+| `setSelectedOption`             | A callback to set the selected option.                                        |
+| `setSelectedOptions`            | A callback to set multiple selected options at once.                          |
+| `isOptionInStock`               | A callback that returns a boolean indicating if the option is in stock.       |
+| `setSelectedSellingPlan`        | A callback to set the selected selling plan to the one passed as an argument. |
+| `selectedSellingPlan`           | The selected selling plan.                                                    |
+| `selectedSellingPlanAllocation` | The selected selling plan allocation.                                         |
+| `sellingPlanGroups`             | The selling plan groups.                                                      |
+
+### Variables
+
+The [Product object](https://shopify.dev/api/storefront/reference/products/product) includes variables that you will need to provide values for when performing your query.
+
+| Variable                                   | Description                                                                                           |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `$numProductVariantMetafields`             | The number of `Metafield` objects to query for in a variant's `MetafieldConnection`.                  |
+| `$numProductVariantSellingPlanAllocations` | The number of `SellingPlanAllocations` to query for in a variant's `SellingPlanAllocationConnection`. |
+| `$numProductSellingPlanGroups`             | The number of `SellingPlanGroups` objects to query for in a `SellingPlanGroupConnection`.             |
+| `$$numProductSellingPlans`                 | The number of `SellingPlan` objects to query for in a `SellingPlanConnection`.                        |
+
+## Related components
+
+- [`ProductProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productprovider)


### PR DESCRIPTION
### Description

Hydrogen UI includes a useProduct component that isn't part of Hydrogen, although it copies the existing component API from useProductOptions. This PR ensures there's a reference doc for this hook on Shopify.dev.

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
