### PR TITLE
noindex v1

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -36,6 +36,9 @@ const config = {
     locales: ['en'],
   },
 
+  // Remove from search engines
+  noIndex: true,
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
### Description

v1 docs are [ranking highly in Hydrogen-related Google searches](https://github.com/user-attachments/assets/94b261ce-68a2-41d2-b142-cd8b0b034080), confusing a bunch of folks.

For developers still using v1, they can access docs [via the main readme](https://github.com/user-attachments/assets/6aecc074-5293-45e3-b762-4042ce470cf8).

This PR adds a [`noindex`](https://docusaurus.io/docs/api/docusaurus-config#noIndex) field to the docusaurus config, which adds `<meta name="robots" content="noindex, nofollow">` to all v1 docs. [This workflow](https://github.com/Shopify/hydrogen-v1/blob/5c641b7f313ecdf2a17008fd41afe75727bfd5b3/.github/workflows/deploy_docs.yml) should take care of the rest.

Tested locally:

![image](https://github.com/user-attachments/assets/333f87b0-db9d-4b7b-87ee-c19fa49f23e0)




