### PR TITLE
Temporary hack to fix analytics

### DIFF
--- a/.changeset/pretty-ducks-refuse.md
+++ b/.changeset/pretty-ducks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix race condition and memory leak within Hydrogen Analytics


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We cannot guarantee that analytics event listeners are setup before the analytics events fire. This adds an artificial 2 second timeout before analytics events will fire. It also makes sure that navigation before those 2 seconds won't improperly dedupe the first event.

This may not cover every usecase. But usually by the time the app _starts to hydrate_ it shouldn't be more than 2 seconds for it to finish hydrating? Maybe there are scenarios where it would, but we assume it to be rare.

<!-- Insert your description here and provide info about what issue this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
