### PR TITLE
Fix unhandled errors when parsing invalid RSC state

### DIFF
--- a/.changeset/thick-ladybugs-hug.md
+++ b/.changeset/thick-ladybugs-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix unhandled errors when parsing invalid RSC states from URL.

--- a/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
+++ b/packages/hydrogen/src/foundation/HydrogenRequest/HydrogenRequest.server.ts
@@ -15,7 +15,7 @@ import {hashKey} from '../../utilities/hash.js';
 import {HelmetData as HeadData} from 'react-helmet-async';
 import {RSC_PATHNAME} from '../../constants.js';
 import type {SessionSyncApi} from '../session/session-types.js';
-import {parseJSON} from '../../utilities/parse.js';
+import {parseState} from '../../utilities/parse.js';
 import {generateUUID} from '../../utilities/random.js';
 
 export type PreloadQueryEntry = {
@@ -281,7 +281,9 @@ function getInitFromNodeRequest(request: any) {
 
 function normalizeUrl(rawUrl: string) {
   const url = new URL(rawUrl);
-  const state = parseJSON(url.searchParams.get('state') ?? '');
+  const state = parseState(url);
+  if (!state) return '';
+
   const normalizedUrl = new URL(state?.pathname ?? '', url.origin);
   normalizedUrl.search = state?.search;
 

--- a/packages/hydrogen/src/foundation/useUrl/useUrl.ts
+++ b/packages/hydrogen/src/foundation/useUrl/useUrl.ts
@@ -1,6 +1,6 @@
 import {useContext, useMemo} from 'react';
 import {RSC_PATHNAME} from '../../constants.js';
-import {parseJSON} from '../../utilities/parse.js';
+import {parseState} from '../../utilities/parse.js';
 import {RouterContext} from '../Router/BrowserRouter.client.js';
 import {useEnvContext, META_ENV_SSR} from '../ssr-interop.js';
 
@@ -14,10 +14,10 @@ export function useUrl(): URL {
     );
 
     if (serverUrl.pathname === RSC_PATHNAME) {
-      const state = parseJSON(serverUrl.searchParams.get('state') || '{}');
+      const state = parseState(serverUrl);
 
-      const parsedUrl = `${serverUrl.origin}${state.pathname ?? ''}${
-        state.search ?? ''
+      const parsedUrl = `${serverUrl.origin}${state?.pathname ?? ''}${
+        state?.search ?? ''
       }`;
 
       return new URL(parsedUrl);

--- a/packages/hydrogen/src/utilities/parse.ts
+++ b/packages/hydrogen/src/utilities/parse.ts
@@ -5,3 +5,11 @@ export function parseJSON(json: any) {
 function noproto(k: string, v: string) {
   if (k !== '__proto__') return v;
 }
+
+export function parseState(url: URL) {
+  try {
+    return parseJSON(url.searchParams.get('state') ?? '');
+  } catch {
+    // Do not throw to prevent unhandled errors
+  }
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -106,6 +106,11 @@ export default async function testCases({
     expect(scopedContext).toContain('{"test2":true}');
   });
 
+  it('it responds with error when RSC state is invalid', async () => {
+    const response = await fetch(getServerUrl() + '/__rsc?state=invalid{state');
+    expect(response.status).toEqual(400);
+  });
+
   it.skip('should render server props in client component', async () => {
     await page.goto(getServerUrl() + '/test-server-props');
     expect(await page.textContent('#server-props')).toMatchInlineSnapshot(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/Shopify/hydrogen/issues/1863

Parsing invalid JSON from the RSC state param could crash the server. This PR changes it to ignore the JSON parsing errors and returns 400 response instead.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
