### PR TITLE
Fix top level async breaks with routes that don't stream

### DIFF
--- a/.changeset/strange-radios-deliver.md
+++ b/.changeset/strange-radios-deliver.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix a critical issue where a top level asynchronous request within `App.server.jsx` would break if subsequent routes attempt to disable streaming.

--- a/packages/playground/server-components/src/App.server.jsx
+++ b/packages/playground/server-components/src/App.server.jsx
@@ -5,6 +5,8 @@ import {
   FileRoutes,
   ShopifyProvider,
   useRequestContext,
+  useUrl,
+  useSession,
 } from '@shopify/hydrogen';
 import {Suspense} from 'react';
 import Custom1 from './customRoutes/custom1.server';
@@ -15,6 +17,11 @@ import ServerParams from './customRoutes/params.server';
 export default renderHydrogen(({request, response}) => {
   if (request.headers.get('user-agent') === 'custom bot') {
     response.doNotStream();
+  }
+
+  const url = useUrl();
+  if (url.href.includes('top-level-async')) {
+    useSession();
   }
 
   useRequestContext().test1 = true;

--- a/packages/playground/server-components/src/routes/top-level-async.server.jsx
+++ b/packages/playground/server-components/src/routes/top-level-async.server.jsx
@@ -1,0 +1,4 @@
+export default function topLevelAsync({response}) {
+  response.doNotStream();
+  return <div>Hello!</div>;
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -155,6 +155,14 @@ export default async function testCases({
     expect(body).toContain('>footer!<');
   });
 
+  it('disables streaming with a top level async operation', async () => {
+    const response = await fetch(getServerUrl() + '/top-level-async').then(
+      (resp) => resp.text()
+    );
+
+    expect(response).toContain('<meta data-flight="S2');
+  });
+
   it('streams if server component calls doNotStream after stream has already started', async () => {
     const response = await fetch(getServerUrl() + '/midwaynostream');
     const streamedChunks = [];


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix a critical issue where a top level asynchronous request within `App.server.jsx` would break if subsequent routes attempt to disable streaming. For example:

```ts
// App.server.jsx
export default renderHydrogen() {
  useSession(); 
  ...
}

// NotFound.server.jsx
export default function NotFound({response}) {
  resonse.doNotStream();
  ...
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
