### PR TITLE
Update useCartLine docs

### DIFF
--- a/docs/hooks/cart/usecartline.md
+++ b/docs/hooks/cart/usecartline.md
@@ -9,7 +9,12 @@ The `useCartLine` hook provides access to the cart line object. It must be a des
 ## Example code
 
 ```tsx
-import {CartLineProvider, useCartLine, useCart} from '@shopify/hydrogen';
+import {
+  CartLinePrice,
+  CartLineProvider,
+  useCartLine,
+  useCart,
+} from '@shopify/hydrogen';
 
 export function MyComponent() {
   const {lines} = useCart();
@@ -24,13 +29,18 @@ export function MyComponent() {
 }
 
 export function CartLineItem() {
-  const {price, productTitle, quantity} = useCartLine();
+  const {
+    quantity,
+    merchandise: {
+      product: { title },
+    },
+  } = useCartLine();
 
   return (
     <>
-      <h2>{productTitle}</h2>
-      <span>{price}</span>
+      <h2>{title}</h2>
       <span>{quantity}</span>
+      <CartLinePrice as="span" />
     </>
   );
 }


### PR DESCRIPTION
### Description

[useCartLine](https://shopify.dev/api/hydrogen/hooks/cart/usecartline) docs are out of date. Reported in [Partner Slack](https://shopifypartners.slack.com/archives/C02F94JC3QC/p1667344092012709).

![image](https://user-images.githubusercontent.com/59898611/199818418-55416739-7925-45ab-8942-54ed88c21ec9.png)

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
