### PR TITLE
Cart update missing attribute

### DIFF
--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
@@ -33,8 +33,8 @@ export function CartLineQuantityAdjustButton<
       return;
     }
 
-    linesUpdate([{id: cartLine.id, quantity}]);
-  }, [adjust, cartLine.id, cartLine.quantity, linesRemove, linesUpdate]);
+    linesUpdate([{id: cartLine.id, quantity, attributes: cartLine.attributes}]);
+  }, [adjust, cartLine.id, cartLine.quantity, cartLine.attributes, linesRemove, linesUpdate]);
 
   return (
     <BaseButton


### PR DESCRIPTION
### Description

We recently noticed that if we send a product with an attribute to the minicart and update its quantity, we end up losing the attribute that was already in the minicart, which could lead to the lack of some important information for that purchase.

The solution I took for my code is to remake this native Hydrogen function by sending the attributes along with the product ID and its new quantity.

With this solution, we facilitate the developer's work and avoid custom functions.
