### PR TITLE
Make `<CartProvider>` use country code from `<ShopifyProvider>`

### DIFF
--- a/.changeset/chilly-dogs-sneeze.md
+++ b/.changeset/chilly-dogs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix the `<CartProvider>` to by default pull localization from `<ShopifyProvider>`. You can still override the countryCode by passing a prop directly to `<CartProvider>`. Resolves https://github.com/Shopify/hydrogen/issues/622

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -34,6 +34,7 @@ import {CartNoteUpdateMutationVariables} from './graphql/CartNoteUpdateMutation.
 import {useCartAPIStateMachine} from './useCartAPIStateMachine.client.js';
 import {CART_ID_STORAGE_KEY} from './constants.js';
 import {ClientAnalytics} from '../../foundation/Analytics/ClientAnalytics.js';
+import {useLocalization, useShop} from '../../client.js';
 
 export function CartProvider({
   children,
@@ -57,7 +58,7 @@ export function CartProvider({
   data: cart,
   cartFragment = defaultCartFragment,
   customerAccessToken,
-  countryCode = CountryCode.Us,
+  countryCode,
 }: {
   /** Any `ReactNode` elements. */
   children: React.ReactNode;
@@ -104,6 +105,12 @@ export function CartProvider({
   /** The ISO country code for i18n. */
   countryCode?: CountryCode;
 }) {
+  const {country} = useLocalization();
+
+  countryCode = (
+    (countryCode as string) ?? country.isoCode
+  ).toUpperCase() as CountryCode;
+
   if (countryCode) countryCode = countryCode.toUpperCase() as CountryCode;
   const [prevCountryCode, setPrevCountryCode] = useState(countryCode);
   const [prevCustomerAccessToken, setPrevCustomerAccessToken] =

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -34,7 +34,7 @@ import {CartNoteUpdateMutationVariables} from './graphql/CartNoteUpdateMutation.
 import {useCartAPIStateMachine} from './useCartAPIStateMachine.client.js';
 import {CART_ID_STORAGE_KEY} from './constants.js';
 import {ClientAnalytics} from '../../foundation/Analytics/ClientAnalytics.js';
-import {useLocalization} from '../../client.js';
+import {useLocalization} from '../../hooks/useLocalization/useLocalization.js';
 
 export function CartProvider({
   children,

--- a/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
+++ b/packages/hydrogen/src/components/CartProvider/CartProvider.client.tsx
@@ -34,7 +34,7 @@ import {CartNoteUpdateMutationVariables} from './graphql/CartNoteUpdateMutation.
 import {useCartAPIStateMachine} from './useCartAPIStateMachine.client.js';
 import {CART_ID_STORAGE_KEY} from './constants.js';
 import {ClientAnalytics} from '../../foundation/Analytics/ClientAnalytics.js';
-import {useLocalization, useShop} from '../../client.js';
+import {useLocalization} from '../../client.js';
 
 export function CartProvider({
   children,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix the `<CartProvider>` to by default pull localization from `<ShopifyProvider>`. You can still override the countryCode by passing a prop directly to `<CartProvider>`. Resolves https://github.com/Shopify/hydrogen/issues/622

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
