### PR TITLE
Make sure that we don't cache sub-requests that 400-500 error

### DIFF
--- a/.changeset/odd-melons-wash.md
+++ b/.changeset/odd-melons-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Make sure sub-requests that are 400 or 500 HTTP errors are not cached

--- a/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
+++ b/packages/hydrogen/src/hooks/useShopQuery/hooks.ts
@@ -18,12 +18,6 @@ export interface UseShopQueryResponse<T> {
   errors: any;
 }
 
-// Check if the response body has GraphQL errors
-// https://spec.graphql.org/June2018/#sec-Response-Format
-const shouldCacheResponse = (body: any) => {
-  return !body?.errors;
-};
-
 /**
  * The `useShopQuery` hook allows you to make server-only GraphQL queries to the Storefront API. It must be a descendent of a `ShopifyProvider` component.
  */
@@ -77,6 +71,15 @@ export function useShopQuery<T>({
 
   const body = query ? graphqlRequestBody(query, variables) : '';
 
+  let _response: Response;
+
+  // Check if the response body has GraphQL errors
+  // https://spec.graphql.org/June2018/#sec-Response-Format
+  // and that the response is not an error
+  const shouldCacheResponse = (body: any) => {
+    return !body?.errors && _response?.ok;
+  };
+
   const {data, error} = useQuery(
     [storeDomain, storefrontApiVersion, body],
     async (request) => {
@@ -89,7 +92,7 @@ export function useShopQuery<T>({
         storefrontId,
         privateStorefrontToken,
       });
-      const response = await fetch(url, requestInit);
+      const response = (_response = await fetch(url, requestInit));
       const text = await response.text();
 
       try {

--- a/packages/hydrogen/src/hooks/useShopQuery/tests/useShopQuery.test.tsx
+++ b/packages/hydrogen/src/hooks/useShopQuery/tests/useShopQuery.test.tsx
@@ -102,4 +102,21 @@ describe('useShopQuery', () => {
 
     expect(await cache.keys()).toHaveLength(0);
   });
+
+  it('handles 500 errors', async () => {
+    mockedFetch.mockResolvedValue(new Response('{}', {status: 500}));
+    const component = await mountComponent();
+
+    expect(await cache.keys()).toHaveLength(0);
+
+    await component.act(async () => {
+      await Promise.all(waitUntilPromises);
+    });
+
+    expect(component).toContainReactComponent('div', {
+      children: '{}',
+    });
+
+    expect(await cache.keys()).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We were caching sub-requests to the SFAPI that 400 or 500 error without a graphql JSON error response body. Make sure we don't do that and add a test.



### Before submitting the PR, please make sure you do the following:

- [X] Read the [Contributing Guidelines](https://github.com/shopify/hydrogen/blob/main/.github/contributing.md)
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [X] Update docs in this repository according to your change
- [X] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
