### PR TITLE
[React Storefront Kit]: Rename product and `npm` package

### DIFF
--- a/docs/components/global/shopifyprovider.md
+++ b/docs/components/global/shopifyprovider.md
@@ -43,15 +43,15 @@ The `ShopifyProvider` component is a server component that renders inside `App.s
 
 ## `ShopifyProvider` in alternate frameworks
 
-If you're using a third-party framework, such as Next.js, you should import `ShopifyProvider` from Hydrogen UI via the `@shopify/hydrogen-react` package.
+If you're using a third-party framework, such as Next.js, you should import `ShopifyProvider` from React Storefront Kit using the `@shopify/storefront-kit-react` package.
 
 > Note:
-> Hydrogen UI is an experimental feature at this time and is subject to change. Learn more about using [alternate frameworks](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks).
+> React Storefront Kit is an experimental feature at this time and is subject to change. Learn more about using [alternate frameworks](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks).
 
 ### Example code
 
 ```tsx
-import {ShopifyProvider} from '@shopify/hydrogen-react';
+import {ShopifyProvider} from '@shopify/storefront-kit-react';
 
 export default function App() {
   return <ShopifyProvider>{/* Routes, Pages, etc */}</ShopifyProvider>;
@@ -65,7 +65,7 @@ export default function App() {
 | storefrontId? | <code>string</code> | The globally unique identifier for the Shop |
 | storeDomain | <code>string</code> | The host name of the domain (eg: `{shop}.myshopify.com`). If a URL with a scheme (for example `https://`) is passed in, then the scheme is removed. |
 | storefrontToken | <code>string</code> | The Storefront API public access token. Refer to the [authentication](https://shopify.dev/api/storefront#authentication) documentation for more details. |
-| storefrontApiVersion | <code>string</code> | The Storefront API version. This should almost always be the same as the version Hydrogen-UI was built for. Learn more about Shopify [API versioning](https://shopify.dev/api/usage/versioning) for more details. |
+| storefrontApiVersion | <code>string</code> | The Storefront API version. This should almost always be the same as the version React Storefront Kit was built for. Learn more about Shopify [API versioning](https://shopify.dev/api/usage/versioning) for more details. |
 | country? | <code>{isoCode: CountryCode}</code>  | The code designating a country, which generally follows ISO 3166-1 alpha-2 guidelines. If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision of another country. For example, the territories associated with Spain are represented by the country code `ES`, and the territories associated with the United States of America are represented by the country code `US`. |
 | language? | <code>{isoCode: LanguageCode}</code> | `ISO 369` language codes supported by Shopify.
 | locale? | <code>string</code> | The locale string based on `country` and `language`. | Any `ReactNode` elements.

--- a/docs/components/global/shopifyprovider.md
+++ b/docs/components/global/shopifyprovider.md
@@ -46,7 +46,7 @@ The `ShopifyProvider` component is a server component that renders inside `App.s
 If you're using a third-party framework, such as Next.js, you should import `ShopifyProvider` from React Storefront Kit using the `@shopify/storefront-kit-react` package.
 
 > Note:
-> React Storefront Kit is an experimental feature at this time and is subject to change. Learn more about using [alternate frameworks](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks).
+> React Storefront Kit is an experimental feature at this time and is subject to change. Learn more about using [React Storefront Kit](https://shopify.dev/custom-storefronts/react-storefront-kit).
 
 ### Example code
 
@@ -72,7 +72,7 @@ export default function App() {
 
 ### Considerations
 
-- This version of `ShopifyProvider` is meant to only be used on the client. To make API calls from the server, check out the [`createShopifyClient()` helper](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks#step-2-authenticate-the-storefront-api-client).
+- This version of `ShopifyProvider` is meant to only be used on the client. To make API calls from the server, check out the [`createShopifyClient()` helper](https://shopify.dev/custom-storefronts/react-storefront-kit#step-2-authenticate-the-storefront-api-client).
 
 ## Related framework topics
 

--- a/docs/components/product-variant/productprovider.md
+++ b/docs/components/product-variant/productprovider.md
@@ -6,14 +6,14 @@ hidden: true
 ---
 
 > Note:
-> `ProductProvider` is only available as part of the [Hydrogen UI](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`ProductOptionsProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productoptionsprovider)
+> `ProductProvider` is only available as part of the [React Storefront Kit](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`ProductOptionsProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productoptionsprovider)
 
 The `ProductProvider` component sets up a context with state that tracks the selected variant and options. Descendants of this component can use the [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions) hook.
 
 ## Example code
 
 ```tsx
-import {ProductProvider} from '@shopify/hydrogen-react';
+import {ProductProvider} from '@shopify/storefront-kit-react';
 import {gql} from '@shopify/hydrogen';
 
 const QUERY = gql`

--- a/docs/components/product-variant/productprovider.md
+++ b/docs/components/product-variant/productprovider.md
@@ -6,7 +6,7 @@ hidden: true
 ---
 
 > Note:
-> `ProductProvider` is only available as part of the [React Storefront Kit](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`ProductOptionsProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productoptionsprovider)
+> `ProductProvider` is only available as part of the [React Storefront Kit](https://shopify.dev/custom-storefronts/react-storefront-kit) package, which is in beta. If you’re building with Hydrogen, then use [`ProductOptionsProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productoptionsprovider)
 
 The `ProductProvider` component sets up a context with state that tracks the selected variant and options. Descendants of this component can use the [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions) hook.
 

--- a/docs/decisions/001-release-strategy/README.md
+++ b/docs/decisions/001-release-strategy/README.md
@@ -101,7 +101,7 @@ Note: this gets a bit messy, because pre mode does make changes to package versi
 
 ### If we introduce storefront-kit-react-vue?
 
-Vue (and other potential variants of React Storefront Kit) will be pinned to the SFAPI, too. We will not be creating other variants of the framework, so we don't need to worry about factoring another semver into the equation.
+Vue (and other potential variants of React Storefront Kit) will be pinned to the SFAPI, too. We will not be creating other variants of the framework, so we don't need to worry about factoring another SemVer into the equation.
 
 ### To the demo store templates?
 

--- a/docs/decisions/001-release-strategy/README.md
+++ b/docs/decisions/001-release-strategy/README.md
@@ -105,7 +105,7 @@ Vue (and other potential variants of React Storefront Kit) will be pinned to the
 
 ### To the demo store templates?
 
-The demo store templates will be affected by both Hydrogen and React Storefront Kit. This means this versioning and branching strategy is a perfect fit. Scaffolding CLIs are unique because only their latest versions are intended to be used. This means we don't need to be concerned about versioning here.
+The demo store templates will be affected by both Hydrogen and React Storefront Kit. This means that this versioning and branching strategy is a perfect fit. Scaffolding CLIs are unique because only their latest versions are intended to be used. This means we don't need to be concerned about versioning here.
 
 ### To the linter packages and any other semver packages we might include in the Hydrogen monorepo?
 

--- a/docs/decisions/001-release-strategy/README.md
+++ b/docs/decisions/001-release-strategy/README.md
@@ -6,7 +6,7 @@ Approved by internal consensus in early 2022.
 
 ## tl;dr
 
-We should use a Git branch strategy driven by major-release pairs of our two main packages (hydrogen and hydrogen-ui). We should set our GitHub default branch to the latest major version branch. We should use an `unstable` branch which generates scheduled or on-demand snapshot releases.
+We should use a Git branch strategy driven by major-release pairs of our two main packages (`hydrogen` and `storefront-kit-react`). We should set our GitHub default branch to the latest major version branch. We should use an `unstable` branch which generates scheduled or on-demand snapshot releases.
 
 The first branch will be `v1.x-2022-07`.
 
@@ -21,11 +21,11 @@ We want to keep iterating Hydrogen now that we have reached v1.0. Especially aga
 - Allows us to apply the same patches to stable and to the new major version of Hydrogen
 
 
-We plan to version hydrogen and hydrogen-ui differently on NPM:
+We plan to version hydrogen and storefront-kit-react differently on NPM:
 
-- hydrogen will be versioned using [semver](https://semver.org/) `(<major>.<minor>.<patch>)`
+- `hydrogen` will be versioned using [semver](https://semver.org/) `(<major>.<minor>.<patch>)`
 
-- hydrogen-ui will be versioned using [calver](https://calver.org/) `(<year>.<month>.<patch>)` according to its compatibility with the Storefront API of the same version
+- `storefront-kit-react` will be versioned using [calver](https://calver.org/) `(<year>.<month>.<patch>)` according to its compatibility with the Storefront API of the same version
 
 ## What should we do?
 
@@ -37,7 +37,7 @@ We should use major version branches. At v1.0 Hydrogen launch, we'll create a ne
 
 - A Changesets GitHub Action is responsible for keeping a Release PR active and handling Git tag & release via Shipit.
 
-- Developers can install the latest stable release by running `yarn add @shopify/hydrogen @shopify/hydrogen-ui`
+- Developers can install the latest stable release by running `yarn add @shopify/hydrogen @shopify/storefront-kit-react`
 
 Meanwhile, we'll start using a new `unstable` branch to build brand new features into Hydrogen, which are tied directly to the `unstable` SFAPI.
 
@@ -47,9 +47,9 @@ Meanwhile, we'll start using a new `unstable` branch to build brand new features
 
 - We will add a new redirect <https://hydrogen.new/unstable> which creates a Stackblitz based on the latest unstable release.
 
-- Developers can install the latest unstable release by running `yarn add @shopify/hydrogen@unstable @shopify/hydrogen-ui@unstable`
+- Developers can install the latest unstable release by running `yarn add @shopify/hydrogen@unstable @shopify/storefront-kit-react@unstable`
 
-Then, when it comes time to release Hydrogen UI for the next version of the stable SFAPI, we'll cut a new branch and make it the default branch in GitHub:
+Then, when it comes time to release React Storefront Kit for the next version of the stable SFAPI, we'll cut a new branch and make it the default branch in GitHub:
 
 `v1.x-2022-10`
 
@@ -69,7 +69,7 @@ Note that this means we now have two "most recent major versions" to account for
 
 `v2.x-2022-10`
 
-At least until we bump to the new version of hydrogen-ui, and we'll be back to just maintaining a single one:
+At least until we bump to the new version of storefront-kit-react, and we'll be back to just maintaining a single one:
 
 `v2.x-2023-01`
 
@@ -99,13 +99,13 @@ Leading up to a new major release, we might want to issue release candidates. To
 
 Note: this gets a bit messy, because pre mode does make changes to package versions and changelogs. It will make merging stuff from `unstable` more tricky, and it can bloat the changelog. We can probably get around this with manual changelog grooming.
 
-### If we introduce hydrogen-ui-vue?
+### If we introduce storefront-kit-react-vue?
 
-Vue (and other potential variants of Hydrogen UI) will be pinned to the SFAPI, too. We will not be creating other variants of the framework, so we don't need to worry about factoring another semver into the equation.
+Vue (and other potential variants of React Storefront Kit) will be pinned to the SFAPI, too. We will not be creating other variants of the framework, so we don't need to worry about factoring another semver into the equation.
 
 ### To the demo store templates?
 
-The demo store templates will be affected by both Hydrogen and Hydrogen UI. This means this versioning and branching strategy is a perfect fit. Scaffolding CLIs are unique because only their latest versions are intended to be used. This means we don't need to be concerned about versioning here.
+The demo store templates will be affected by both Hydrogen and React Storefront Kit. This means this versioning and branching strategy is a perfect fit. Scaffolding CLIs are unique because only their latest versions are intended to be used. This means we don't need to be concerned about versioning here.
 
 ### To the linter packages and any other semver packages we might include in the Hydrogen monorepo?
 

--- a/docs/decisions/006-abandoning-fragments/README.md
+++ b/docs/decisions/006-abandoning-fragments/README.md
@@ -28,6 +28,6 @@ Removing fragments makes the starter templates much more verbose. It's possible 
 
 It's less simple to fetch data than requesting a massive REST-style payload for components.
 
-It also makes it more difficult to design Hydrogen UI components around a varying data input, as developers can completely customize queries.
+It also makes it more difficult to design React Storefront Kit components around a varying data input, as developers can completely customize queries.
 
 We've found the performance benefits and discoverability benefits to outweigh these initial drawbacks, but there are places where fragments can be useful. For example, housed in the demo store template and reused across a single project. Or the `Media` type spreading fragment.

--- a/docs/hooks/product-variant/useproduct.md
+++ b/docs/hooks/product-variant/useproduct.md
@@ -5,7 +5,7 @@ description: The useProduct hook returns an object that enables you to keep trac
 ---
 
 > Note:
-> `useProduct` is only available as part of the [React Storefront Kit](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions)
+> `useProduct` is only available as part of the [React Storefront Kit](https://shopify.dev/custom-storefronts/react-storefront-kit) package, which is in beta. If you’re building with Hydrogen, then use [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions)
 
 The `useProduct` hook returns an object that enables you to keep track of the
 selected variant and/or selling plan state, as well as callbacks for modifying the state. The `useProduct` hook must be a child of the [`ProductProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productprovider) component.

--- a/docs/hooks/product-variant/useproduct.md
+++ b/docs/hooks/product-variant/useproduct.md
@@ -5,7 +5,7 @@ description: The useProduct hook returns an object that enables you to keep trac
 ---
 
 > Note:
-> `useProduct` is only available as part of the [Hydrogen UI](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions)
+> `useProduct` is only available as part of the [React Storefront Kit](https://shopify.dev/custom-storefronts/hydrogen/alternate-frameworks) package, which is in beta. If you’re building with Hydrogen, then use [`useProductOptions`](https://shopify.dev/api/hydrogen/hooks/product-variant/useproductoptions)
 
 The `useProduct` hook returns an object that enables you to keep track of the
 selected variant and/or selling plan state, as well as callbacks for modifying the state. The `useProduct` hook must be a child of the [`ProductProvider`](https://shopify.dev/api/hydrogen/components/product-variant/productprovider) component.
@@ -16,7 +16,7 @@ selected variant and/or selling plan state, as well as callbacks for modifying t
 /**
  * Iterate through a list of variants and allow the customer to select a specific variant.
  */
-import {useProduct} from '@shopify/hydrogen-react';
+import {useProduct} from '@shopify/storefront-kit-react';
 
 export function MyComponent() {
   const {variants, selectedVariant, setSelectedVariant} = useProduct();
@@ -50,7 +50,7 @@ export function MyComponent() {
  * Support selling plans. You should display a selling plan selector to a user
  * when a product has selling plans enabled. You need to pass `sellingPlanGroups` to the hook.
  */
-import {useProduct} from '@shopify/hydrogen-react';
+import {useProduct} from '@shopify/storefront-kit-react';
 
 export function MyComponent() {
   const {
@@ -93,7 +93,7 @@ export function MyComponent() {
 /**
  * Use product options.
  */
-import {useProduct} from '@shopify/hydrogen-react';
+import {useProduct} from '@shopify/storefront-kit-react';
 
 export function MyComponent() {
   const {options, selectedVariant, selectedOptions, setSelectedOption} =

--- a/packages/hydrogen/src/hooks/useMoney/tests/hooks.test.tsx
+++ b/packages/hydrogen/src/hooks/useMoney/tests/hooks.test.tsx
@@ -4,7 +4,7 @@ import {useMoney} from '../index.js';
 
 const mountUseMoney = createMountableHook(useMoney);
 
-// this has already been migrated to Vitest in hydrogen-ui; no need to migrate it here as well
+// this has already been migrated to Vitest in storefront-kit-react; no need to migrate it here as well
 describe(`useMoney`, () => {
   it('returns an object with all of the details about the money', async () => {
     const money = await mountUseMoney({


### PR DESCRIPTION
## This PR: 
- Renames the `Hydrogen UI` product to `React Storefront Kit`
- Renames the `@shopify/hydrogen-react` npm package to `@shopify/storefront-kit-react`
- Partially fixes https://github.com/Shopify/shopify-dev/issues/28612
- Relates to https://github.com/Shopify/shopify-dev/pull/29198, https://github.com/Shopify/hydrogen-ui/pull/98, and [Custom Storefronts - Product Overview](https://docs.google.com/document/d/1WfSxs38NUzpfNJnhkd3gyd74sb3PVem96LO_PG-U6WE/edit)

### Additional context

I've left references to Hydrogen UI in the changelog as-is, as they refer to a point in time when the product was still called Hydrogen UI, and the package was called `@shopify/hydrogen-react`.