### PR TITLE
Fix concatenating requests

### DIFF
--- a/.changeset/wet-boats-carry.md
+++ b/.changeset/wet-boats-carry.md
@@ -1,0 +1,15 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow concatenating requests with a header. For example, if you want the route `/shop` to proxy render everything on `/products`, setup an API route at `/routes/shop.server.jsx` with the following:
+
+```jsx
+export async function api(request) {
+  return new Request(new URL(request.url).origin + '/products', {
+    headers: {
+      'Hydrogen-Concatenate': 'true',
+    },
+  });
+}
+```

--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -299,7 +299,7 @@ export async function renderApiRoute(
       return new Request(getRscUrl(url, newUrl), {
         headers: response.headers,
       });
-    } else {
+    } else if (!response.headers.get('hydrogen-concatenate')) {
       // This request was made by a native form presumably because the client components had yet to hydrate,
       // Because of this, we need to redirect instead of just rendering the response.
       // Doing so prevents odd refresh / back behavior. The redirect response also should *never* be cached.

--- a/packages/playground/server-components/src/routes/concatenate.server.jsx
+++ b/packages/playground/server-components/src/routes/concatenate.server.jsx
@@ -1,0 +1,7 @@
+export async function api(request) {
+  return new Request(new URL(request.url).origin + '/about', {
+    headers: {
+      'Hydrogen-Concatenate': 'true',
+    },
+  });
+}

--- a/packages/playground/server-components/tests/e2e-test-cases.ts
+++ b/packages/playground/server-components/tests/e2e-test-cases.ts
@@ -624,13 +624,18 @@ export default async function testCases({
       expect(await page.textContent('*')).toContain('fname=sometext');
     });
 
-    it('can concatenate requests', async () => {
+    it('can concatenate form requests', async () => {
       await page.goto(getServerUrl() + '/html-form');
       expect(await page.textContent('#counter')).toEqual('0');
       await page.click('#increase');
       expect(await page.textContent('#counter')).toEqual('1');
       await page.click('#increase');
       expect(await page.textContent('#counter')).toEqual('2');
+    });
+
+    it('can concatenate requests', async () => {
+      await page.goto(getServerUrl() + '/concatenate');
+      expect(await page.textContent('body')).toContain('About');
     });
 
     it('responds with RSC', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Concatenating requests is broken, which is sometimes important for proxying one route to another. This fixes it in a somewhat hacky, but less likely to break other things, way by simply adding a header. This can be tested by booting up the playground and navigating to `/concatenate`, notice the `/about` route is rendered. There's also an e2e test that validates it.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
