### PR TITLE
Let us put an end to this madness once and for all

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ packages/hydrogen/graphql.schema.json
 **/vendor
 docs/
 **/coverage/
+packages/hydrogen/CHANGELOG.md


### PR DESCRIPTION
`CHANGELOG` is a machine-generated file, but without fail,
it ends up triggering a CI failure _after_ each release. This
is unnecessary. We ought to add better linting to
markdown changeset files,
but this will do in the meantime.
