### PR TITLE
Deploy docs on push to default branch, not main

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -3,7 +3,7 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - v1.x-2022-07
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 

--- a/.github/workflows/deploy_docs_test.yml
+++ b/.github/workflows/deploy_docs_test.yml
@@ -3,7 +3,7 @@ name: Test docs deployment
 on:
   pull_request:
     branches:
-      - main
+      - v1.x-2022-07
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 


### PR DESCRIPTION
### Description

Updates the Documentation Deploy actions to trigger on a push to the default `v1.x-2022-07` branch, since syncing to `main` doesn't trigger the workflow.

---

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
