### PR TITLE
Hydrogen release 1.6.2: backport client component note

### DIFF
--- a/docs/hooks/global/fetchsync.md
+++ b/docs/hooks/global/fetchsync.md
@@ -143,9 +143,9 @@ The following considerations apply to `fetchSync` in server and client component
 
 - Suspense boundaries in client components are rendered during server-side rendering (SSR). This means the fallback is streamed to the client while the fetch call runs.
 - Data fetched on the server during SSR isn't serialized to the client. This means that your client `fetchSync` function will run twice during initial page load: once on the server and once on the client.
-- Suspense boundaries inside client components rendered during a subsequent navigation are only rendered on the client - not on the server.
+- Suspense boundaries inside client components rendered during a subsequent navigation are only rendered on the client and not on the server.
 - If you include browser-only logic inside your client component Suspense boundary, which would otherwise fail on the server, then you should conditionally include the suspending component with a piece of client state activated by `useEffect` or with a user action: `{isLoaded && <Suspense><MyComponent></Suspense>}`.
-- If you are using `fetchSync` to call an API endpoint in the same Hydrogen app, you must wrap the call in conditional logic with a piece of client state activated by `useEffect` to ensure it does not execute during pre-rendering (SSR): `{isLoaded && <Suspense><MyComponent></Suspense>}`.
+- If you're using `fetchSync` to call an API endpoint in the same Hydrogen app, then you must wrap the call in conditional logic with a piece of client state that's activated by `useEffect`. This ensures that `fetchSync` doesn't execute during pre-rendering (SSR): `{isLoaded && <Suspense><MyComponent></Suspense>}`.
 
 ## Related hooks
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Applies [some edits made to the reference](https://github.com/Shopify/shopify-dev/pull/28154) when regenerating them for this release.

### Additional context

>This ensures that `fetchSync` doesn't execute during pre-rendering (SSR): `{isLoaded && <Suspense><MyComponent></Suspense>}`.

Is `fetchSync` accurate here or are we referring to the call not executing?

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
