### PR TITLE
Add support for graphql-typed-document-node

### DIFF
--- a/.changeset/wild-rivers-refuse.md
+++ b/.changeset/wild-rivers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add support for @graphql-typed-document-node


### PR DESCRIPTION
### Description

Related #200 

I propose to support `typed-document-node` for more typesafety.
https://github.com/dotansimha/graphql-typed-document-node

### Additional context

- Need to add a test?

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [x] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
