### PR TITLE
Fix RSC responses where the pathname contains double quotes

### DIFF
--- a/.changeset/serious-geckos-heal.md
+++ b/.changeset/serious-geckos-heal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix RSC responses in some situations where the pathname contains double quotes.

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -286,15 +286,17 @@ async function processRequest(
       : apiResponse;
   }
 
-  const state: Record<string, any> = isRSCRequest
-    ? parseState(new URL(decodeURIComponent(url.toString())))
-    : {
-        pathname: decodeURIComponent(url.pathname),
-        search: decodeURIComponent(url.search),
-      };
+  const state = parseState(url);
 
-  if (isRSCRequest && !state) {
-    postRequestTasks('rsc', 400, request, response, true);
+  if (!state) {
+    postRequestTasks(
+      isRSCRequest ? 'rsc' : 'ssr',
+      400,
+      request,
+      response,
+      true
+    );
+
     return new Response(`Invalid RSC state`, {status: 400});
   }
 

--- a/packages/hydrogen/src/utilities/parse.ts
+++ b/packages/hydrogen/src/utilities/parse.ts
@@ -16,11 +16,12 @@ export function parseState(url: URL) {
         ? parseJSON(url.searchParams.get('state') ?? '{}')
         : {pathname, search};
 
-    return {
-      ...state,
-      pathname: decodeURIComponent(state.pathname ?? ''),
-      search: decodeURIComponent(state.search ?? ''),
-    };
+    return Object.fromEntries(
+      Object.entries(state).map(([key, value]) => [
+        decodeURIComponent(key ?? ''),
+        decodeURIComponent(value ?? ''),
+      ])
+    );
   } catch {
     // Do not throw to prevent unhandled errors
   }

--- a/packages/hydrogen/src/utilities/parse.ts
+++ b/packages/hydrogen/src/utilities/parse.ts
@@ -1,3 +1,5 @@
+import {RSC_PATHNAME} from '../constants.js';
+
 export function parseJSON(json: any) {
   if (String(json).includes('__proto__')) return JSON.parse(json, noproto);
   return JSON.parse(json);
@@ -8,7 +10,17 @@ function noproto(k: string, v: string) {
 
 export function parseState(url: URL) {
   try {
-    return parseJSON(url.searchParams.get('state') ?? '');
+    const {pathname, search} = url;
+    const state: Record<string, any> =
+      pathname === RSC_PATHNAME
+        ? parseJSON(url.searchParams.get('state') ?? '{}')
+        : {pathname, search};
+
+    return {
+      ...state,
+      pathname: decodeURIComponent(state.pathname ?? ''),
+      search: decodeURIComponent(state.search ?? ''),
+    };
   } catch {
     // Do not throw to prevent unhandled errors
   }

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -106,7 +106,7 @@ export default async function testCases({
     expect(scopedContext).toContain('{"test2":true}');
   });
 
-  it('it responds with error when RSC state is invalid', async () => {
+  it('responds with error when RSC state is invalid', async () => {
     const response = await fetch(getServerUrl() + '/__rsc?state=invalid{state');
     expect(response.status).toEqual(400);
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes #1863 (again)

We were calling `decodeURIComponent` **before** `JSON.parse`, which may end up trying to parse invalid JSON. Example:
`/?param="` => `{"pathname":"/?param=%22"}` => `{"pathname":"/?param=""}` => Parse error.

This PR changes the order to first parse the JSON, and then run `decodeURIComponent` in the properties of the resulting object.

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
