### PR TITLE
tag h1 to hydrogen v1 releases

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -50,7 +50,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: yarn run version
-          publish: yarn changeset publish
+          publish: yarn changeset publish --tag h1
           commit: '[ci] release ${{ github.ref_name }}'
           title: '[ci] release ${{ github.ref_name }}'
         env:


### PR DESCRIPTION
### Description

Deploying hydrogen v1 overwrites the current latest for hydrogen v2. Should we tag h1 releases as h1 to avoid this issue?

### Additional context

Just updated our publish tag to be h1