### PR TITLE
Use correct `defaultCartFragment` in `CartProvider.client.tsx`

### DIFF
--- a/.changeset/tricky-papayas-cross.md
+++ b/.changeset/tricky-papayas-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Use correct defaultCartFragment in CartProvider.client.tsx This resolves an error sending Add To Cart events to Shopify Analytics

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -15,6 +15,7 @@ import {
   CartLineUpdateInput,
   CountryCode,
 } from '../../storefront-api-types.js';
+import { defaultCartFragment } from './cart-queries.js';
 import {CartContext} from './context.js';
 import {
   BuyerIdentityUpdateEvent,
@@ -614,104 +615,3 @@ function publishDiscountCodesUpdateAnalytics(
     }
   );
 }
-
-export const defaultCartFragment = `
-fragment CartFragment on Cart {
-  id
-  checkoutUrl
-  totalQuantity
-  buyerIdentity {
-    countryCode
-    customer {
-      id
-      email
-      firstName
-      lastName
-      displayName
-    }
-    email
-    phone
-  }
-  lines(first: $numCartLines) {
-    edges {
-      node {
-        id
-        quantity
-        attributes {
-          key
-          value
-        }
-        cost {
-          totalAmount {
-            amount
-            currencyCode
-          }
-          compareAtAmountPerQuantity {
-            amount
-            currencyCode
-          }
-        }
-        merchandise {
-          ... on ProductVariant {
-            id
-            availableForSale
-            compareAtPriceV2 {
-              ...MoneyFragment
-            }
-            priceV2 {
-              ...MoneyFragment
-            }
-            requiresShipping
-            title
-            image {
-              ...ImageFragment
-            }
-            product {
-              handle
-              title
-            }
-            selectedOptions {
-              name
-              value
-            }
-          }
-        }
-      }
-    }
-  }
-  cost {
-    subtotalAmount {
-      ...MoneyFragment
-    }
-    totalAmount {
-      ...MoneyFragment
-    }
-    totalDutyAmount {
-      ...MoneyFragment
-    }
-    totalTaxAmount {
-      ...MoneyFragment
-    }
-  }
-  note
-  attributes {
-    key
-    value
-  }
-  discountCodes {
-    code
-  }
-}
-
-fragment MoneyFragment on MoneyV2 {
-  currencyCode
-  amount
-}
-fragment ImageFragment on Image {
-  id
-  url
-  altText
-  width
-  height
-}
-`;

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -15,7 +15,7 @@ import {
   CartLineUpdateInput,
   CountryCode,
 } from '../../storefront-api-types.js';
-import { defaultCartFragment } from './cart-queries.js';
+import {defaultCartFragment} from './cart-queries.js';
 import {CartContext} from './context.js';
 import {
   BuyerIdentityUpdateEvent,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In this PR https://github.com/Shopify/hydrogen/pull/2238 there was a revamp to Shopify Customer Events. This required a change to the query to get the `Cart` in the `<CartProvider />`. It looks like the change was made to `cart-queries.ts` and the `defaultCartFragment` in there wasn't actually being used. This results in the Add To Cart events not working in Shopify Analytics. This PR updates the `CartProvider` to use this correct fragment and fix the error.

### Additional context

Without this change:
<img width="702" alt="Screenshot 2022-11-17 at 7 16 12 PM" src="https://user-images.githubusercontent.com/5790877/202587476-b3657eee-206b-49ac-a1bc-fd44af5e5f43.png">


---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
