### PR TITLE
Fix streaming SSR with multibyte characters

### DIFF
--- a/.changeset/six-beans-turn.md
+++ b/.changeset/six-beans-turn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix streaming SSR with multibyte characters

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -919,7 +919,7 @@ function tagOnWrite(
 
   response.write = (arg: any) => {
     if (arg instanceof Uint8Array) {
-      savedChunks.push(decoder.decode(arg));
+      savedChunks.push(decoder.decode(arg, {stream: true}));
     } else {
       savedChunks.push(arg);
     }

--- a/packages/hydrogen/src/streaming.server.ts
+++ b/packages/hydrogen/src/streaming.server.ts
@@ -47,7 +47,7 @@ export async function bufferReadableStream(
     if (done) break;
 
     const stringValue =
-      typeof value === 'string' ? value : decoder.decode(value);
+      typeof value === 'string' ? value : decoder.decode(value, {stream: true});
 
     result += stringValue;
 


### PR DESCRIPTION
### Description

Fixes #2302 

It is necessary to set stream options in multibyte characters language.
https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode#parameters

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
