### PR TITLE
Move form docs

### DIFF
--- a/docs/components/framework/form.md
+++ b/docs/components/framework/form.md
@@ -11,7 +11,7 @@ description: The Form provides a declarative way to perform mutations for creati
 
 </aside>
 
-Within a Hydrogen app, [React Server Components](/custom-storefronts/hydrogen/react-server-components/work-with-rsc#fetching-data-on-the-server) are used to fetch data and [API routes](/custom-storefronts/hydrogen/routing#api-routes) are used to mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components. The component mimics the functionality of a native `<form>` element, but it provides an enhanced user experience with client-side JavaScript.
+Within a Hydrogen app, [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/react-server-components/work-with-rsc#fetching-data-on-the-server) are used to fetch data and [API routes](https://shopify.dev/custom-storefronts/hydrogen/routing#api-routes) are used to mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components. The component mimics the functionality of a native `<form>` element, but it provides an enhanced user experience with client-side JavaScript.
 
 ## HTML `form` element
 
@@ -216,9 +216,8 @@ The `Form` component shares the same props that are available to the [native `<f
 
 ## Component type
 
-The `Form` component is a client component, so it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/react-server-components).
+The `Form` component is a client component, so it renders on the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/react-server-components).
 
 ## Related framework topics
 
-- [Forms and API routes](/custom-storefronts/hydrogen/routing/manage-routes#concatenate-requests)
-
+- [Forms and API routes](https://shopify.dev/custom-storefronts/hydrogen/routing/manage-routes#concatenate-requests)

--- a/docs/components/framework/form.md
+++ b/docs/components/framework/form.md
@@ -11,9 +11,44 @@ description: The Form provides a declarative way to perform mutations for creati
 
 </aside>
 
-Within a Hydrogen app, [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/react-server-components/work-with-rsc#fetching-data-on-the-server) are used to fetch data and [API routes](https://shopify.dev/custom-storefronts/hydrogen/routing#api-routes) are used to mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components. The `Form` component mimics the functionality of a native `<form>` element, but it provides an enhanced user experience with client-side JavaScript.
+Within a Hydrogen app, [React Server Components](/custom-storefronts/hydrogen/react-server-components/work-with-rsc#fetching-data-on-the-server) are used to fetch data and [API routes](/custom-storefronts/hydrogen/routing#api-routes) are used to mutate data. The `Form` component provides a declarative way to send data to API routes and re-render server components. The component mimics the functionality of a native `<form>` element, but it provides an enhanced user experience with client-side JavaScript.
+
+## HTML `form` element
+
+The `Form` component builds on the native HTML `<form>` element. The following is an example:
+
+{% codeblock file, filename: 'index.html' %}
+
+```html
+<form action="/login" method="post">
+  <label> Username <input type="text" name="username" /> </label>
+  <label> Password <input type="password" name="password" /> </label>
+  <button type="submit">Submit</button>
+</form>
+```
+
+{% endcodeblock %}
+
+This example HTML doesn't run any JavaScript. When **Submit** is clicked, the browser sends a `POST` request to `/login` with each form field encoded. The browser also reloads the entire page to display the server's response. Learn more about [native HTML forms](https://developer.mozilla.org/en-US/docs/Learn/Forms).
+
+## Hydrogen `Form` component
+
+Hydrogen's `Form` component mimics the functionality of a native `<form>` element, while providing an enhanced experience with client-side JavaScript.
+
+Native HTML forms work without JavaScript. However, JavaScript can provide the following improvements:
+
+- **Performance**: JavaScript prevents the entire page from reloading to display responses from the server.
+- **UX**: JavaScript provides client-side validation and feedback. Client-side validation is quicker than making a round trip to the server, and feedback helps the user know when the form is in the process of submitting.
+
+## Client validation and feedback
+
+The best user experience has client-side validation and gives user feedback while the form is submitting. This requires a client component.
 
 ## Example code
+
+The following example rewrites the [example form element](#html-form-element) by substituting the native HTML with a `Form` component that's imported from Hydrogen.
+
+Because the `Form` is within a client component, `children` can be a render prop. This enables you to give users feedback while the form is submitting.
 
 {% codeblock file, filename: 'LoginForm.client.jsx' %}
 
@@ -47,6 +82,127 @@ export default function Login() {
 
 {% endcodeblock %}
 
+## Hidden fields
+
+You can use the `Form` component for any mutation that doesn't include a text field.
+
+For example, the following uses a `Form` component for adding items an item to a cart:
+
+{% codeblock file, filename: 'Product.server.jsx' %}
+
+```tsx
+import {Form} from '@shopify/hydrogen/experimental';
+
+export default function Product({product}) {
+  return (
+    <ProductDetails>
+      <Form action="/addToCart" method="post">
+        <input type="hidden" name="productId" value={product.id} />
+        <button type="submit">Add to cart</button>
+      </Form>
+    </ProductDetails>
+  );
+}
+```
+
+{% endcodeblock %}
+
+The hidden input field for the `productId` is sent to the server when the **Add to cart** button is clicked. The API route at `/addToCart` can contain all the logic to add the product to the cart and re-render the page. The button is actionable before the page fully loads and the JavaScript is hydrated.
+
+## Form in server components
+
+We recommend that you use `Form` in client components for the best user experience. However, you can use `Form` in server components if required. The following is an example:
+
+{% codeblock file, filename: 'login.server.jsx' %}
+
+```tsx
+import {Form} from '@shopify/hydrogen/experimental';
+
+export default function Login() {
+  return (
+    <Form action="/login" method="post">
+      <label>
+        Username <input type="text" name="username" />
+      </label>
+      <label>
+        Password <input type="password" name="password" />
+      </label>
+      <button type="submit">Submit</button>
+    </Form>
+  );
+}
+```
+
+{% endcodeblock %}
+
+### `Form` requires an API route
+
+The `action` attribute must point to an API route. The following is an example implementation:
+
+{% codeblock file, filename: 'login.server.jsx' %}
+
+```tsx
+export async function api(request, {session}) {
+  // Access the form data
+  const data = await request.formData();
+  const username = data.get('username');
+  const password = data.get('password');
+
+  // Find the user
+  const userId = await getUser(username, password);
+
+  if (!userId) {
+    // We couldn't find the user.
+    // Re-render the login page with a login error displayed
+    await session.set('loginError', true);
+    return new Request('/login');
+  }
+
+  // Save the user to the session
+  await session.set('userId', userId);
+
+  // Forward the user to the account page
+  return new Request('/account');
+}
+```
+
+{% endcodeblock %}
+
+Read data in the API route from the `Form` by using the [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) API. The API route must respond with a `new Request()`. This renders the server components for the given page. You can re-render the current page, or render an entirely different page in the app.
+
+In the previous example, when the user is not found, the current page is re-rendered with an error set on the session. The following code updates the server component to render the login error:
+
+{% codeblock file, filename: 'login.server.jsx' %}
+
+```tsx
+import {Form, useFlashSession} from '@shopify/hydrogen/experimental';
+
+export default function Login() {
+  // `useFlashSession` also clears the value after reading it. This way,
+  // if the user refreshes the page, the validation error goes away.
+  const loginError = useFlashSession('loginError');
+
+  return (
+    <Form action="/login" method="post">
+      <label>
+        Username <input type="text" name="username" />
+      </label>
+      <label>
+        Password <input type="password" name="password" />
+      </label>
+      {loginError ? (
+        <h2 className="text-red-700">Invalid username or password</h2>
+      ) : null}
+      <button type="submit">Submit</button>
+    </Form>
+  );
+}
+```
+
+{% endcodeblock %}
+
+The page initially loads without a session `loginError` value. If the login mutation fails, then the server components re-render with the `loginError` session value and display a message to the user. Because the component uses `useFlashSession` instead of `useSession`, the value is subsequently cleared. If the user refreshes the page, then the validation error goes away.
+
 ## Props
 
 The `Form` component shares the same props that are available to the [native `<form>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) with the following additions:
@@ -60,8 +216,9 @@ The `Form` component shares the same props that are available to the [native `<f
 
 ## Component type
 
-The `Form` component is a client component, so it renders on the client. For more information about component types, refer to [React Server Components](https://shopify.dev/custom-storefronts/hydrogen/react-server-components).
+The `Form` component is a client component, so it renders on the client. For more information about component types, refer to [React Server Components](/custom-storefronts/hydrogen/react-server-components).
 
 ## Related framework topics
 
-- [Forms and API routes](https://shopify.dev/custom-storefronts/hydrogen/routing/manage-routes#concatenate-requests)
+- [Forms and API routes](/custom-storefronts/hydrogen/routing/manage-routes#concatenate-requests)
+


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Partial fix for https://github.com/Shopify/shopify-dev/issues/27190

In the rework of the Hydrogen IA that split content out of a `/custom-storefronts/hydrogen/framework` there was a request to move out the `Forms` docs from `/custom-storefronts/hydrogen` and surface the content under `/api/hydrogen` instead, with the other `form` content.

### Additional context

The content includes a bunch on setting cart as a server component. Do we want to keep that? Our explicit recommendation is to use client-side. 

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [x] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
