### PR TITLE
Update `powered-by` header default to `Shopify, Hydrogen`

### DIFF
--- a/.changeset/short-frogs-obey.md
+++ b/.changeset/short-frogs-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Updates default `powered-by` header output to `Shopify, Hydrogen`, and updates associateed documentation.

--- a/docs/docs/tutorials/configuration/index.md
+++ b/docs/docs/tutorials/configuration/index.md
@@ -104,7 +104,7 @@ export default defineConfig({
 
 ### `poweredByHeader`
 
-By default, Hydrogen responds with the `x-powered-by: Shopify-Hydrogen` header. You can disable this by adding `poweredByHeader: false` to your config:
+By default, Hydrogen responds with the `powered-by: Shopify, Hydrogen` header. You can disable this by adding `poweredByHeader: false` to your config:
 
 ```tsx
 // hydrogen.config.ts

--- a/packages/hydrogen/src/entry-server.tsx
+++ b/packages/hydrogen/src/entry-server.tsx
@@ -136,7 +136,7 @@ export const renderHydrogen = (App: any) => {
 
     if (hydrogenConfig.poweredByHeader ?? true) {
       // If undefined in the config, then always show the header
-      response.headers.set('powered-by', 'Shopify-Hydrogen');
+      response.headers.set('powered-by', 'Shopify, Hydrogen');
     }
 
     sessionApi ??= hydrogenConfig.session?.(log);

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -274,7 +274,7 @@ export default async function testCases({
 
   it('returns powered-by header', async () => {
     const response = await fetch(getServerUrl() + '/');
-    expect(response.headers.get('powered-by')).toBe('Shopify-Hydrogen');
+    expect(response.headers.get('powered-by')).toBe('Shopify, Hydrogen');
   });
 
   it('properly escapes props in the SSR flight script chunks', async () => {


### PR DESCRIPTION
This pull request changes the `powered-by` header value to `Shopify, Hydrogen`.

Replaces #2516