### PR TITLE
🔧 Fix `<CartLineQuantityAdjust />` to include cartline attributes

### DIFF
--- a/.changeset/tame-beans-speak.md
+++ b/.changeset/tame-beans-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fixed a bug when using <CartLineQuantityAdjustButton /> that caused CartLine Attributes to be erased. CartLine Attributes should now be persisted when using that component.

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/CartLineQuantityAdjustButton.tsx
@@ -2,11 +2,16 @@ import React, {useCallback} from 'react';
 import {useCart} from '../CartProvider/index.js';
 import {useCartLine} from '../CartLineProvider/index.js';
 import {BaseButton, BaseButtonProps} from '../BaseButton/index.js';
+import type {CartLineUpdateInput} from '../../storefront-api-types.js';
 
-interface CartLineQuantityAdjustButtonProps {
+interface CartLineQuantityAdjustButtonBaseProps {
   /** The adjustment for a cart line's quantity. Valid values: `increase` (default), `decrease`, or `remove`. */
   adjust?: 'increase' | 'decrease' | 'remove';
 }
+
+type CartLineQuantityAdjustButtonProps<
+  AsType extends React.ElementType = 'button'
+> = BaseButtonProps<AsType> & CartLineQuantityAdjustButtonBaseProps;
 
 /**
  * The `CartLineQuantityAdjustButton` component renders a button that adjusts the cart line's quantity when pressed.
@@ -14,34 +19,54 @@ interface CartLineQuantityAdjustButtonProps {
  */
 export function CartLineQuantityAdjustButton<
   AsType extends React.ElementType = 'button'
->(props: CartLineQuantityAdjustButtonProps & BaseButtonProps<AsType>) {
+>(props: CartLineQuantityAdjustButtonProps<AsType>): JSX.Element {
   const {status, linesRemove, linesUpdate} = useCart();
   const cartLine = useCartLine();
   const {children, adjust, onClick, ...passthroughProps} = props;
 
   const handleAdjust = useCallback(() => {
     if (adjust === 'remove') {
-      linesRemove([cartLine.id]);
+      linesRemove([cartLine?.id ?? '']);
       return;
     }
 
     const quantity =
-      adjust === 'decrease' ? cartLine.quantity - 1 : cartLine.quantity + 1;
+      adjust === 'decrease'
+        ? (cartLine?.quantity ?? 0) - 1
+        : (cartLine?.quantity ?? 0) + 1;
 
     if (quantity <= 0) {
-      linesRemove([cartLine.id]);
+      linesRemove([cartLine?.id ?? '']);
       return;
     }
 
-    linesUpdate([{id: cartLine.id, quantity}]);
-  }, [adjust, cartLine.id, cartLine.quantity, linesRemove, linesUpdate]);
+    const lineUpdate: CartLineUpdateInput = {
+      id: cartLine?.id ?? '',
+      quantity,
+      attributes: (cartLine?.attributes ??
+        []) as CartLineUpdateInput['attributes'],
+    };
+
+    linesUpdate([lineUpdate]);
+  }, [
+    adjust,
+    cartLine?.attributes,
+    cartLine?.id,
+    cartLine?.quantity,
+    linesRemove,
+    linesUpdate,
+  ]);
 
   return (
     <BaseButton
-      disabled={status !== 'idle'}
       onClick={onClick}
       defaultOnClick={handleAdjust}
-      {...passthroughProps}
+      {...(passthroughProps as any)}
+      disabled={
+        typeof passthroughProps.disabled !== 'undefined'
+          ? passthroughProps.disabled
+          : status !== 'idle'
+      }
     >
       {children}
     </BaseButton>

--- a/packages/hydrogen/src/components/CartLineQuantityAdjustButton/tests/CartLineQuantityAdjustButton.test.tsx
+++ b/packages/hydrogen/src/components/CartLineQuantityAdjustButton/tests/CartLineQuantityAdjustButton.test.tsx
@@ -33,6 +33,12 @@ describe('CartLineQuantityAdjustButton', () => {
       {
         id: CART_LINE.id,
         quantity: 2,
+        attributes: [
+          {
+            key: 'color',
+            value: 'red',
+          },
+        ],
       },
     ]);
   });
@@ -66,6 +72,12 @@ describe('CartLineQuantityAdjustButton', () => {
       {
         id: CART_LINE.id,
         quantity: 1,
+        attributes: [
+          {
+            key: 'color',
+            value: 'red',
+          },
+        ],
       },
     ]);
   });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixed a bug when using <CartLineQuantityAdjustButton /> that caused CartLine Attributes to be erased. CartLine Attributes should now be persisted when using that component.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
