### PR TITLE
Fix preload cache ballooning

### DIFF
--- a/.changeset/gold-papayas-grin.md
+++ b/.changeset/gold-papayas-grin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix issue with preload cache which would cause problems when scaled to large amounts of traffic in production.

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -155,6 +155,9 @@ export function preloadRequestCacheData(request: HydrogenRequest): void {
   const preloadQueries = request.getPreloadQueries();
   const {cache} = request.ctx;
 
+  // TODO: Remove before shipping
+  console.log(preloadQueries?.size ?? 0, 'preloaded queries');
+
   preloadQueries?.forEach((preloadQuery, cacheKey) => {
     collectQueryTimings(request, preloadQuery.key, 'preload');
 

--- a/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
+++ b/packages/hydrogen/src/foundation/ServerRequestProvider/ServerRequestProvider.tsx
@@ -155,9 +155,6 @@ export function preloadRequestCacheData(request: HydrogenRequest): void {
   const preloadQueries = request.getPreloadQueries();
   const {cache} = request.ctx;
 
-  // TODO: Remove before shipping
-  console.log(preloadQueries?.size ?? 0, 'preloaded queries');
-
   preloadQueries?.forEach((preloadQuery, cacheKey) => {
     collectQueryTimings(request, preloadQuery.key, 'preload');
 

--- a/packages/hydrogen/src/foundation/useQuery/hooks.ts
+++ b/packages/hydrogen/src/foundation/useQuery/hooks.ts
@@ -50,7 +50,7 @@ export function useQuery<T>(
   /** A string or array to uniquely identify the current query. */
   key: QueryKey,
   /** An asynchronous query function like `fetch` which returns data. */
-  queryFn: () => Promise<T>,
+  queryFn: (request: HydrogenRequest) => Promise<T>,
   /** The options to manage the cache behavior of the sub-request. */
   queryOptions?: HydrogenUseQueryOptions
 ) {
@@ -98,7 +98,7 @@ export function shouldPreloadQuery(
 
 function cachedQueryFnBuilder<T>(
   key: QueryKey,
-  generateNewOutput: () => Promise<T>,
+  generateNewOutput: (request: HydrogenRequest) => Promise<T>,
   queryOptions?: HydrogenUseQueryOptions
 ) {
   const resolvedQueryOptions = {
@@ -144,7 +144,7 @@ function cachedQueryFnBuilder<T>(
             );
 
             try {
-              const output = await generateNewOutput();
+              const output = await generateNewOutput(request);
 
               if (shouldCacheResponse(output)) {
                 await setItemInCache(key, output, resolvedQueryOptions?.cache);
@@ -164,7 +164,7 @@ function cachedQueryFnBuilder<T>(
       return output;
     }
 
-    const newOutput = await generateNewOutput();
+    const newOutput = await generateNewOutput(request);
 
     /**
      * Important: Do this async

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -9,6 +9,7 @@ import {fetchSync} from '../../foundation/fetchSync/server/fetchSync.js';
 import {META_ENV_SSR} from '../../foundation/ssr-interop.js';
 import {getStorefrontApiRequestHeaders} from '../../utilities/storefrontApi.js';
 import {parseJSON} from '../../utilities/parse.js';
+import {STOREFRONT_API_BUYER_IP_HEADER} from '../../constants.js';
 
 export interface UseShopQueryResponse<T> {
   /** The data returned by the query. */
@@ -240,6 +241,10 @@ function useCreateShopRequest(body: string) {
     privateStorefrontToken,
     storefrontId,
   });
+
+  console.log(
+    `Using ${extraHeaders[STOREFRONT_API_BUYER_IP_HEADER]} for buyer IP`
+  );
 
   headers = {...headers, ...extraHeaders};
 

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -9,7 +9,6 @@ import {sendMessageToClient} from '../../utilities/devtools.js';
 import {META_ENV_SSR} from '../../foundation/ssr-interop.js';
 import {getStorefrontApiRequestHeaders} from '../../utilities/storefrontApi.js';
 import {parseJSON} from '../../utilities/parse.js';
-import {STOREFRONT_API_BUYER_IP_HEADER} from '../../constants.js';
 import {useQuery} from '../../foundation/useQuery/hooks.js';
 import {HydrogenRequest} from '../../foundation/HydrogenRequest/HydrogenRequest.server.js';
 
@@ -250,10 +249,6 @@ function useCreateShopRequest({
     privateStorefrontToken,
     storefrontId,
   });
-
-  console.log(
-    `Using ${extraHeaders[STOREFRONT_API_BUYER_IP_HEADER]} for buyer IP`
-  );
 
   headers = {...headers, ...extraHeaders};
 

--- a/packages/hydrogen/src/utilities/hash.ts
+++ b/packages/hydrogen/src/utilities/hash.ts
@@ -1,4 +1,3 @@
-import {STOREFRONT_API_BUYER_IP_HEADER} from '../constants.js';
 import type {QueryKey} from '../types.js';
 
 export function hashKey(queryKey: QueryKey): string {

--- a/packages/hydrogen/src/utilities/hash.ts
+++ b/packages/hydrogen/src/utilities/hash.ts
@@ -16,9 +16,6 @@ export function hashKey(queryKey: QueryKey): string {
         // fallback to a safer (but slower) stringify.
         if (!!key.body && typeof key.body === 'string') {
           hash += key.body;
-          if (!!key.headers && key.headers[STOREFRONT_API_BUYER_IP_HEADER]) {
-            hash += key.headers[STOREFRONT_API_BUYER_IP_HEADER];
-          }
         } else {
           hash += JSON.stringify(key);
         }

--- a/packages/hydrogen/src/utilities/tests/hash.vitest.ts
+++ b/packages/hydrogen/src/utilities/tests/hash.vitest.ts
@@ -18,14 +18,16 @@ describe('Hash key for subrequests', () => {
     expect(
       hashKey(['hello', 'world', {body: 'longquery', headers: {}}])
     ).toEqual('helloworldlongquery');
+  });
 
+  it('does not include any buyer-specific information in hashes', () => {
     expect(
       hashKey([
         'hello',
         'world',
         {body: 'longquery', headers: {[STOREFRONT_API_BUYER_IP_HEADER]: '42'}},
       ])
-    ).toEqual('helloworldlongquery42');
+    ).toEqual('helloworldlongquery');
   });
 
   it('does not choke on other types', () => {


### PR DESCRIPTION
This PR fixes an issue we noticed when Oxygen was running load tests against our Hydrogen demo store template.

**tl;dr** - we have been including the buyer IP as part of our cache keys on the server. This cache key is used for [preload query cache](https://shopify.dev/custom-storefronts/hydrogen/framework/preloaded-queries), which causes duplicate entries to be added to the preload cache as more unique buyers hit the same Cloudflare colo. These queries get re-run at the beginning of every request, opening up hundreds of HTTP connections (specifically to the Cache API) and exhaust the resources of that cluster.

## Details

Starting in https://github.com/Shopify/hydrogen/pull/1518, we added the Storefront Buyer IP to cache keys used for preload cache. This was to ensure we wouldn't be re-using the same buyer's IP over and over again as subsequent preloads ran, which would inadvertently rate-limit the merchant.

The easy solution is to remove the buyer IP from the cache key. However, that means each preload request re-uses the first buyer's IP - leading to rate limiting.

The solution here is to pass the current `HydrogenRequest` to the `queryFn` closure used in `useQuery` and stored in-memory for the preload cache.

This means we no longer directly use `fetchSync` inside `useShopQuery`.

This problem is hard to reproduce and debug because it requires a ton of traffic from unique IPs to hit a single Cloudflare colo in a limited time period. We noticed this _more_ when running load tests out of a couple of specific regions, but less when our large merchants have flash sales, because the traffic is much more spread out (and less likely to saturate a single colo with lots of unique IP addresses). It's more likely noticeable if you are deploying to a long-lived process like Node.js in production with a bunch of traffic.