### PR TITLE
Fix an issue where non-string server prop values get in-properly parsed

### DIFF
--- a/.changeset/pink-garlics-happen.md
+++ b/.changeset/pink-garlics-happen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix an issue where non-string server prop values get in-properly parsed. Resolves https://github.com/Shopify/hydrogen/issues/2365

--- a/packages/hydrogen/src/utilities/parse.ts
+++ b/packages/hydrogen/src/utilities/parse.ts
@@ -11,17 +11,18 @@ function noproto(k: string, v: string) {
 export function parseState(url: URL) {
   try {
     const {pathname, search} = url;
+    const stateParam = url.searchParams.get('state');
     const state: Record<string, any> =
       pathname === RSC_PATHNAME
-        ? parseJSON(url.searchParams.get('state') ?? '{}')
-        : {pathname, search};
+        ? stateParam
+          ? parseJSON(decodeURIComponent(stateParam))
+          : {}
+        : {
+            pathname: decodeURIComponent(pathname),
+            search: decodeURIComponent(search),
+          };
 
-    return Object.fromEntries(
-      Object.entries(state).map(([key, value]) => [
-        decodeURIComponent(key ?? ''),
-        decodeURIComponent(value ?? ''),
-      ])
-    );
+    return state;
   } catch {
     // Do not throw to prevent unhandled errors
   }

--- a/packages/playground/server-components/src/components/ReadServerProps.client.jsx
+++ b/packages/playground/server-components/src/components/ReadServerProps.client.jsx
@@ -12,12 +12,12 @@ export default function ReadServerProps() {
             : 'server-props'
         }
       >
-        props: {JSON.stringify(serverProps)}
+        client: {JSON.stringify(serverProps)}
       </p>
       <button
         id="update-server-props"
         onClick={() => {
-          setServerProps({hello: 'world'});
+          setServerProps('message', {hello: 'world'});
         }}
       >
         Update server props

--- a/packages/playground/server-components/src/routes/test-server-props.server.jsx
+++ b/packages/playground/server-components/src/routes/test-server-props.server.jsx
@@ -1,9 +1,10 @@
 import ReadServerProps from '../components/ReadServerProps.client';
 
-export default function TestServerProps() {
+export default function TestServerProps({message}) {
   return (
     <div>
       <h1>Test Server Props</h1>
+      <div id="server-comp-server-props">Server: {JSON.stringify(message)}</div>
       <ReadServerProps />
     </div>
   );


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix an issue where non-string server prop values get in-properly parsed. Resolves https://github.com/Shopify/hydrogen/issues/2365

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
