### PR TITLE
Move H2 migration doc into archival docs microsite

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,7 +6,7 @@ slug: /
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/migrate-v2.md
+++ b/docs/docs/migrate-v2.md
@@ -1,0 +1,6 @@
+---
+slug: /migrate
+---
+
+# Migrate from Hydrogen v1 to v2
+

--- a/docs/docs/migrate-v2.md
+++ b/docs/docs/migrate-v2.md
@@ -4,3 +4,60 @@ slug: /migrate
 
 # Migrate from Hydrogen v1 to v2
 
+The recommended method for upgrading from Hydrogen v1 to  is to [create a new Hydrogen project](https://shopify.dev/docs/custom-storefronts/hydrogen/getting-started) and transfer required features and assets manually.
+
+## Key differences between Hydrogen v1 and Hydrogen v2
+
+- Hydrogen now [uses Remix as its foundational framework](https://hydrogen.shopify.dev/update/remixing-hydrogen). Remix promotes server-side rendering, web standard technologies, and principles of progressive enhancement to boost site performance. Hydrogen provides a collection of components, utilities, and design patterns that make it easier and more performant to work with Shopify APIs.
+- Hydrogen no longer uses React Server Components. Use [Remix loader functions](https://remix.run/docs/en/main/route/loader) instead.
+- Since version 2023.1, Hydrogen has been [calendar versioned](https://calver.org/). This keeps Hydrogen's features in sync with Shopify's [API versioning](https://shopify.dev/docs/api/usage/versioning).
+
+To quickly get up to speed on Remix, we recommend completing its [30-minute introductory tutorial](https://remix.run/docs/en/main/start/tutorial).
+
+## Routes
+
+Remix uses [nested routes](https://remix.run/docs/en/main/discussion/routes) to define the site path.
+
+Hydrogen's default [Skeleton template](https://github.com/Shopify/hydrogen/tree/main/templates/skeleton) includes all of Shopify's standard storefront routes. When setting up a new Hydrogen project, select the option to "scaffold routes and core functionality" to set up these routes autoatically.
+
+You can also scaffold routes after the fact by [using the Hydrogen CLI](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-generate-routes):
+
+```sh
+# Run in your new Hydrogen project
+npx shopify hydrogen generate routes
+```
+
+For reference, this table compares some typical Hydrogen v1 route files with their Remix equivalents. However, we don't recommend creating every file manually; the `generate routes` command is the most reliable method to create consistent results.
+
+| **Hydrogen v1**                 | **Hydrogen with Remix** |
+| ------------------------------- | ----------------------- |
+| index.html                      | root.jsx
+| robots.txt.server.js            | [robots.txt].jsx        |
+| sitemap.xml.server.ts           | [sitemap.xml].jsx       |
+| products/[handle].server.jsx    | products.$handle.jsx    |
+| policies/[handle].server.jsx    | policies.$handle.jsx    |
+| collections/[handle].server.jsx | collections.$handle.jsx |
+| pages/[handle].server.jsx       | pages.$handle.jsx       |
+
+
+### API routes
+
+In Remix, instead of a separate pattern for API routes, `loader` and `action` functions serve as the same purpose — [routes are their own API](https://remix.run/docs/en/main/guides/api-routes#routes-are-their-own-api).
+
+### 404 route
+
+Hydrogen v1 handled 404 pages with a wildcard route defined in `App.server.jsx`. Remix also needs a wildcard route; in Remix, these are called [Splat Routes](https://remix.run/docs/en/main/file-conventions/routes#splat-routes).
+
+A standard 404 route is generated when setting up a new Hydrogen project if you opt to [scaffold the standard routes](#routes). Consult the Skeleton template's [404 route file on GitHub](https://github.com/Shopify/hydrogen/blob/main/templates/skeleton/app/routes/%24.tsx) if you want to set it up yourself.
+
+## Moving static assets
+
+Remix features two directories that can contain static assets:
+
+1. `public` is for static files that should be uploaded directly to Shopify's CDN without being processed by Vite. Files in this directory will be available relative to the site root when deployed. You can hard-code their paths in site files.
+1. `app/assets` is for static files that will be imported in your site files and will be processed by Vite. File names may be hashed and the files themselves may be optimized or bundled during the build process.
+
+### CSS
+
+Remix uses Vite for bundling and optimization, so all of [Vite's standard CSS methods](https://vitejs.dev/guide/features#css) are available in Hydrogen.
+

--- a/docs/docs/tutorials/analytics/configure-analytics.md
+++ b/docs/docs/tutorials/analytics/configure-analytics.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/analytics/index.md
+++ b/docs/docs/tutorials/analytics/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/authentication/configure-user-authentication.md
+++ b/docs/docs/tutorials/authentication/configure-user-authentication.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/authentication/index.md
+++ b/docs/docs/tutorials/authentication/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/best-practices/accessibility.md
+++ b/docs/docs/tutorials/best-practices/accessibility.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/best-practices/examples.md
+++ b/docs/docs/tutorials/best-practices/examples.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/best-practices/index.md
+++ b/docs/docs/tutorials/best-practices/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/best-practices/performance.md
+++ b/docs/docs/tutorials/best-practices/performance.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/best-practices/testing.md
+++ b/docs/docs/tutorials/best-practices/testing.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/configuration/change-config-file-location.md
+++ b/docs/docs/tutorials/configuration/change-config-file-location.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/configuration/index.md
+++ b/docs/docs/tutorials/configuration/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/content.md
+++ b/docs/docs/tutorials/content.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/css-support/create-custom-fonts.md
+++ b/docs/docs/tutorials/css-support/create-custom-fonts.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/css-support/import-css-in-rsc.md
+++ b/docs/docs/tutorials/css-support/import-css-in-rsc.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/css-support/index.md
+++ b/docs/docs/tutorials/css-support/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/css-support/remove-tailwind.md
+++ b/docs/docs/tutorials/css-support/remove-tailwind.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/data-sources/configure-default-entry-points.md
+++ b/docs/docs/tutorials/data-sources/configure-default-entry-points.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/data-sources/index.md
+++ b/docs/docs/tutorials/data-sources/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/data-sources/work-with-3p-data-sources.md
+++ b/docs/docs/tutorials/data-sources/work-with-3p-data-sources.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/eslint.md
+++ b/docs/docs/tutorials/eslint.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/index.md
+++ b/docs/docs/tutorials/getting-started/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/quickstart.md
+++ b/docs/docs/tutorials/getting-started/quickstart.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/templates.md
+++ b/docs/docs/tutorials/getting-started/templates.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/tutorial/begin.md
+++ b/docs/docs/tutorials/getting-started/tutorial/begin.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/tutorial/cart.md
+++ b/docs/docs/tutorials/getting-started/tutorial/cart.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/tutorial/collections.md
+++ b/docs/docs/tutorials/getting-started/tutorial/collections.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/tutorial/fetch-data.md
+++ b/docs/docs/tutorials/getting-started/tutorial/fetch-data.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/tutorial/index.md
+++ b/docs/docs/tutorials/getting-started/tutorial/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/getting-started/tutorial/products.md
+++ b/docs/docs/tutorials/getting-started/tutorial/products.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/proxy-routes-to-online-store.md
+++ b/docs/docs/tutorials/proxy-routes-to-online-store.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/querying/cache.md
+++ b/docs/docs/tutorials/querying/cache.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/querying/manage-caching.md
+++ b/docs/docs/tutorials/querying/manage-caching.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/querying/preload-queries.md
+++ b/docs/docs/tutorials/querying/preload-queries.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/querying/preloaded-queries.md
+++ b/docs/docs/tutorials/querying/preloaded-queries.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/react-server-components/index.md
+++ b/docs/docs/tutorials/react-server-components/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/react-server-components/work-with-rsc.md
+++ b/docs/docs/tutorials/react-server-components/work-with-rsc.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/routing/index.md
+++ b/docs/docs/tutorials/routing/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/routing/manage-routes.md
+++ b/docs/docs/tutorials/routing/manage-routes.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/seo/index.md
+++ b/docs/docs/tutorials/seo/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/seo/manage-seo.md
+++ b/docs/docs/tutorials/seo/manage-seo.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/server-props.md
+++ b/docs/docs/tutorials/server-props.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/sessions/index.md
+++ b/docs/docs/tutorials/sessions/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/sessions/manage-sessions.md
+++ b/docs/docs/tutorials/sessions/manage-sessions.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/static-assets/index.md
+++ b/docs/docs/tutorials/static-assets/index.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/static-assets/manage-static-assets.md
+++ b/docs/docs/tutorials/static-assets/manage-static-assets.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/streaming-ssr.md
+++ b/docs/docs/tutorials/streaming-ssr.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docs/tutorials/third-party-dependencies.md
+++ b/docs/docs/tutorials/third-party-dependencies.md
@@ -2,7 +2,7 @@
 
 
 :::tip
-Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate to Hydrogen 2.0](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) as soon as possible.
+Hydrogen 2.0 is out now. These archival Hydrogen 1.0 docs are provided only to assist developers during their upgrade process. Please [migrate](/migrate) as soon as possible.
 :::
 
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -77,7 +77,7 @@ const config = {
             label: 'API reference',
           },
           {
-            href: 'https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix',
+            href: 'migrate',
             label: 'Migrate to Hydrogen 2',
             position: 'left',
           },

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -21,6 +21,11 @@ const sidebars = {
       id: 'index'
     },
     {
+      type: 'doc',
+      label: 'Migrate to v2',
+      id: 'migrate-v2',
+    },
+    {
       type: 'category',
       label: 'Tutorials',
       link: {


### PR DESCRIPTION
We'd like to simplify streamline [this migration guide](https://shopify.dev/docs/custom-storefronts/hydrogen/migrate-hydrogen-remix) based on lessons learned since the initial switchover. This will also allow us to remove the last piece of H1 content on shopify.dev, while still keeping the guidance available for remaining H1 users.

## 🎩 Tophat
- checkout `gfs-migrate` branch
- run `yarn start`
- open http://localhost:3000/hydrogen-v1/migrate